### PR TITLE
feature: use bun + TypeScript when available for 4x faster startup

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -9,12 +9,14 @@ Add this statusLine configuration to `~/.claude/settings.json`:
 {
   "statusLine": {
     "type": "command",
-    "command": "bash -c 'node \"$(ls -td ~/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | head -1)dist/index.js\"'"
+    "command": "bash -c 'P=$(ls -td ~/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | head -1); if command -v bun >/dev/null; then bun \"${P}src/index.ts\"; else node \"${P}dist/index.js\"; fi'"
   }
 }
 ```
 
-This command automatically finds and runs the latest installed version.
+This command automatically:
+- Uses **bun + TypeScript** if available (4x faster startup), otherwise falls back to **node + JS**
+- Finds and runs the latest installed version
 
 Merge with existing settings. Do not overwrite other fields.
 


### PR DESCRIPTION
## Summary

- Auto-detects bun and uses it with TypeScript source directly
- Falls back to node + compiled JS when bun not available
- Bun's native TS transpiler is faster than loading pre-compiled JS

## Benchmarks

| Runtime | Average | Speedup |
|---------|---------|---------|
| bash -c + node + JS (before) | 89ms | baseline |
| bash -c + bun + TS (after) | 22ms | **4x faster** |

(10 runs each, macOS)

## Test plan

- [x] Verified command works with bun available (uses bun + src/index.ts)
- [x] Verified fallback to node + dist/index.js when bun not in PATH