### PR TITLE
fix: move --no-optional-locks to correct position as global git option

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -43,7 +43,7 @@ export async function getGitStatus(cwd?: string): Promise<GitStatus | null> {
     try {
       const { stdout: statusOut } = await execFileAsync(
         'git',
-        ['status', '--porcelain', '--no-optional-locks'],
+        ['--no-optional-locks', 'status', '--porcelain'],
         { cwd, timeout: 1000, encoding: 'utf8' }
       );
       isDirty = statusOut.trim().length > 0;


### PR DESCRIPTION
## Summary
- Moves `--no-optional-locks` flag from subcommand position to global position

## Problem
PR #63 added `--no-optional-locks` to prevent stale index.lock files, but placed it as a subcommand option:
```
git status --porcelain --no-optional-locks  # wrong
```

This causes "unknown option" error because `--no-optional-locks` is a **global** git option that must come before the subcommand:
```
git --no-optional-locks status --porcelain  # correct
```

## Test plan
- [x] Verified fix locally: `npm run build && npm test` passes (122/122)
- [x] CI should now pass