### PR TITLE
fix(extra-cmd): improve robustness and add tests

### DIFF
--- a/src/extra-cmd.ts
+++ b/src/extra-cmd.ts
@@ -5,6 +5,15 @@ const execAsync = promisify(exec);
 
 const MAX_BUFFER = 10 * 1024; // 10KB - plenty for a label
 const MAX_LABEL_LENGTH = 50;
+const TIMEOUT_MS = 3000;
+
+const isDebug = process.env.DEBUG?.includes('claude-hud') ?? false;
+
+function debug(message: string): void {
+  if (isDebug) {
+    console.error(`[claude-hud:extra-cmd] ${message}`);
+  }
+}
 
 export interface ExtraLabel {
   label: string;
@@ -14,35 +23,63 @@ export interface ExtraLabel {
  * Sanitize output to prevent terminal escape injection.
  * Strips ANSI escapes, OSC sequences, control characters, and bidi controls.
  */
-function sanitize(input: string): string {
+export function sanitize(input: string): string {
   return input
-    .replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')   // CSI sequences
+    .replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '') // CSI sequences
     .replace(/\x1B\][^\x07\x1B]*(?:\x07|\x1B\\)/g, '') // OSC sequences
-    .replace(/\x1B[@-Z\\-_]/g, '')              // 7-bit C1 / ESC Fe
+    .replace(/\x1B[@-Z\\-_]/g, '') // 7-bit C1 / ESC Fe
     .replace(/[\u0000-\u001F\u007F-\u009F]/g, '') // C0/C1 controls
     .replace(/[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069\u206A-\u206F]/g, ''); // bidi
 }
 
 /**
  * Parse --extra-cmd argument from process.argv
- * Usage: node dist/index.js --extra-cmd "command here"
+ * Supports both: --extra-cmd "command" and --extra-cmd="command"
  */
 export function parseExtraCmdArg(argv: string[] = process.argv): string | null {
-  const idx = argv.indexOf('--extra-cmd');
-  if (idx === -1 || idx + 1 >= argv.length) {
-    return null;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    // Handle --extra-cmd=value syntax
+    if (arg.startsWith('--extra-cmd=')) {
+      const value = arg.slice('--extra-cmd='.length);
+      if (value === '') {
+        debug('Warning: --extra-cmd value is empty, ignoring');
+        return null;
+      }
+      return value;
+    }
+
+    // Handle --extra-cmd value syntax
+    if (arg === '--extra-cmd') {
+      if (i + 1 >= argv.length) {
+        debug('Warning: --extra-cmd specified but no value provided');
+        return null;
+      }
+      const value = argv[i + 1];
+      if (value === '') {
+        debug('Warning: --extra-cmd value is empty, ignoring');
+        return null;
+      }
+      return value;
+    }
   }
-  return argv[idx + 1];
+
+  return null;
 }
 
 /**
  * Execute a command and parse JSON output expecting { label: string }
  * Returns null on any error (timeout, parse failure, missing label)
+ *
+ * SECURITY NOTE: The cmd parameter is sourced exclusively from CLI arguments
+ * (--extra-cmd) typed by the user. Since the user controls their own shell,
+ * shell injection is not a concern here - it's intentional user input.
  */
-export async function runExtraCmd(cmd: string): Promise<string | null> {
+export async function runExtraCmd(cmd: string, timeout: number = TIMEOUT_MS): Promise<string | null> {
   try {
     const { stdout } = await execAsync(cmd, {
-      timeout: 3000,
+      timeout,
       maxBuffer: MAX_BUFFER,
     });
     const data: unknown = JSON.parse(stdout.trim());
@@ -58,8 +95,20 @@ export async function runExtraCmd(cmd: string): Promise<string | null> {
       }
       return label;
     }
+    debug(`Command output missing 'label' field or invalid type: ${JSON.stringify(data)}`);
     return null;
-  } catch {
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message.includes('TIMEOUT') || err.message.includes('killed')) {
+        debug(`Command timed out after ${timeout}ms: ${cmd}`);
+      } else if (err instanceof SyntaxError) {
+        debug(`Failed to parse JSON output: ${err.message}`);
+      } else {
+        debug(`Command failed: ${err.message}`);
+      }
+    } else {
+      debug(`Command failed with unknown error`);
+    }
     return null;
   }
 }

--- a/tests/extra-cmd.test.js
+++ b/tests/extra-cmd.test.js
@@ -1,0 +1,169 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sanitize, parseExtraCmdArg, runExtraCmd } from '../dist/extra-cmd.js';
+
+// ============================================================================
+// sanitize() tests
+// ============================================================================
+
+test('sanitize strips ANSI CSI sequences', () => {
+  const input = '\x1B[31mRed\x1B[0m Text';
+  assert.equal(sanitize(input), 'Red Text');
+});
+
+test('sanitize strips OSC sequences', () => {
+  const input = '\x1B]0;Window Title\x07Normal Text';
+  assert.equal(sanitize(input), 'Normal Text');
+});
+
+test('sanitize strips C0 control characters', () => {
+  const input = 'Hello\x00World\x1FTest';
+  assert.equal(sanitize(input), 'HelloWorldTest');
+});
+
+test('sanitize strips C1 control characters', () => {
+  const input = 'Hello\x80World\x9FTest';
+  assert.equal(sanitize(input), 'HelloWorldTest');
+});
+
+test('sanitize strips bidi control characters', () => {
+  const input = 'Hello\u200EWorld\u202ATest\u2069End';
+  assert.equal(sanitize(input), 'HelloWorldTestEnd');
+});
+
+test('sanitize preserves normal text', () => {
+  const input = 'Just normal text 123!';
+  assert.equal(sanitize(input), 'Just normal text 123!');
+});
+
+test('sanitize handles empty string', () => {
+  assert.equal(sanitize(''), '');
+});
+
+test('sanitize handles complex mixed escape sequences', () => {
+  const input = '\x1B[1;32mBold Green\x1B[0m \x1B]0;Title\x07 \x00Hidden\x1F';
+  assert.equal(sanitize(input), 'Bold Green  Hidden');
+});
+
+// ============================================================================
+// parseExtraCmdArg() tests
+// ============================================================================
+
+test('parseExtraCmdArg returns null when no --extra-cmd present', () => {
+  const argv = ['node', 'index.js', '--other', 'arg'];
+  assert.equal(parseExtraCmdArg(argv), null);
+});
+
+test('parseExtraCmdArg parses --extra-cmd value syntax', () => {
+  const argv = ['node', 'index.js', '--extra-cmd', 'echo hello'];
+  assert.equal(parseExtraCmdArg(argv), 'echo hello');
+});
+
+test('parseExtraCmdArg parses --extra-cmd=value syntax', () => {
+  const argv = ['node', 'index.js', '--extra-cmd=echo hello'];
+  assert.equal(parseExtraCmdArg(argv), 'echo hello');
+});
+
+test('parseExtraCmdArg returns null when --extra-cmd is last arg with space syntax', () => {
+  const argv = ['node', 'index.js', '--extra-cmd'];
+  assert.equal(parseExtraCmdArg(argv), null);
+});
+
+test('parseExtraCmdArg returns null for empty value with equals syntax', () => {
+  const argv = ['node', 'index.js', '--extra-cmd='];
+  assert.equal(parseExtraCmdArg(argv), null);
+});
+
+test('parseExtraCmdArg returns null for empty value with space syntax', () => {
+  const argv = ['node', 'index.js', '--extra-cmd', ''];
+  assert.equal(parseExtraCmdArg(argv), null);
+});
+
+test('parseExtraCmdArg handles command with equals sign in value', () => {
+  const argv = ['node', 'index.js', '--extra-cmd=echo "key=value"'];
+  assert.equal(parseExtraCmdArg(argv), 'echo "key=value"');
+});
+
+test('parseExtraCmdArg takes first occurrence when multiple present', () => {
+  const argv = ['node', 'index.js', '--extra-cmd', 'first', '--extra-cmd', 'second'];
+  assert.equal(parseExtraCmdArg(argv), 'first');
+});
+
+test('parseExtraCmdArg handles command with spaces and quotes', () => {
+  const argv = ['node', 'index.js', '--extra-cmd', 'echo "hello world"'];
+  assert.equal(parseExtraCmdArg(argv), 'echo "hello world"');
+});
+
+// ============================================================================
+// runExtraCmd() tests
+// ============================================================================
+
+test('runExtraCmd returns label from valid JSON output', async () => {
+  const result = await runExtraCmd('echo \'{"label": "test"}\'');
+  assert.equal(result, 'test');
+});
+
+test('runExtraCmd returns null for non-JSON output', async () => {
+  const result = await runExtraCmd('echo "not json"');
+  assert.equal(result, null);
+});
+
+test('runExtraCmd returns null for JSON without label field', async () => {
+  const result = await runExtraCmd('echo \'{"other": "field"}\'');
+  assert.equal(result, null);
+});
+
+test('runExtraCmd returns null for JSON with non-string label', async () => {
+  const result = await runExtraCmd('echo \'{"label": 123}\'');
+  assert.equal(result, null);
+});
+
+test('runExtraCmd truncates long labels with ellipsis', async () => {
+  const longLabel = 'a'.repeat(60);
+  const result = await runExtraCmd(`echo '{"label": "${longLabel}"}'`);
+  assert.equal(result?.length, 50);
+  assert.ok(result?.endsWith('…'));
+});
+
+test('runExtraCmd sanitizes output containing escape sequences', async () => {
+  const result = await runExtraCmd('echo \'{"label": "\\u001b[31mRed\\u001b[0m"}\'');
+  assert.equal(result, 'Red');
+});
+
+test('runExtraCmd returns null when command fails', async () => {
+  const result = await runExtraCmd('exit 1');
+  assert.equal(result, null);
+});
+
+test('runExtraCmd returns null when command does not exist', async () => {
+  const result = await runExtraCmd('nonexistent-command-xyz123');
+  assert.equal(result, null);
+});
+
+test('runExtraCmd handles timeout', async () => {
+  const start = Date.now();
+  const result = await runExtraCmd('sleep 10', 100);
+  const elapsed = Date.now() - start;
+  assert.equal(result, null);
+  assert.ok(elapsed < 1000, `Expected timeout around 100ms, but took ${elapsed}ms`);
+});
+
+test('runExtraCmd handles empty stdout', async () => {
+  const result = await runExtraCmd('echo ""');
+  assert.equal(result, null);
+});
+
+test('runExtraCmd handles JSON array instead of object', async () => {
+  const result = await runExtraCmd('echo \'[1,2,3]\'');
+  assert.equal(result, null);
+});
+
+test('runExtraCmd handles null JSON', async () => {
+  const result = await runExtraCmd('echo "null"');
+  assert.equal(result, null);
+});
+
+test('runExtraCmd handles valid JSON with extra whitespace', async () => {
+  const result = await runExtraCmd('echo \'  { "label": "trimmed" }  \'');
+  assert.equal(result, 'trimmed');
+});


### PR DESCRIPTION
## Summary

Follow-up improvements to the `--extra-cmd` feature (merged in #92) based on Codex security review.

### Changes
- **Debug logging**: Add logging for failures using existing `DEBUG=claude-hud` pattern
- **Syntax support**: Support `--extra-cmd=value` in addition to `--extra-cmd value`
- **Empty value handling**: Reject empty values with debug warning
- **Security comment**: Document that shell injection is intentional (user-typed CLI input)
- **Export sanitize()**: Allow testing of sanitization function
- **30 unit tests**: Cover sanitize, arg parsing, timeout, malformed JSON

### Test plan
- [x] All 152 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)