### PR TITLE
fix: use Opus 4.5 for GitHub Actions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,5 +53,5 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-opus-4-5-20251101 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,8 +43,6 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--model claude-opus-4-5-20251101'
 


### PR DESCRIPTION
## Summary
- Configure both Claude Code workflows to use Opus 4.5 instead of default Sonnet
- Add `--model claude-opus-4-5-20251101` to `claude_args` in both workflows

**Why**: Claude Code GitHub Actions default to Sonnet. Per the [docs](https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md), use `claude_args: --model` to specify Opus 4.5.

## Test plan
- [ ] Next PR triggers claude-code-review with Opus 4.5
- [ ] @claude mentions use Opus 4.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)