### PR TITLE
fix: move EXDEV detection to run first on Linux setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ Inside a Claude Code instance, run the following commands:
 ```
 
 **Step 2: Install the plugin**
+
+<details>
+<summary><strong>⚠️ Linux users: Click here first</strong></summary>
+
+On Linux, `/tmp` is often a separate filesystem (tmpfs), which causes plugin installation to fail with:
+```
+EXDEV: cross-device link not permitted
+```
+
+**Fix**: Set TMPDIR before installing:
+```bash
+mkdir -p ~/.cache/tmp && TMPDIR=~/.cache/tmp claude
+```
+
+Then run the install command below in that session. This is a [Claude Code platform limitation](https://github.com/anthropics/claude-code/issues/14799).
+
+</details>
+
 ```
 /plugin install claude-hud
 ```


### PR DESCRIPTION
## Summary

- Fixes the EXDEV detection that was added in #53 but placed in an unreachable location
- Adds visible Linux warning in README before users attempt installation
- Restructures setup.md to check for cross-device filesystem issue FIRST on Linux

## Problem

PR #53 added EXDEV detection inside the "plugin path empty" check in setup.md. This was unreachable because:

1. User runs `/plugin install claude-hud`
2. Installation fails with EXDEV error
3. User can't run `/claude-hud:setup` because plugin isn't installed
4. The detection code never executes

Users in #52 and #70 confirmed the fix didn't help.

## Solution

**README.md**: Collapsible warning before install step catches users BEFORE they hit the error.

**setup.md**: New "Step 0" runs EXDEV check unconditionally on Linux:
- Runs FIRST, before checking plugin path
- Uses `~` instead of `~/.claude` (works even if .claude doesn't exist yet)
- If CROSS_DEVICE detected AND plugin not installed → shows workaround
- If plugin already installed → continues normally

## Test plan

- [ ] Linux user with tmpfs `/tmp` sees README warning before installing
- [ ] `/claude-hud:setup` on Linux runs Step 0 check first
- [ ] CROSS_DEVICE detection works with fresh install (no ~/.claude yet)
- [ ] macOS/Windows users unaffected (Step 0 skipped)

Fixes #52, #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)