### PR TITLE
fix: reconvert Date objects when reading from cache

### DIFF
--- a/src/usage-api.ts
+++ b/src/usage-api.ts
@@ -61,7 +61,17 @@ function readCache(homeDir: string, now: number): UsageData | null {
     const ttl = cache.data.apiUnavailable ? CACHE_FAILURE_TTL_MS : CACHE_TTL_MS;
     if (now - cache.timestamp >= ttl) return null;
 
-    return cache.data;
+    // JSON.stringify converts Date to ISO string, so we need to reconvert on read.
+    // new Date() handles both Date objects and ISO strings safely.
+    const data = cache.data;
+    if (data.fiveHourResetAt) {
+      data.fiveHourResetAt = new Date(data.fiveHourResetAt);
+    }
+    if (data.sevenDayResetAt) {
+      data.sevenDayResetAt = new Date(data.sevenDayResetAt);
+    }
+
+    return data;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes the `resetAt.getTime is not a function` error reported in #44.

## Root Cause

`JSON.stringify()` converts `Date` objects to ISO strings (e.g., `"2024-01-15T12:00:00.000Z"`), but `JSON.parse()` doesn't automatically convert them back to `Date` objects. 

When `readCache()` returns cached data, the `fiveHourResetAt` and `sevenDayResetAt` fields are strings instead of `Date` objects, causing `formatResetTime()` to fail when calling `.getTime()` on them.

## Fix

Reconvert the date strings back to `Date` objects after parsing the cache file. The `new Date()` constructor safely handles both Date objects and ISO strings, so this works regardless of whether the data came from cache (string) or fresh API response (Date).

## Test plan

- [x] All existing tests pass (110/110)
- [x] Manually verified HUD works after clearing cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)