### PR TITLE
fix: support win32 + bash shell in setup command

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -93,11 +93,12 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
 **IMPORTANT**: Determine the platform from your environment context (`Platform:` value), NOT from `uname -s`. The Bash tool may report a different environment than the user's actual platform (e.g., Git Bash on Windows reports MINGW even when the user launched Claude Code from PowerShell).
 
-| Platform | Command Format |
-|----------|---------------|
-| `darwin` | bash (macOS) |
-| `linux` | bash (all Linux distros including NixOS, Ubuntu, Arch, etc.) |
-| `win32` | PowerShell (works universally on Windows 10+) |
+| Platform | Shell | Command Format |
+|----------|-------|---------------|
+| `darwin` | any | bash |
+| `linux` | any | bash |
+| `win32` | `bash` (Git Bash, MSYS2) | bash (same as macOS/Linux) |
+| `win32` | PowerShell / cmd | PowerShell |
 
 ---
 
@@ -134,6 +135,13 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
    ```
 
 **Windows** (Platform: `win32`):
+
+**First, detect the shell**: Check the `Shell:` value from the environment context (shown in the system prompt).
+- If Shell is `bash` (Git Bash, MSYS2): Use the **macOS/Linux instructions above** — they work identically in Git Bash since it provides a POSIX-compatible environment.
+- If Shell is `powershell`, `pwsh`, or `cmd`: Use the **PowerShell instructions below**.
+- If unsure, check for bash: `echo $BASH_VERSION` — if it outputs a version string, use the macOS/Linux instructions.
+
+**PowerShell instructions** (only when Shell is NOT bash):
 
 1. Get plugin path:
    ```powershell


### PR DESCRIPTION
## Summary

Fixes #121

- Add shell detection in `commands/setup.md` Step 1 for `win32` platform
- When Shell is `bash` (Git Bash/MSYS2), redirect to macOS/Linux bash instructions instead of generating PowerShell commands
- Existing PowerShell/cmd behavior is unchanged

## Root Cause

Claude Code executes the `statusLine` command using the user's **detected shell** (shown as `Shell:` in the environment context). On Git Bash environments, `Platform: win32` but `Shell: bash`. The previous setup logic only checked `Platform` and always generated a PowerShell command for `win32`, creating a 3-layer process chain:

```
bash -c 'powershell -Command "& { ... bun ... }"'
```

This chain fails because:
1. `$` variables in the PowerShell command are interpreted by bash first
2. PowerShell startup adds ~2s latency, risking the statusLine timeout
3. stdin pipe (JSON data) breaks across the bash→PowerShell boundary

The fix detects the shell and uses the native bash command format when the shell is bash, avoiding the cross-shell chain entirely.

## Changes

**`commands/setup.md`**:
- Updated platform table to include Shell column with `win32 + bash` row
- Added shell detection guidance at top of Windows section
- Existing PowerShell instructions wrapped under conditional heading

## Test Plan

- [x] Verified bash command works on MINGW64 (Git Bash): `echo '{"model":{"id":"test"}}' | bash -c '"bun" "$(ls -td ~/.claude/plugins/cache/claude-hud/claude-hud/*/ | head -1)src/index.ts"'`
- [ ] Verify PowerShell path is unaffected on native Windows PowerShell
- [ ] Verify macOS/Linux paths are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)