### PR TITLE
fix: context percent now matches /context output exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Claude HUD will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Context percentage now matches Claude Code's `/context` output exactly (raw token usage)
+- Previously inflated by 23% after compactions due to hardcoded 45k buffer
+
+### Changed
+- Warnings (yellow/red colors, token breakdown, COMPACT indicator) now trigger based on "compact risk" (raw + 45k buffer) while displaying raw percent
+- When approaching compact risk threshold (85%+), shows remaining headroom: `65% (in: 10, cache: 130k) (12% until auto-compact if enabled)`
+- This gives users advance warning of autocompact while showing accurate current usage
+
+---
+
 ## [0.0.2] - 2025-01-04
 
 ### Security
@@ -9,7 +22,7 @@ All notable changes to Claude HUD will be documented in this file.
 - Remove dist/ from git tracking - PRs now contain source only, CI handles compilation
 
 ### Fixed
-- Add 45k token autocompact buffer to context percentage calculation - now matches `/context` output accurately by accounting for Claude Code's reserved autocompact space
+- ~~Add 45k token autocompact buffer to context percentage calculation~~ (reverted in next release)
 - Fix CI caching with package-lock.json
 - Use Opus 4.5 for GitHub Actions code review
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,16 @@
 /**
- * Autocompact buffer: reserved space that /context includes in its calculation.
- * This is fixed at 45k tokens (22.5% of 200k) - must be added to match /context output.
+ * Autocompact buffer: Claude Code reserves tokens for the autocompact process.
+ *
+ * This value (~45k tokens) is an estimate based on community observations and
+ * reverse-engineering. It is NOT officially documented by Anthropic and may
+ * change between Claude Code versions.
+ *
+ * How it's used:
+ * - Displayed percent shows raw usage (matches /context exactly)
+ * - Warning colors and thresholds use (raw + buffer) to give advance notice
+ * - "X% until auto-compact if enabled" = 100 - buffered percent
+ *
+ * If you notice the warnings are triggering too early or too late compared to
+ * actual autocompact behavior, this value may need adjustment.
  */
 export const AUTOCOMPACT_BUFFER = 45000;

--- a/tests/fixtures/expected/render-basic.txt
+++ b/tests/fixtures/expected/render-basic.txt
@@ -1,4 +1,4 @@
-[Opus] █████░░░░░ 45% | my-project
+[Opus] ██░░░░░░░░ 23% | my-project
 ◐ Edit: .../authentication.ts | ✓ Read ×1
 ✓ explore [haiku]: Finding auth code (<1s)
 ▸ Add tests (1/2)


### PR DESCRIPTION
---
  TL;DR

 The HUD's context percentage was showing significantly inflated values compared to Claude Code's /context command. because it was assuming all users would have the auto-compaction feature enabled, however I don't use CC auto-compaction because i think its too noisy.  Because I compact ad-hoc (usually very near the limits of the context winxow) compaction the HUD might show 88% while /context reports 65%. This caused confusion about actual context usage. The fix separates "display percentage" (raw, matches /context) from "warning percentage" (buffered, used for color thresholds and compact warnings).

 Problem

When Claude Code compacts a conversation, the actual token count drops significantly—but the HUD was adding a hardcoded 45,000 token "autocompact buffer" to the percentage calculation. This buffer exists because Claude Code triggers autocompact around 45k tokens before hitting the limit, so the buffer helps warn users before that happens. This buffer was being applied to the displayed percentage, not just the warning thresholds. 

However, the actual auto-compaction thresholds i don't think are reported (i assume this plugin tried to reverse engineer it), nor are they guaranteed to be deterministic (tracking them with a constant is flaky) and very well could be changed often, and model dependent. The result:

  - Misleading display: User sees 88% in HUD but /context shows 65%
  - Post-compaction confusion: After compacting, the HUD still shows high usage even though actual usage dropped 
  - Trust erosion: Users learn not to trust the HUD's percentage, defeating its purpose! (I had to constantly check the /context even when using the plugin)

  The core issue was conflating two different concepts:
  1. Actual context usage - what /context reports, what the user cares about
  2. Compact risk level - when to start warning about approaching autocompact

  Solution

  This PR proposes we calculate and use **two** separate percentages:

  getContextPercent(stdin) - Raw percentage (for display)

  // Returns actual token usage / context window size
  // This matches what /context reports
  const percent = getContextPercent(ctx.stdin);  // e.g., 65%

  getBufferedPercent(stdin) - Buffered percentage (for warnings)

  // Returns (actual tokens + 45k buffer) / context window size
  // This represents "compact risk" level
  const bufferedPercent = getBufferedPercent(ctx.stdin);  // e.g., 88%

  How they're used together

  | Element                 | Uses               | Why                                                  |
  |-------------------------|--------------------|------------------------------------------------------|
  | Displayed percentage    | Raw                | Users see actual usage matching /context             |
  | Progress bar color      | Buffered           | Warns early about approaching autocompact            |
  | Token breakdown (85%+)  | Buffered threshold | Shows details when compact risk is high              |
  | "COMPACT" warning       | Buffered           | Appears at 95% compact risk, not 95% actual          |
  | "X% until auto-compact" | Buffered           | Shows remaining headroom before autocompact triggers |

  Example output at 65% actual / 88% buffered:

  [Opus] ██████░░░░ 65% | my-project  (in: 130k, cache: 5k) (12% until auto-compact if enabled)

  - Shows 65% (actual usage, matches /context)
  - Bar is yellow (buffered 88% > 70% warning threshold)
  - Token breakdown shown (buffered 88% > 85% detail threshold)
  - Shows 12% remaining until autocompact would trigger (100% - 88%)
  - Compact threshold warning goes away after theoretically threshold is reached

  Files Changed

  - src/constants.ts - Added documentation explaining the AUTOCOMPACT_BUFFER constant
  - src/stdin.ts - Added getBufferedPercent() function alongside existing getContextPercent()
  - src/render/session-line.ts - Updated to use raw percent for display, buffered percent for thresholds
  - tests/core.test.js - Added tests for both percentage functions including regression test
  - tests/render.test.js - Added test verifying the autocompact indicator appears correctly
  - CHANGELOG.md - Documented the fix

  Screenshots
BEFORE

This was the output of /context after a compaction
<img width="705" height="255" alt=" context" src="https://github.com/user-attachments/assets/c6edac49-802d-49bd-9152-0347b1c12db6" />

And this is what claude-hud would say
<img width="844" height="151" alt="OCX 1 2 CLALOR nd l 4 hoaks l o Di tla (lai l, coches IATI) A COMPACT" src="https://github.com/user-attachments/assets/03a4fde7-4697-4a39-a876-4062a9e4ec9f" />


AFTER
This accurately reflects the actual context 1:1 and shows a friendly hit for those who have auto-compaction turned on
<img width="856" height="115" alt="• bets connit the context percent fia" src="https://github.com/user-attachments/assets/5d9ea0d9-2171-4836-b542-9ba7f16e59c7" />


---
