### PR TITLE
chore: release 0.0.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hud",
   "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to Claude HUD will be documented in this file.
 
+## [0.0.3] - 2025-01-06
+
+### Added
+- Display git branch name in session line (#23)
+- Display project folder name in session line (#18)
+- Dynamic platform and runtime detection in setup command (#24)
+
+### Changed
+- Remove redundant COMPACT warning at high context usage (#27)
+
+### Fixed
+- Skip auto-review for fork PRs to prevent CI failures (#25)
+
+### Dependencies
+- Bump @types/node from 20.19.27 to 25.0.3 (#2)
+
+---
+
 ## [0.0.2] - 2025-01-04
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hud",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Real-time statusline HUD for Claude Code",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.0.3 in package.json and plugin.json
- Update CHANGELOG.md with changes since 0.0.2

### Changes in 0.0.3
- **Added**: Display git branch name in session line (#23)
- **Added**: Display project folder name in session line (#18)
- **Added**: Dynamic platform and runtime detection in setup (#24)
- **Changed**: Remove redundant COMPACT warning at high context usage (#27)
- **Fixed**: Skip auto-review for fork PRs (#25)
- **Deps**: Bump @types/node to 25.0.3 (#2)

## Test plan
- [x] `npm ci` - dependencies installed
- [x] `npm run build` - compiles successfully
- [x] `npm test` - 57 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)