### PR TITLE
feat: add HTTP proxy support and extended usage data

### DIFF
--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -29,7 +29,18 @@ export function renderUsageLine(ctx: RenderContext): string | null {
     const resetTime = ctx.usageData.fiveHour === 100
       ? formatResetTime(ctx.usageData.fiveHourResetAt)
       : formatResetTime(ctx.usageData.sevenDayResetAt);
-    return `${label} ${red(`⚠ Limit reached${resetTime ? ` (resets ${resetTime})` : ''}`)}`;
+    let limitMsg = red(`⚠ Limit reached${resetTime ? ` (resets ${resetTime})` : ''}`);
+    // Show Extra Usage even when limit reached
+    if (ctx.usageData.extraUsage?.isEnabled) {
+      const extra = ctx.usageData.extraUsage;
+      const usageBarEnabled = (ctx.config?.display?.usageBarEnabled ?? true);
+      const extraUtil = extra.utilization ?? (extra.monthlyLimit && extra.monthlyLimit > 0 ? Math.round(((extra.usedCredits ?? 0) / extra.monthlyLimit) * 100) : 0);
+      const extraPart = usageBarEnabled
+        ? `${quotaBar(extraUtil)} ${formatUsagePercent(extraUtil)} Extra`
+        : `Extra: ${formatUsagePercent(extraUtil)}`;
+      limitMsg += ` | ${extraPart}`;
+    }
+    return `${label} ${limitMsg}`;
   }
 
   const threshold = display?.usageThreshold ?? 0;
@@ -41,6 +52,7 @@ export function renderUsageLine(ctx: RenderContext): string | null {
     return null;
   }
 
+  const parts: string[] = [];
   const fiveHourDisplay = formatUsagePercent(ctx.usageData.fiveHour);
   const fiveHourReset = formatResetTime(ctx.usageData.fiveHourResetAt);
 
@@ -52,6 +64,7 @@ export function renderUsageLine(ctx: RenderContext): string | null {
     : (fiveHourReset
         ? `5h: ${fiveHourDisplay} (${fiveHourReset})`
         : `5h: ${fiveHourDisplay}`);
+  parts.push(fiveHourPart);
 
   const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
   if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
@@ -62,10 +75,20 @@ export function renderUsageLine(ctx: RenderContext): string | null {
           ? `${quotaBar(sevenDay)} ${sevenDayDisplay} (${sevenDayReset} / 7d)`
           : `${quotaBar(sevenDay)} ${sevenDayDisplay}`)
       : `7d: ${sevenDayDisplay}`;
-    return `${label} ${fiveHourPart} | ${sevenDayPart}`;
+    parts.push(sevenDayPart);
   }
 
-  return `${label} ${fiveHourPart}`;
+  // Extra Usage
+  if (ctx.usageData.extraUsage?.isEnabled) {
+    const extra = ctx.usageData.extraUsage;
+    const extraUtil = extra.utilization ?? (extra.monthlyLimit && extra.monthlyLimit > 0 ? Math.round(((extra.usedCredits ?? 0) / extra.monthlyLimit) * 100) : 0);
+    const extraPart = usageBarEnabled
+      ? `${quotaBar(extraUtil)} ${formatUsagePercent(extraUtil)} Extra`
+      : `Extra: ${formatUsagePercent(extraUtil)}`;
+    parts.push(extraPart);
+  }
+
+  return `${label} ${parts.join(' | ')}`;
 }
 
 function formatUsagePercent(percent: number | null): string {
@@ -93,7 +116,16 @@ function formatResetTime(resetAt: Date | null): string {
   const diffMins = Math.ceil(diffMs / 60000);
   if (diffMins < 60) return `${diffMins}m`;
 
-  const hours = Math.floor(diffMins / 60);
-  const mins = diffMins % 60;
-  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  const totalHours = Math.floor(diffMins / 60);
+  if (totalHours < 24) {
+    const mins = diffMins % 60;
+    return mins > 0 ? `${totalHours}h ${mins}m` : `${totalHours}h`;
+  }
+
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  if (hours > 0) {
+    return `${days}d ${hours}h`;
+  }
+  return `${days}d`;
 }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -134,6 +134,16 @@ export function renderSessionLine(ctx: RenderContext): string {
         ? formatResetTime(ctx.usageData.fiveHourResetAt)
         : formatResetTime(ctx.usageData.sevenDayResetAt);
       parts.push(red(`⚠ Limit reached${resetTime ? ` (resets ${resetTime})` : ''}`));
+      // Show Extra Usage even when limit reached
+      if (ctx.usageData.extraUsage?.isEnabled) {
+        const extra = ctx.usageData.extraUsage;
+        const usageBarEnabled = (display?.usageBarEnabled ?? true);
+        const extraUtil = extra.utilization ?? (extra.monthlyLimit && extra.monthlyLimit > 0 ? Math.round(((extra.usedCredits ?? 0) / extra.monthlyLimit) * 100) : 0);
+        const extraPart = usageBarEnabled
+          ? `${quotaBar(extraUtil)} ${formatUsagePercent(extraUtil)} Extra`
+          : `Extra: ${formatUsagePercent(extraUtil)}`;
+        parts.push(extraPart);
+      }
     } else {
       const usageThreshold = display?.usageThreshold ?? 0;
       const fiveHour = ctx.usageData.fiveHour;
@@ -153,6 +163,7 @@ export function renderSessionLine(ctx: RenderContext): string {
               ? `5h: ${fiveHourDisplay} (${fiveHourReset})`
               : `5h: ${fiveHourDisplay}`);
 
+        const usageParts: string[] = [fiveHourPart];
         const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
         if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
           const sevenDayDisplay = formatUsagePercent(sevenDay);
@@ -162,10 +173,20 @@ export function renderSessionLine(ctx: RenderContext): string {
                 ? `${quotaBar(sevenDay)} ${sevenDayDisplay} (${sevenDayReset} / 7d)`
                 : `${quotaBar(sevenDay)} ${sevenDayDisplay}`)
             : `7d: ${sevenDayDisplay}`;
-          parts.push(`${fiveHourPart} | ${sevenDayPart}`);
-        } else {
-          parts.push(fiveHourPart);
+          usageParts.push(sevenDayPart);
         }
+
+        // Extra Usage
+        if (ctx.usageData.extraUsage?.isEnabled) {
+          const extra = ctx.usageData.extraUsage;
+          const extraUtil = extra.utilization ?? (extra.monthlyLimit && extra.monthlyLimit > 0 ? Math.round(((extra.usedCredits ?? 0) / extra.monthlyLimit) * 100) : 0);
+          const extraPart = usageBarEnabled
+            ? `${quotaBar(extraUtil)} ${formatUsagePercent(extraUtil)} Extra`
+            : `Extra: ${formatUsagePercent(extraUtil)}`;
+          usageParts.push(extraPart);
+        }
+
+        parts.push(usageParts.join(' | '));
       }
     }
   }
@@ -249,7 +270,16 @@ function formatResetTime(resetAt: Date | null): string {
   const diffMins = Math.ceil(diffMs / 60000);
   if (diffMins < 60) return `${diffMins}m`;
 
-  const hours = Math.floor(diffMins / 60);
-  const mins = diffMins % 60;
-  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  const totalHours = Math.floor(diffMins / 60);
+  if (totalHours < 24) {
+    const mins = diffMins % 60;
+    return mins > 0 ? `${totalHours}h ${mins}m` : `${totalHours}h`;
+  }
+
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  if (hours > 0) {
+    return `${days}d ${hours}h`;
+  }
+  return `${days}d`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,12 +52,24 @@ export interface UsageWindow {
   resetAt: Date | null;
 }
 
+export interface ExtraUsageData {
+  isEnabled: boolean;
+  monthlyLimit?: number;
+  usedCredits?: number;
+  utilization: number | null;  // 0-100 percentage
+}
+
 export interface UsageData {
   planName: string | null;  // 'Max', 'Pro', or null for API users
   fiveHour: number | null;  // 0-100 percentage, null if unavailable
   sevenDay: number | null;  // 0-100 percentage, null if unavailable
   fiveHourResetAt: Date | null;
   sevenDayResetAt: Date | null;
+  sevenDaySonnet?: number | null;  // Sonnet model 7-day usage
+  sevenDaySonnetResetAt?: Date | null;
+  sevenDayOpus?: number | null;  // Opus model 7-day usage
+  sevenDayOpusResetAt?: Date | null;
+  extraUsage?: ExtraUsageData | null;  // Extra usage credits
   apiUnavailable?: boolean; // true if API call failed (user should check DEBUG logs)
   apiError?: string; // short error reason (e.g., 401, timeout)
 }

--- a/src/usage-api.ts
+++ b/src/usage-api.ts
@@ -2,6 +2,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as https from 'https';
+import * as http from 'http';
+import * as url from 'url';
+import * as tls from 'tls';
 import { execFileSync } from 'child_process';
 import type { UsageData } from './types.js';
 import { createDebug } from './debug.js';
@@ -29,6 +32,20 @@ interface UsageApiResponse {
   seven_day?: {
     utilization?: number;
     resets_at?: string;
+  };
+  seven_day_sonnet?: {
+    utilization?: number;
+    resets_at?: string;
+  };
+  seven_day_opus?: {
+    utilization?: number;
+    resets_at?: string;
+  };
+  extra_usage?: {
+    is_enabled?: boolean;
+    monthly_limit?: number;
+    used_credits?: number;
+    utilization?: number;
   };
 }
 
@@ -72,6 +89,12 @@ function readCache(homeDir: string, now: number): UsageData | null {
     }
     if (data.sevenDayResetAt) {
       data.sevenDayResetAt = new Date(data.sevenDayResetAt);
+    }
+    if (data.sevenDaySonnetResetAt) {
+      data.sevenDaySonnetResetAt = new Date(data.sevenDaySonnetResetAt);
+    }
+    if (data.sevenDayOpusResetAt) {
+      data.sevenDayOpusResetAt = new Date(data.sevenDayOpusResetAt);
     }
 
     return data;
@@ -170,12 +193,31 @@ export async function getUsage(overrides: Partial<UsageApiDeps> = {}): Promise<U
     const fiveHourResetAt = parseDate(apiResult.data.five_hour?.resets_at);
     const sevenDayResetAt = parseDate(apiResult.data.seven_day?.resets_at);
 
+    // Parse model-specific usage
+    const sevenDaySonnet = parseUtilization(apiResult.data.seven_day_sonnet?.utilization);
+    const sevenDaySonnetResetAt = parseDate(apiResult.data.seven_day_sonnet?.resets_at);
+    const sevenDayOpus = parseUtilization(apiResult.data.seven_day_opus?.utilization);
+    const sevenDayOpusResetAt = parseDate(apiResult.data.seven_day_opus?.resets_at);
+
+    // Parse extra usage
+    const extraUsage = apiResult.data.extra_usage ? {
+      isEnabled: apiResult.data.extra_usage.is_enabled || false,
+      monthlyLimit: apiResult.data.extra_usage.monthly_limit,
+      usedCredits: apiResult.data.extra_usage.used_credits,
+      utilization: parseUtilization(apiResult.data.extra_usage.utilization),
+    } : null;
+
     const result: UsageData = {
       planName,
       fiveHour,
       sevenDay,
       fiveHourResetAt,
       sevenDayResetAt,
+      sevenDaySonnet,
+      sevenDaySonnetResetAt,
+      sevenDayOpus,
+      sevenDayOpusResetAt,
+      extraUsage,
     };
 
     // Write to file cache
@@ -387,55 +429,128 @@ function parseDate(dateStr: string | undefined): Date | null {
   return date;
 }
 
+function getProxyUrl(): string | null {
+  return process.env.https_proxy ||
+    process.env.HTTPS_PROXY ||
+    process.env.http_proxy ||
+    process.env.HTTP_PROXY ||
+    null;
+}
+
+function handleResponse(resolve: (value: UsageApiResult) => void): (res: http.IncomingMessage) => void {
+  return (res) => {
+    let data = '';
+    res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+    res.on('end', () => {
+      if (res.statusCode !== 200) {
+        debug('API returned non-200 status:', res.statusCode);
+        resolve({ data: null, error: res.statusCode ? `http-${res.statusCode}` : 'http-error' });
+        return;
+      }
+      try {
+        const parsed: UsageApiResponse = JSON.parse(data);
+        resolve({ data: parsed });
+      } catch (error) {
+        debug('Failed to parse API response:', error);
+        resolve({ data: null, error: 'parse' });
+      }
+    });
+  };
+}
+
 function fetchUsageApi(accessToken: string): Promise<UsageApiResult> {
   return new Promise((resolve) => {
-    const options = {
-      hostname: 'api.anthropic.com',
-      path: '/api/oauth/usage',
-      method: 'GET',
-      headers: {
-        'Authorization': `Bearer ${accessToken}`,
-        'anthropic-beta': 'oauth-2025-04-20',
-        'User-Agent': 'claude-hud/1.0',
-      },
-      timeout: 5000,
+    const proxyUrl = getProxyUrl();
+    const targetHost = 'api.anthropic.com';
+    const targetPath = '/api/oauth/usage';
+    const requestHeaders = {
+      'Authorization': `Bearer ${accessToken}`,
+      'anthropic-beta': 'oauth-2025-04-20',
+      'User-Agent': 'claude-hud/1.0',
+      'Host': targetHost,
     };
 
-    const req = https.request(options, (res) => {
-      let data = '';
+    if (proxyUrl) {
+      debug('Using proxy:', proxyUrl);
+      const proxy = new url.URL(proxyUrl);
 
-      res.on('data', (chunk: Buffer) => {
-        data += chunk.toString();
+      const proxyReq = http.request({
+        hostname: proxy.hostname,
+        port: proxy.port || 80,
+        method: 'CONNECT',
+        path: `${targetHost}:443`,
+        timeout: 5000,
       });
 
-      res.on('end', () => {
+      proxyReq.on('connect', (res, socket) => {
         if (res.statusCode !== 200) {
-          debug('API returned non-200 status:', res.statusCode);
-          resolve({ data: null, error: res.statusCode ? `http-${res.statusCode}` : 'http-error' });
+          debug('Proxy CONNECT failed:', res.statusCode);
+          socket.destroy();
+          resolve({ data: null, error: 'proxy' });
           return;
         }
 
-        try {
-          const parsed: UsageApiResponse = JSON.parse(data);
-          resolve({ data: parsed });
-        } catch (error) {
-          debug('Failed to parse API response:', error);
-          resolve({ data: null, error: 'parse' });
-        }
+        const tlsSocket = tls.connect({
+          socket: socket,
+          servername: targetHost,
+        }, () => {
+          const httpsReq = https.request({
+            hostname: targetHost,
+            path: targetPath,
+            method: 'GET',
+            headers: requestHeaders,
+            timeout: 5000,
+            createConnection: () => tlsSocket,
+          }, handleResponse(resolve));
+
+          httpsReq.on('error', (error) => {
+            debug('HTTPS request error:', error);
+            resolve({ data: null, error: 'network' });
+          });
+          httpsReq.on('timeout', () => {
+            debug('HTTPS request timeout');
+            httpsReq.destroy();
+            resolve({ data: null, error: 'timeout' });
+          });
+          httpsReq.end();
+        });
+
+        tlsSocket.on('error', (error) => {
+          debug('TLS socket error:', error);
+          resolve({ data: null, error: 'network' });
+        });
       });
-    });
 
-    req.on('error', (error) => {
-      debug('API request error:', error);
-      resolve({ data: null, error: 'network' });
-    });
-    req.on('timeout', () => {
-      debug('API request timeout');
-      req.destroy();
-      resolve({ data: null, error: 'timeout' });
-    });
+      proxyReq.on('error', (error) => {
+        debug('Proxy request error:', error);
+        resolve({ data: null, error: 'network' });
+      });
+      proxyReq.on('timeout', () => {
+        debug('Proxy request timeout');
+        proxyReq.destroy();
+        resolve({ data: null, error: 'timeout' });
+      });
+      proxyReq.end();
+    } else {
+      const req = https.request({
+        hostname: targetHost,
+        path: targetPath,
+        method: 'GET',
+        headers: requestHeaders,
+        timeout: 5000,
+      }, handleResponse(resolve));
 
-    req.end();
+      req.on('error', (error) => {
+        debug('API request error:', error);
+        resolve({ data: null, error: 'network' });
+      });
+      req.on('timeout', () => {
+        debug('API request timeout');
+        req.destroy();
+        resolve({ data: null, error: 'timeout' });
+      });
+      req.end();
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

- Add HTTP CONNECT tunnel support so the Usage API works behind corporate/SOCKS proxies (reads `https_proxy`/`HTTPS_PROXY`/`http_proxy`/`HTTP_PROXY`)
- Parse model-specific 7-day usage (`seven_day_sonnet`, `seven_day_opus`) from the API response
- Parse and display Extra Usage credits (`extra_usage`) with utilization bar
- Extend `formatResetTime` to show days for 7-day reset windows (e.g. `3d 5h`)

## Motivation

Many enterprise and regional environments require HTTP proxies. The existing `fetchUsageApi` used `https.request` directly, which doesn't support proxies. This PR adds a standard HTTP CONNECT tunnel that establishes a TLS connection through the proxy.

The extended usage fields (`seven_day_sonnet`, `seven_day_opus`, `extra_usage`) are already returned by the Anthropic API but were not being parsed or displayed.

## Changes

| File | Change |
|------|--------|
| `src/usage-api.ts` | Proxy detection from env vars, HTTP CONNECT tunnel with TLS, parse sonnet/opus/extra_usage fields, reconvert new Date fields from cache |
| `src/types.ts` | Add `ExtraUsageData` interface, extend `UsageData` with model-specific and extra usage fields |
| `src/render/lines/usage.ts` | Display Extra Usage bar/percent in expanded layout, `formatResetTime` supports days |
| `src/render/session-line.ts` | Display Extra Usage bar/percent in compact layout, `formatResetTime` supports days |

## Test plan

- [ ] Set `https_proxy` env var and verify Usage API calls succeed through the proxy
- [ ] Unset proxy env vars and verify direct HTTPS calls still work
- [ ] Verify Extra Usage displays correctly when `extra_usage.is_enabled` is true
- [ ] Verify `formatResetTime` shows `3d 5h` format for multi-day resets
- [ ] `npm run build` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)