### PR TITLE
fix: remove AUTOCOMPACT_BUFFER from context percentage calculation

### DIFF
--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -37,7 +37,7 @@ export function getContextPercent(stdin: StdinData): number {
     (usage.cache_creation_input_tokens ?? 0) +
     (usage.cache_read_input_tokens ?? 0);
 
-  return Math.min(100, Math.round(((totalTokens + AUTOCOMPACT_BUFFER) / size) * 100));
+  return Math.min(100, Math.round((totalTokens / size) * 100));
 }
 
 export function getModelName(stdin: StdinData): string {


### PR DESCRIPTION
## Problem

The `getContextPercent` function adds `AUTOCOMPACT_BUFFER` (45k) to `totalTokens` before calculating the percentage, which inflates the displayed percentage significantly.

**Example:**
- Actual usage: 56k tokens
- Window size: 200k tokens
- Expected: 56k / 200k = **28%**
- Current (with buffer): (56k + 45k) / 200k = **51%**

This causes the HUD to show nearly double the actual context usage, which is confusing when compared to the `/context` command output.

## Solution

Simply remove the `+ AUTOCOMPACT_BUFFER` from the percentage calculation:

```diff
- return Math.min(100, Math.round(((totalTokens + AUTOCOMPACT_BUFFER) / size) * 100));
+ return Math.min(100, Math.round((totalTokens / size) * 100));
```

The `AUTOCOMPACT_BUFFER` constant is still used in the guard condition to handle edge cases, so no other changes are needed.

## Related

This is a follow-up to #21 where I incorrectly diagnosed the issue. This PR addresses the actual root cause.