### PR TITLE
fix(stdin): normalize Bedrock model IDs to human-readable labels

### DIFF
--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -94,6 +94,10 @@ const BEDROCK_MODEL_LABEL_BY_ID: Record<string, string> = {
   'anthropic.claude-haiku-4-5-20251001-v1:0': 'Haiku 4.5',
   'anthropic.claude-3-5-haiku-20241022-v1:0': 'Haiku 3.5',
   'anthropic.claude-3-haiku-20240307-v1:0': 'Haiku 3',
+  'anthropic.claude-3-5-sonnet-20240620-v1:0': 'Sonnet 3.5',
+  'anthropic.claude-3-5-sonnet-20241022-v2:0': 'Sonnet 3.5',
+  'anthropic.claude-3-opus-20240229-v1:0': 'Opus 3',
+  'anthropic.claude-3-sonnet-20240229-v1:0': 'Sonnet 3',
 };
 
 function canonicalizeBedrockId(modelId: string): string | null {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -313,6 +313,34 @@ test('getModelName normalizes documented haiku 3 id', () => {
   );
 });
 
+test('getModelName normalizes documented sonnet 3.5 v1 id', () => {
+  assert.equal(
+    getModelName({ model: { id: 'anthropic.claude-3-5-sonnet-20240620-v1:0' } }),
+    'Sonnet 3.5'
+  );
+});
+
+test('getModelName normalizes documented sonnet 3.5 v2 id', () => {
+  assert.equal(
+    getModelName({ model: { id: 'anthropic.claude-3-5-sonnet-20241022-v2:0' } }),
+    'Sonnet 3.5'
+  );
+});
+
+test('getModelName normalizes documented opus 3 id', () => {
+  assert.equal(
+    getModelName({ model: { id: 'anthropic.claude-3-opus-20240229-v1:0' } }),
+    'Opus 3'
+  );
+});
+
+test('getModelName normalizes documented sonnet 3 id', () => {
+  assert.equal(
+    getModelName({ model: { id: 'anthropic.claude-3-sonnet-20240229-v1:0' } }),
+    'Sonnet 3'
+  );
+});
+
 test('getModelName normalizes opus 4.6 compatibility alias', () => {
   assert.equal(
     getModelName({ model: { id: 'anthropic.claude-opus-4-6-v1:0' } }),


### PR DESCRIPTION
## Quality Declaration

This change set was implemented atomically in small, focused commits with test-first validation per step. Each behavior change was introduced with explicit tests and verified with targeted red/green runs to maintain quality and reduce regression risk.

## Summary

This PR fixes Bedrock model labeling when `model.display_name` is missing by normalizing known Bedrock model IDs to readable names instead of showing raw IDs.

Key updates:
- Hardens `getModelName` fallback behavior:
  - trims `display_name` / `id`
  - handles blank/non-string values safely
- Adds Bedrock ID normalization path in `src/stdin.ts`:
  - documented prefix handling
  - case-insensitive canonicalization
  - exact ID -> label map
- Expands exact map coverage to include currently documented IDs used in Bedrock inference profiles, including:
  - `anthropic.claude-3-5-sonnet-20240620-v1:0`
  - `anthropic.claude-3-5-sonnet-20241022-v2:0`
  - `anthropic.claude-3-opus-20240229-v1:0`
  - `anthropic.claude-3-sonnet-20240229-v1:0`
- Adds compatibility alias mapping:
  - `anthropic.claude-opus-4-6-v1:0`
- Adds comprehensive `tests/core.test.js` coverage for:
  - all mapped IDs (including Haiku and Claude 3 family)
  - prefix handling and unknown-prefix passthrough
  - wrong date/version/family passthrough guards
  - `display_name` precedence
  - provider label guardrails

## Testing

- [ ] `npm test`
- [ ] `npm run test:coverage`
- [x] `npm run build && node --test tests/core.test.js`

`npm test` currently fails on an existing unrelated test in this repo:
- `tests/index.test.js`: `index entrypoint runs when executed directly`

## Checklist

- [x] Tests updated or not needed
- [ ] Docs updated if behavior changed
