### PR TITLE
fix: skip auto-review for fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip fork PRs (no OIDC/secrets access). Use @claude mention for fork PR reviews.
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Skip automatic Claude code review for fork PRs (they don't have OIDC/secrets access)
- Eliminates CI failures like the one in #22
- Fork PRs can still be reviewed via `@claude` mention in comments

## Context
Fork PRs can't access OIDC tokens or secrets due to GitHub's security model (prevents malicious PRs from exfiltrating secrets). This was causing the claude-code-action to fail with:

```
Error: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

## Test plan
- [ ] Same-repo PR triggers auto-review (existing behavior)
- [ ] Fork PR skips auto-review (no CI error)
- [ ] Fork PR can be reviewed via `@claude` comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)