### PR TITLE
fix: resolve symlinks in path comparison for auto-execute

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,10 +95,15 @@ export function formatSessionDuration(sessionStart?: Date, now: () => number = (
   return `${hours}h ${remainingMins}m`;
 }
 
-// Use realpathSync to resolve symlinks, ensuring paths match even when
-// ~/.claude is a symlink (e.g., to iCloud on macOS)
 const scriptPath = fileURLToPath(import.meta.url);
 const argvPath = process.argv[1];
-if (argvPath && realpathSync(argvPath) === realpathSync(scriptPath)) {
+const isSamePath = (a: string, b: string): boolean => {
+  try {
+    return realpathSync(a) === realpathSync(b);
+  } catch {
+    return a === b;
+  }
+};
+if (argvPath && isSamePath(argvPath, scriptPath)) {
   void main();
 }


### PR DESCRIPTION
## Summary

- Fix HUD not outputting when `~/.claude` is a symlink (e.g., iCloud on macOS)
- Use `realpathSync` to normalize both paths before comparison

## Problem

When `~/.claude` is a symlink:
- `process.argv[1]` = `/Users/user/.claude/plugins/...` (symlink path)
- `fileURLToPath(import.meta.url)` = `/Users/user/Library/Mobile Documents/.../...` (real path)

Paths don't match → `main()` never called → no output.

## Solution

```typescript
const scriptPath = fileURLToPath(import.meta.url);
const argvPath = process.argv[1];
if (argvPath && realpathSync(argvPath) === realpathSync(scriptPath)) {
  void main();
}
```

## Test plan

- [x] Build passes (`npm run build`)
- [x] Tested with symlink path — now produces output
- [x] Tested with direct path — still works

Fixes #86

🤖 Generated with [Claude Code](https://claude.ai/code)