### PR TITLE
feat(git): Add file stats display with specific format like `(!2 +1 ?3)`

### DIFF
--- a/commands/configure.md
+++ b/commands/configure.md
@@ -105,6 +105,7 @@ Info items (Counts, Tokens, Usage, Duration) can be turned off via "Reset to Min
   - "Branch only" - git:(main)
   - "Branch + dirty" - git:(main*) shows uncommitted changes
   - "Full details" - git:(main* ↑2 ↓1) includes ahead/behind
+  - "File stats" - git:(main* !2 +1 ?3) Starship-compatible format
 
 **Skip Q3 if Git is OFF** - show only 3 questions total, or replace with placeholder.
 
@@ -143,9 +144,10 @@ Info items (Counts, Tokens, Usage, Duration) can be turned off via "Reset to Min
 
 | Option | Config |
 |--------|--------|
-| Branch only | `gitStatus: { enabled: true, showDirty: false, showAheadBehind: false }` |
-| Branch + dirty | `gitStatus: { enabled: true, showDirty: true, showAheadBehind: false }` |
-| Full details | `gitStatus: { enabled: true, showDirty: true, showAheadBehind: true }` |
+| Branch only | `gitStatus: { enabled: true, showDirty: false, showAheadBehind: false, showFileStats: false }` |
+| Branch + dirty | `gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false }` |
+| Full details | `gitStatus: { enabled: true, showDirty: true, showAheadBehind: true, showFileStats: false }` |
+| File stats | `gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: true }` |
 
 ---
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ export interface HudConfig {
     enabled: boolean;
     showDirty: boolean;
     showAheadBehind: boolean;
+    showFileStats: boolean;
   };
   display: {
     showModel: boolean;
@@ -35,6 +36,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     enabled: true,
     showDirty: true,
     showAheadBehind: false,
+    showFileStats: false,
   },
   display: {
     showModel: true,
@@ -86,6 +88,9 @@ function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showAheadBehind: typeof userConfig.gitStatus?.showAheadBehind === 'boolean'
       ? userConfig.gitStatus.showAheadBehind
       : DEFAULT_CONFIG.gitStatus.showAheadBehind,
+    showFileStats: typeof userConfig.gitStatus?.showFileStats === 'boolean'
+      ? userConfig.gitStatus.showFileStats
+      : DEFAULT_CONFIG.gitStatus.showFileStats,
   };
 
   const display = {

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -74,6 +74,19 @@ export function renderSessionLine(ctx: RenderContext): string {
         }
       }
 
+      // Show file stats in Starship-compatible format (!modified +added ✘deleted ?untracked)
+      if (gitConfig?.showFileStats && ctx.gitStatus.fileStats) {
+        const { modified, added, deleted, untracked } = ctx.gitStatus.fileStats;
+        const statParts: string[] = [];
+        if (modified > 0) statParts.push(`!${modified}`);
+        if (added > 0) statParts.push(`+${added}`);
+        if (deleted > 0) statParts.push(`✘${deleted}`);
+        if (untracked > 0) statParts.push(`?${untracked}`);
+        if (statParts.length > 0) {
+          gitParts.push(` ${statParts.join(' ')}`);
+        }
+      }
+
       gitPart = ` ${magenta('git:(')}${cyan(gitParts.join(''))}${magenta(')')}`;
     }
 


### PR DESCRIPTION

  ## Summary

  This PR adds a new `showFileStats` option to display file change counts in the git status indicator.

  ## Motivation

  The current git status only shows a dirty indicator (`*`) when there are uncommitted changes. This enhancement provides more granular information about the working tree state, helping users quickly understand:
  - How many files are modified
  - How many new files are staged
  - How many files are deleted
  - How many untracked files exist

  ## Display Format

  I researched several popular shell prompt tools to find a commonly-used format:

  | Tool | Format Example |
  |------|----------------|
  | [Starship](https://starship.rs/) | `[!1 +2 ✘1 ?3]` |
  | [oh-my-zsh git plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/git) | `✚1 ✖1 ●2` |
  | [zsh-git-prompt](https://github.com/olivierverdier/zsh-git-prompt) | `2↑ 1↓ 3✎` |

  Based on this research, I adopted the Starship-style format as it provides clear, concise symbols that are intuitive and widely recognized:

  git:(main* !2 +1 ✘1 ?3)

  | Symbol | Meaning |
  |--------|---------|
  | `!` | Modified files |
  | `+` | Added/staged files |
  | `✘` | Deleted files |
  | `?` | Untracked files |

  **Note:** Counts of 0 are omitted for cleaner display.

  ## Configuration

  Add to your `~/.claude/plugins/claude-hud/config.json`:

  ```json
  {
    "gitStatus": {
      "enabled": true,
      "showDirty": true,
      "showFileStats": true
    }
  }
```

  The option is also available in the /configure command under "Git Style" → "File stats".

  Changes

  - src/git.ts: Added parseFileStats() function to parse git status --porcelain output
  - src/types.ts: Added FileStats interface to GitStatus
  - src/config.ts: Added showFileStats option (default: false)
  - src/render/session-line.ts: Added file stats rendering logic
  - commands/configure.md: Added "File stats" option to Git Style selection
  - tests/git.test.js: Added 5 tests for file stats parsing
  - tests/render.test.js: Added 4 tests for rendering and backward compatibility

  Backward Compatibility

  - Default value is false, so existing users see no change
  - Existing configs without showFileStats work correctly (tested)
  - Works with all combinations of showDirty and showAheadBehind

  Testing

  All 111 tests pass:
  ✔ tests/config.test.js (14 tests)
  ✔ tests/git.test.js (12 tests)
  ✔ tests/render.test.js (85 tests)

  Tested locally with various git states (clean, modified, staged, deleted, untracked files).