### PR TITLE
fix: add ghost installation detection and cleanup to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ Inside a Claude Code instance, run the following commands:
 ```
 
 **Step 2: Install the plugin**
+
+<details>
+<summary><strong>⚠️ Linux users: Click here first</strong></summary>
+
+On Linux, `/tmp` is often a separate filesystem (tmpfs), which causes plugin installation to fail with:
+```
+EXDEV: cross-device link not permitted
+```
+
+**Fix**: Set TMPDIR before installing:
+```bash
+mkdir -p ~/.cache/tmp && TMPDIR=~/.cache/tmp claude
+```
+
+Then run the install command below in that session. This is a [Claude Code platform limitation](https://github.com/anthropics/claude-code/issues/14799).
+
+</details>
+
 ```
 /plugin install claude-hud
 ```


### PR DESCRIPTION
## Summary

- Adds Step 0 to setup.md that detects and fixes ghost/broken installations
- Adds EXDEV detection for Linux (cross-device filesystem issue)
- Provides cleanup commands for all platforms

**Supersedes #74** (EXDEV fix is included here).

## Problems Addressed

| Issue | Symptom | Root Cause |
|-------|---------|------------|
| #52, #70 | `EXDEV: cross-device link not permitted` | `/tmp` on different filesystem than `~/.claude` |
| #62 | "already installed" but `/plugin list` empty | Cache/registry out of sync |
| #59 | Ghost version can't be uninstalled | Partial install state |
| #60 | `temp_local_*` invalid manifest | Interrupted install left temp files |

## Solution

New **Step 0: Detect Ghost Installation** runs first and checks:

```
Cache exists? + Registry entry? + Temp files? + (Linux) EXDEV?
```

| Cache | Registry | Meaning | Action |
|-------|----------|---------|--------|
| YES | NO | Ghost - cache orphaned | Clean cache |
| NO | YES | Ghost - registry stale | Clean registry |
| Any | Any | temp_local_* exists | Clean temp files |

Provides platform-specific cleanup commands (macOS/Linux/Windows).

## Test plan

- [ ] Ghost install with orphaned cache detected and cleaned
- [ ] Ghost install with stale registry detected and cleaned  
- [ ] temp_local_* files detected and cleaned
- [ ] EXDEV check works on Linux with tmpfs /tmp
- [ ] Normal installs unaffected (Step 0 shows clean state, continues)

Fixes #52, #59, #60, #62, #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)