### PR TITLE
feat: add native context percentage support for Claude Code v2.1.6+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Native context percentage support for Claude Code v2.1.6+
+  - Uses `used_percentage` field from stdin when available (accurate, matches `/context`)
+  - Automatic fallback to manual calculation for older versions
+  - Handles edge cases: NaN, negative values, values >100
+
 ### Changed
 - Context percentage now uses percentage-based buffer (22.5%) instead of hardcoded 45k tokens
   - Scales correctly for enterprise context windows (>200k)

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -32,9 +32,27 @@ function getTotalTokens(stdin: StdinData): number {
   );
 }
 
-export function getContextPercent(stdin: StdinData): number {
-  const size = stdin.context_window?.context_window_size;
+/**
+ * Get native percentage from Claude Code v2.1.6+ if available.
+ * Returns null if not available or invalid, triggering fallback to manual calculation.
+ */
+function getNativePercent(stdin: StdinData): number | null {
+  const nativePercent = stdin.context_window?.used_percentage;
+  if (typeof nativePercent === 'number' && !Number.isNaN(nativePercent)) {
+    return Math.min(100, Math.max(0, Math.round(nativePercent)));
+  }
+  return null;
+}
 
+export function getContextPercent(stdin: StdinData): number {
+  // Prefer native percentage (v2.1.6+) - accurate and matches /context
+  const native = getNativePercent(stdin);
+  if (native !== null) {
+    return native;
+  }
+
+  // Fallback: manual calculation without buffer
+  const size = stdin.context_window?.context_window_size;
   if (!size || size <= 0) {
     return 0;
   }
@@ -44,8 +62,15 @@ export function getContextPercent(stdin: StdinData): number {
 }
 
 export function getBufferedPercent(stdin: StdinData): number {
-  const size = stdin.context_window?.context_window_size;
+  // Prefer native percentage (v2.1.6+) - accurate and matches /context
+  // Native percentage already accounts for context correctly, no buffer needed
+  const native = getNativePercent(stdin);
+  if (native !== null) {
+    return native;
+  }
 
+  // Fallback: manual calculation with buffer for older Claude Code versions
+  const size = stdin.context_window?.context_window_size;
   if (!size || size <= 0) {
     return 0;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,10 @@ export interface StdinData {
       input_tokens?: number;
       cache_creation_input_tokens?: number;
       cache_read_input_tokens?: number;
-    };
+    } | null;
+    // Native percentage fields (Claude Code v2.1.6+)
+    used_percentage?: number | null;
+    remaining_percentage?: number | null;
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds support for Claude Code v2.1.6+'s new `used_percentage` field for accurate context percentage display
- Automatically falls back to manual calculation for older Claude Code versions
- Handles edge cases: NaN, negative values, and values >100

## Motivation

Claude Code v2.1.6 introduced native `used_percentage` and `remaining_percentage` fields in the statusline stdin JSON. These values are authoritative and match the `/context` command output exactly.

Previously, claude-hud calculated context percentage manually using token counts and an estimated buffer. With native percentage support:

| Metric | Manual Calculation | Native (v2.1.6+) |
|--------|-------------------|------------------|
| Accuracy | Estimated (~22% buffer) | Exact (matches `/context`) |
| Source | Token math | Claude Code internal |

## Implementation

**New helper function** in `src/stdin.ts`:
```typescript
function getNativePercent(stdin: StdinData): number | null {
  const nativePercent = stdin.context_window?.used_percentage;
  if (typeof nativePercent === 'number' && !Number.isNaN(nativePercent)) {
    return Math.min(100, Math.max(0, Math.round(nativePercent)));
  }
  return null;
}
```

**Key design decisions:**
- Both `getContextPercent()` and `getBufferedPercent()` return native value when available (buffer is irrelevant when native percentage is provided)
- Explicit `Number.isNaN()` check because `typeof NaN === 'number'` returns true
- Clamping to 0-100 range for defensive handling
- Returns `null` to trigger fallback, not `0` (which is a valid percentage)

## Test plan
- [x] Native percentage takes precedence over manual calculation
- [x] Fallback works when `used_percentage` is `null`
- [x] Fallback works when `used_percentage` is `NaN`
- [x] Zero value (0%) handled correctly
- [x] Negative values clamped to 0
- [x] Values >100 clamped to 100
- [x] All 109 existing tests still pass
- [x] TypeScript compilation passes
- [x] Validated with real Claude Code v2.1.6 stdin data

## Compatibility

| Claude Code Version | Behavior |
|---------------------|----------|
| v2.1.6+ | Uses native `used_percentage` (accurate) |
| <v2.1.6 | Falls back to manual calculation (unchanged) |

No breaking changes. No configuration required.

🤖 Generated with [Claude Code](https://claude.ai/code)