### PR TITLE
fix: prevent double-counting CLAUDE.md when cwd is home directory

### DIFF
--- a/src/config-reader.ts
+++ b/src/config-reader.ts
@@ -187,17 +187,23 @@ export async function countConfigs(cwd?: string): Promise<ConfigCounts> {
     }
 
     // {cwd}/.claude/rules/*.md (recursive)
-    rulesCount += countRulesInDir(path.join(cwd, '.claude', 'rules'));
+    // Skip when cwd is home because it overlaps with user-scope ~/.claude/rules.
+    if (!isHome) {
+      rulesCount += countRulesInDir(path.join(cwd, '.claude', 'rules'));
+    }
 
     // {cwd}/.mcp.json (project MCP config) - tracked separately for disabled filtering
     const mcpJsonServers = getMcpServerNames(path.join(cwd, '.mcp.json'));
 
     // {cwd}/.claude/settings.json (project settings)
+    // Skip when cwd is home because it overlaps with user-scope ~/.claude/settings.json.
     const projectSettings = path.join(cwd, '.claude', 'settings.json');
-    for (const name of getMcpServerNames(projectSettings)) {
-      projectMcpServers.add(name);
+    if (!isHome) {
+      for (const name of getMcpServerNames(projectSettings)) {
+        projectMcpServers.add(name);
+      }
+      hooksCount += countHooksInFile(projectSettings);
     }
-    hooksCount += countHooksInFile(projectSettings);
 
     // {cwd}/.claude/settings.local.json (local project settings)
     const localSettings = path.join(cwd, '.claude', 'settings.local.json');

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -375,21 +375,33 @@ test('countConfigs honors project and global config locations', async () => {
   }
 });
 
-test('countConfigs avoids home cwd double-counting and keeps CLAUDE.local.md', async () => {
+test('countConfigs avoids home cwd double-counting across counters and keeps CLAUDE.local.md', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
   const originalHome = process.env.HOME;
   process.env.HOME = homeDir;
 
   try {
-    await mkdir(path.join(homeDir, '.claude'), { recursive: true });
+    await mkdir(path.join(homeDir, '.claude', 'rules'), { recursive: true });
     await writeFile(path.join(homeDir, '.claude', 'CLAUDE.md'), 'global', 'utf8');
     await writeFile(path.join(homeDir, '.claude', 'CLAUDE.local.md'), 'global-local', 'utf8');
+    await writeFile(path.join(homeDir, '.claude', 'rules', 'rule.md'), '# rule', 'utf8');
+    await writeFile(
+      path.join(homeDir, '.claude', 'settings.json'),
+      JSON.stringify({ mcpServers: { one: {} }, hooks: { onStart: {} } }),
+      'utf8'
+    );
 
     const exactCounts = await countConfigs(homeDir);
     assert.equal(exactCounts.claudeMdCount, 2);
+    assert.equal(exactCounts.rulesCount, 1);
+    assert.equal(exactCounts.mcpCount, 1);
+    assert.equal(exactCounts.hooksCount, 1);
 
     const trailingSlashCounts = await countConfigs(`${homeDir}${path.sep}`);
     assert.equal(trailingSlashCounts.claudeMdCount, 2);
+    assert.equal(trailingSlashCounts.rulesCount, 1);
+    assert.equal(trailingSlashCounts.mcpCount, 1);
+    assert.equal(trailingSlashCounts.hooksCount, 1);
   } finally {
     process.env.HOME = originalHome;
     await rm(homeDir, { recursive: true, force: true });


### PR DESCRIPTION
## Problem

When running Claude Code from the home directory (`~`), the HUD displays `2 CLAUDE.md` instead of `1 CLAUDE.md`.

This happens because `countConfigs()` in `config-reader.ts` checks both:
- **User scope**: `~/.claude/CLAUDE.md`
- **Project scope**: `{cwd}/.claude/CLAUDE.md`

When `cwd` is the home directory, both paths resolve to the same file, causing a double count.

## Fix

Skip the project scope `.claude/CLAUDE.md` and `.claude/CLAUDE.local.md` checks when `cwd === os.homedir()`, since those files are already counted in the user scope.

## Testing

- Build passes (`npm run build`)
- When cwd is home: shows `1 CLAUDE.md` (was `2 CLAUDE.md`)
- When cwd is a project dir: behavior unchanged