### PR TITLE
fix(setup): use Platform context instead of uname for detection

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -91,9 +91,17 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
 ## Step 1: Detect Platform & Runtime
 
-**macOS/Linux** (if `uname -s` returns "Darwin", "Linux", or a MINGW*/MSYS*/CYGWIN* variant):
+**IMPORTANT**: Determine the platform from your environment context (`Platform:` value), NOT from `uname -s`. The Bash tool may report a different environment than the user's actual platform (e.g., Git Bash on Windows reports MINGW even when the user launched Claude Code from PowerShell).
 
-> **Git Bash/MSYS2/Cygwin users on Windows**: Follow these macOS/Linux instructions, not the Windows section below. Your environment provides bash and Unix-like tools.
+| Platform | Command Format |
+|----------|---------------|
+| `darwin` | bash (macOS) |
+| `linux` | bash (all Linux distros including NixOS, Ubuntu, Arch, etc.) |
+| `win32` | PowerShell (works universally on Windows 10+) |
+
+---
+
+**macOS/Linux** (Platform: `darwin` or `linux`):
 
 1. Get plugin path:
    ```bash
@@ -125,7 +133,7 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
    bash -c '"{RUNTIME_PATH}" "$(ls -td ~/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | head -1){SOURCE}"'
    ```
 
-**Windows** (native PowerShell/cmd.exe - if `uname` command is not available):
+**Windows** (Platform: `win32`):
 
 1. Get plugin path:
    ```powershell


### PR DESCRIPTION
## Summary

Fixes #90 - Setup incorrectly detects Git Bash on PowerShell systems.

**Root cause**: The Bash tool on Windows uses Git Bash as its interpreter, so `uname -s` returns `MINGW64_NT-*` even when the user launched Claude Code from PowerShell. This caused setup to generate bash commands that fail.

**Fix**: Instruct Claude to use the `Platform:` value from its environment context instead of running `uname -s`. Claude already knows the platform - we just need to use it.

## Platform Detection

| Platform value | Command Format | Covers |
|---------------|----------------|--------|
| `darwin` | bash | macOS |
| `linux` | bash | All Linux distros (Ubuntu, NixOS, Arch, Alpine, etc.) |
| `win32` | PowerShell | Windows 10+ (works from PowerShell, cmd.exe, or Git Bash) |

## Why this works

- `Platform:` comes from Node's `process.platform`, which correctly identifies the OS
- PowerShell commands work universally on Windows 10+ regardless of which terminal the user launched Claude Code from
- No user interaction needed
- No shell detection that can fail

## Test plan

- [ ] Test on macOS - should generate bash command
- [ ] Test on Linux - should generate bash command  
- [ ] Test on Windows from PowerShell - should generate PowerShell command
- [ ] Test on Windows from Git Bash - should generate PowerShell command (still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)