### PR TITLE
Docs: Added Windows setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ Inside a Claude Code instance, run the following commands:
 
 Done! The HUD appears immediately — no restart needed.
 
+### Windows Setup
+If you are using Windows, `bash` is not available by default. Use the following configuration instead:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "node C:\\Users\\<username>\\.claude\\plugins\\cache\\claude-hud\\claude-hud\\0.0.1\\dist\\index.js"
+  }
+}```
+
+Note: Replace <username> with your actual Windows username.
+
 ---
 
 ## What is Claude HUD?


### PR DESCRIPTION
## Summary
Added Windows-specific configuration steps to `README.md` as requested in issue #11. 
This helps Windows users run the plugin without `bash` errors.

Fixes #11

## Testing
- [x] This is a documentation change, so no code testing is required.
- [x] Verified the JSON configuration format is correct.

## Checklist
- [x] Tests updated or not needed
- [x] Docs updated if behavior changed