### PR TITLE
feat: add --extra-cmd CLI argument for custom status labels

### DIFF
--- a/src/extra-cmd.ts
+++ b/src/extra-cmd.ts
@@ -1,0 +1,65 @@
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execAsync = promisify(exec);
+
+const MAX_BUFFER = 10 * 1024; // 10KB - plenty for a label
+const MAX_LABEL_LENGTH = 50;
+
+export interface ExtraLabel {
+  label: string;
+}
+
+/**
+ * Sanitize output to prevent terminal escape injection.
+ * Strips ANSI escapes, OSC sequences, control characters, and bidi controls.
+ */
+function sanitize(input: string): string {
+  return input
+    .replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')   // CSI sequences
+    .replace(/\x1B\][^\x07\x1B]*(?:\x07|\x1B\\)/g, '') // OSC sequences
+    .replace(/\x1B[@-Z\\-_]/g, '')              // 7-bit C1 / ESC Fe
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, '') // C0/C1 controls
+    .replace(/[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069\u206A-\u206F]/g, ''); // bidi
+}
+
+/**
+ * Parse --extra-cmd argument from process.argv
+ * Usage: node dist/index.js --extra-cmd "command here"
+ */
+export function parseExtraCmdArg(argv: string[] = process.argv): string | null {
+  const idx = argv.indexOf('--extra-cmd');
+  if (idx === -1 || idx + 1 >= argv.length) {
+    return null;
+  }
+  return argv[idx + 1];
+}
+
+/**
+ * Execute a command and parse JSON output expecting { label: string }
+ * Returns null on any error (timeout, parse failure, missing label)
+ */
+export async function runExtraCmd(cmd: string): Promise<string | null> {
+  try {
+    const { stdout } = await execAsync(cmd, {
+      timeout: 3000,
+      maxBuffer: MAX_BUFFER,
+    });
+    const data: unknown = JSON.parse(stdout.trim());
+    if (
+      typeof data === 'object' &&
+      data !== null &&
+      'label' in data &&
+      typeof (data as ExtraLabel).label === 'string'
+    ) {
+      let label = sanitize((data as ExtraLabel).label);
+      if (label.length > MAX_LABEL_LENGTH) {
+        label = label.slice(0, MAX_LABEL_LENGTH - 1) + '…';
+      }
+      return label;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { countConfigs } from './config-reader.js';
 import { getGitStatus } from './git.js';
 import { getUsage } from './usage-api.js';
 import { loadConfig } from './config.js';
+import { parseExtraCmdArg, runExtraCmd } from './extra-cmd.js';
 import type { RenderContext } from './types.js';
 import { fileURLToPath } from 'node:url';
 
@@ -15,6 +16,8 @@ export type MainDeps = {
   getGitStatus: typeof getGitStatus;
   getUsage: typeof getUsage;
   loadConfig: typeof loadConfig;
+  parseExtraCmdArg: typeof parseExtraCmdArg;
+  runExtraCmd: typeof runExtraCmd;
   render: typeof render;
   now: () => number;
   log: (...args: unknown[]) => void;
@@ -28,6 +31,8 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     getGitStatus,
     getUsage,
     loadConfig,
+    parseExtraCmdArg,
+    runExtraCmd,
     render,
     now: () => Date.now(),
     log: console.log,
@@ -57,6 +62,9 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       ? await deps.getUsage()
       : null;
 
+    const extraCmd = deps.parseExtraCmdArg();
+    const extraLabel = extraCmd ? await deps.runExtraCmd(extraCmd) : null;
+
     const sessionDuration = formatSessionDuration(transcript.sessionStart, deps.now);
 
     const ctx: RenderContext = {
@@ -70,6 +78,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       gitStatus,
       usageData,
       config,
+      extraLabel,
     };
 
     deps.render(ctx);

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -153,6 +153,10 @@ export function renderSessionLine(ctx: RenderContext): string {
     parts.push(dim(`⏱️  ${ctx.sessionDuration}`));
   }
 
+  if (ctx.extraLabel) {
+    parts.push(dim(ctx.extraLabel));
+  }
+
   let line = parts.join(' | ');
 
   // Token breakdown at high context

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,4 +83,5 @@ export interface RenderContext {
   gitStatus: GitStatus | null;
   usageData: UsageData | null;
   config: HudConfig;
+  extraLabel: string | null;
 }


### PR DESCRIPTION
## Summary

Rebased and cleaned up version of #37 by @xiaocang.

- Added `--extra-cmd` CLI argument that executes a user-specified command and displays its output in the session line
- Command must return JSON with a `label` field, e.g., `{"label": "$1.23/day"}`
- Includes security hardening:
  - `sanitize()` to strip terminal escape sequences (CSI, OSC, control chars, bidi)
  - `maxBuffer: 10KB` limit to prevent memory issues
  - Label truncation to 50 chars max

## Usage

Configure in `settings.json`:
```json
{
  "statusLine": {
    "command": "node /path/to/claude-hud --extra-cmd 'your-command-here'"
  }
}
```

The command should output JSON like:
```json
{"label": "$1.23/day"}
```

## Changes from original PR
- Rebased onto current main (no dist/ files)
- Added security hardening (sanitize, maxBuffer, truncation)

## Test plan
- [x] Build passes
- [x] Tests pass
- [ ] Run with `--extra-cmd` argument and verify label appears in session line
- [ ] Run without `--extra-cmd` to verify no regression
- [ ] Test command timeout (>3s) returns gracefully

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)