### PR TITLE
Fix stale .git/index.lock on macOS

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -43,7 +43,7 @@ export async function getGitStatus(cwd?: string): Promise<GitStatus | null> {
     try {
       const { stdout: statusOut } = await execFileAsync(
         'git',
-        ['status', '--porcelain'],
+        ['status', '--porcelain', '--no-optional-locks'],
         { cwd, timeout: 1000, encoding: 'utf8' }
       );
       isDirty = statusOut.trim().length > 0;


### PR DESCRIPTION
First off, thanks for building claude-hud — it's quickly becoming an essential part of my Claude Code setup!

## Summary
Adds `--no-optional-locks` flag to the `git status --porcelain` command to prevent stale `.git/index.lock` files.

## Problem
On my machine, when claude-hud runs `git status --porcelain` in Claude Code, orphaned `.git/index.lock` files are left behind. These 0-byte lock files persist indefinitely, blocking all git write operations.

**Reproduction (on my machine):**
1. Enable `gitStatus.enabled` in claude-hud config
2. Open Claude Code in a git repository
3. Observe `.git/index.lock` appears and persists
4. Delete the lock file — it reappears within ~1 second

**Note:** Setting `showDirty: false` does not prevent this — `git status` is still called regardless.

## Root Cause (Uncertain)

I'm not entirely sure why this happens. The lock file is 0 bytes and has the `com.apple.provenance` xattr (indicating a sandboxed process created it), but no process holds the lock. Possible causes:

1. **Orphaned child process** — When Claude Code refreshes the statusLine, the Node process may be terminated before `git status` completes, leaving git mid-operation without proper cleanup.

2. **Rapid concurrent invocations** — If statusLine is invoked faster than git can complete, overlapping processes may cause lock conflicts.

3. **Signal propagation issues** — The 1000ms timeout sends SIGTERM to git, but if the parent Node process is simultaneously being killed, signals may not propagate reliably.

4. **macOS sandbox effects** — The sandbox may amplify these issues by slowing git operations or affecting signal delivery, though this is likely a contributing factor rather than the root cause.

## Solution
Add `--no-optional-locks` to the git status command. This flag (Git 2.15+) tells git to skip optional index locking during status checks.

**Tradeoff:** Git normally refreshes the index cache during `status`, which helps detect changes faster. With this flag, dirty detection may be slightly stale until another git operation refreshes the index. For a statusLine updating frequently, this is negligible — a 1-second delay in detection is acceptable, and avoiding lock contention is more important.

From the git documentation ([`--no-optional-locks`](https://git-scm.com/docs/git#Documentation/git.txt---no-optional-locks), [`GIT_OPTIONAL_LOCKS`](https://git-scm.com/docs/git#Documentation/git.txt-GITOPTIONALLOCKS)):

> This is useful for processes running in the background which do not want to cause lock contention with other operations on the repository.

## Testing
- Tested on macOS Darwin 25.2.0 (arm64)
- Verified lock file no longer appears with the fix applied