### PR TITLE
feat: add CLAUDE_CONFIG_DIR env var for custom config paths

### DIFF
--- a/src/config-reader.ts
+++ b/src/config-reader.ts
@@ -97,7 +97,11 @@ export async function countConfigs(cwd?: string): Promise<ConfigCounts> {
   let hooksCount = 0;
 
   const homeDir = os.homedir();
-  const claudeDir = path.join(homeDir, '.claude');
+  // Support CLAUDE_CONFIG_DIR env var for custom config locations (e.g. Windows)
+  const configDir = process.env.CLAUDE_CONFIG_DIR;
+  const claudeDir = configDir || path.join(homeDir, '.claude');
+  // If CLAUDE_CONFIG_DIR is set, derive the parent for .claude.json; otherwise use homeDir
+  const claudeJsonParent = configDir ? path.dirname(configDir) : homeDir;
 
   // Collect all MCP servers across scopes, then subtract disabled ones
   const userMcpServers = new Set<string>();
@@ -105,28 +109,28 @@ export async function countConfigs(cwd?: string): Promise<ConfigCounts> {
 
   // === USER SCOPE ===
 
-  // ~/.claude/CLAUDE.md
+  // {claudeDir}/CLAUDE.md
   if (fs.existsSync(path.join(claudeDir, 'CLAUDE.md'))) {
     claudeMdCount++;
   }
 
-  // ~/.claude/rules/*.md
+  // {claudeDir}/rules/*.md
   rulesCount += countRulesInDir(path.join(claudeDir, 'rules'));
 
-  // ~/.claude/settings.json (MCPs and hooks)
+  // {claudeDir}/settings.json (MCPs and hooks)
   const userSettings = path.join(claudeDir, 'settings.json');
   for (const name of getMcpServerNames(userSettings)) {
     userMcpServers.add(name);
   }
   hooksCount += countHooksInFile(userSettings);
 
-  // ~/.claude.json (additional user-scope MCPs)
-  const userClaudeJson = path.join(homeDir, '.claude.json');
+  // {claudeJsonParent}/.claude.json (additional user-scope MCPs)
+  const userClaudeJson = path.join(claudeJsonParent, '.claude.json');
   for (const name of getMcpServerNames(userClaudeJson)) {
     userMcpServers.add(name);
   }
 
-  // Get disabled user-scope MCPs from ~/.claude.json
+  // Get disabled user-scope MCPs from .claude.json
   const disabledUserMcps = getDisabledMcpServers(userClaudeJson, 'disabledMcpServers');
   for (const name of disabledUserMcps) {
     userMcpServers.delete(name);

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,10 @@ export const DEFAULT_CONFIG: HudConfig = {
 };
 
 export function getConfigPath(): string {
+  const configDir = process.env.CLAUDE_CONFIG_DIR;
+  if (configDir) {
+    return path.join(configDir, 'plugins', 'claude-hud', 'config.json');
+  }
   const homeDir = os.homedir();
   return path.join(homeDir, '.claude', 'plugins', 'claude-hud', 'config.json');
 }

--- a/src/usage-api.ts
+++ b/src/usage-api.ts
@@ -274,22 +274,34 @@ function readKeychainCredentials(now: number, homeDir: string): { accessToken: s
 /**
  * Read credentials from file (legacy method).
  * Older versions of Claude Code stored credentials in ~/.claude/.credentials.json
+ * Supports CLAUDE_CONFIG_DIR env var for custom config locations (e.g. Windows).
  */
 function readFileCredentials(homeDir: string, now: number): { accessToken: string; subscriptionType: string } | null {
-  const credentialsPath = path.join(homeDir, '.claude', '.credentials.json');
+  // Prefer CLAUDE_CONFIG_DIR if set (e.g. custom config location on Windows)
+  const configDir = process.env.CLAUDE_CONFIG_DIR;
+  const candidates = configDir
+    ? [path.join(configDir, '.credentials.json'), path.join(homeDir, '.claude', '.credentials.json')]
+    : [path.join(homeDir, '.claude', '.credentials.json')];
 
-  if (!fs.existsSync(credentialsPath)) {
-    return null;
+  for (const credentialsPath of candidates) {
+    if (!fs.existsSync(credentialsPath)) {
+      continue;
+    }
+
+    try {
+      const content = fs.readFileSync(credentialsPath, 'utf8');
+      const data: CredentialsFile = JSON.parse(content);
+      const result = parseCredentialsData(data, now);
+      if (result) {
+        debug('Read credentials from:', credentialsPath);
+        return result;
+      }
+    } catch (error) {
+      debug('Failed to read credentials file:', credentialsPath, error);
+    }
   }
 
-  try {
-    const content = fs.readFileSync(credentialsPath, 'utf8');
-    const data: CredentialsFile = JSON.parse(content);
-    return parseCredentialsData(data, now);
-  } catch (error) {
-    debug('Failed to read credentials file:', error);
-    return null;
-  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `CLAUDE_CONFIG_DIR` environment variable support so users can override the default `~/.claude` config directory
- On Windows, `os.homedir()` may not resolve to the expected config location; this env var provides a reliable override
- Changes affect three config-path resolution sites: `getConfigPath()`, `countConfigs()`, and `readFileCredentials()`

## Motivation

On Windows (and other non-standard setups), Claude Code may store its configuration in a directory that doesn't match `os.homedir() + '/.claude'`. For example, `os.homedir()` on Windows ignores the `HOME` environment variable and uses `USERPROFILE` instead. Setting `CLAUDE_CONFIG_DIR` allows the HUD plugin to find credentials, settings, and plugin config regardless of the OS-level home directory resolution.

## Changes

| File | Change |
|------|--------|
| `src/config.ts` | `getConfigPath()` checks `CLAUDE_CONFIG_DIR` before falling back to `~/.claude` |
| `src/config-reader.ts` | `countConfigs()` uses `CLAUDE_CONFIG_DIR` for locating settings, CLAUDE.md, and rules |
| `src/usage-api.ts` | `readFileCredentials()` tries `CLAUDE_CONFIG_DIR` first when looking for `.credentials.json` |

## Test plan

- [ ] Set `CLAUDE_CONFIG_DIR` to a custom path and verify HUD reads config from that path
- [ ] Unset `CLAUDE_CONFIG_DIR` and verify default `~/.claude` behavior is unchanged
- [ ] `npm run build` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)