### PR TITLE
fix: handle object layout values in migrateConfig()

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -89,19 +89,28 @@ function validateContextValue(value: unknown): value is ContextValueMode {
 }
 
 interface LegacyConfig {
-  layout?: 'default' | 'separators';
+  layout?: 'default' | 'separators' | Record<string, unknown>;
 }
 
 function migrateConfig(userConfig: Partial<HudConfig> & LegacyConfig): Partial<HudConfig> {
   const migrated = { ...userConfig } as Partial<HudConfig> & LegacyConfig;
 
   if ('layout' in userConfig && !('lineLayout' in userConfig)) {
-    if (userConfig.layout === 'separators') {
-      migrated.lineLayout = 'compact';
-      migrated.showSeparators = true;
-    } else {
-      migrated.lineLayout = 'compact';
-      migrated.showSeparators = false;
+    if (typeof userConfig.layout === 'string') {
+      // Legacy string migration (v0.0.x → v0.1.x)
+      if (userConfig.layout === 'separators') {
+        migrated.lineLayout = 'compact';
+        migrated.showSeparators = true;
+      } else {
+        migrated.lineLayout = 'compact';
+        migrated.showSeparators = false;
+      }
+    } else if (typeof userConfig.layout === 'object' && userConfig.layout !== null) {
+      // Object layout written by third-party tools — extract nested fields
+      const obj = userConfig.layout as Record<string, unknown>;
+      if (typeof obj.lineLayout === 'string') migrated.lineLayout = obj.lineLayout as any;
+      if (typeof obj.showSeparators === 'boolean') migrated.showSeparators = obj.showSeparators;
+      if (typeof obj.pathLevels === 'number') migrated.pathLevels = obj.pathLevels as any;
     }
     delete migrated.layout;
   }
@@ -114,7 +123,7 @@ function validateThreshold(value: unknown, max = 100): number {
   return Math.max(0, Math.min(max, value));
 }
 
-function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
+export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
   const migrated = migrateConfig(userConfig);
 
   const lineLayout = validateLineLayout(migrated.lineLayout)

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { loadConfig, getConfigPath } from '../dist/config.js';
+import { loadConfig, getConfigPath, mergeConfig, DEFAULT_CONFIG } from '../dist/config.js';
 import * as path from 'node:path';
 import * as os from 'node:os';
 
@@ -42,4 +42,48 @@ test('getConfigPath returns correct path', () => {
   const configPath = getConfigPath();
   const homeDir = os.homedir();
   assert.equal(configPath, path.join(homeDir, '.claude', 'plugins', 'claude-hud', 'config.json'));
+});
+
+// --- migrateConfig tests (via mergeConfig) ---
+
+test('migrate legacy layout: "default" -> compact, no separators', () => {
+  const config = mergeConfig({ layout: 'default' });
+  assert.equal(config.lineLayout, 'compact');
+  assert.equal(config.showSeparators, false);
+});
+
+test('migrate legacy layout: "separators" -> compact, with separators', () => {
+  const config = mergeConfig({ layout: 'separators' });
+  assert.equal(config.lineLayout, 'compact');
+  assert.equal(config.showSeparators, true);
+});
+
+test('migrate object layout: extracts nested fields to top level', () => {
+  const config = mergeConfig({
+    layout: { lineLayout: 'expanded', showSeparators: true, pathLevels: 2 },
+  });
+  assert.equal(config.lineLayout, 'expanded');
+  assert.equal(config.showSeparators, true);
+  assert.equal(config.pathLevels, 2);
+});
+
+test('migrate object layout: empty object does not crash', () => {
+  const config = mergeConfig({ layout: {} });
+  // Should fall back to defaults since no fields were extracted
+  assert.equal(config.lineLayout, DEFAULT_CONFIG.lineLayout);
+  assert.equal(config.showSeparators, DEFAULT_CONFIG.showSeparators);
+  assert.equal(config.pathLevels, DEFAULT_CONFIG.pathLevels);
+});
+
+test('no layout key -> no migration, uses defaults', () => {
+  const config = mergeConfig({});
+  assert.equal(config.lineLayout, DEFAULT_CONFIG.lineLayout);
+  assert.equal(config.showSeparators, DEFAULT_CONFIG.showSeparators);
+});
+
+test('both layout and lineLayout present -> layout ignored', () => {
+  const config = mergeConfig({ layout: 'separators', lineLayout: 'expanded' });
+  // When lineLayout is already present, migration should not run
+  assert.equal(config.lineLayout, 'expanded');
+  assert.equal(config.showSeparators, DEFAULT_CONFIG.showSeparators);
 });


### PR DESCRIPTION
## Problem

`migrateConfig()` checks `'layout' in userConfig` to detect the deprecated
legacy format, but doesn't verify `typeof layout === 'string'`. When a
third-party config editor writes `layout` as an object:

```json
{ "layout": { "lineLayout": "expanded", "showSeparators": true, "pathLevels": 2 } }
```

The migration incorrectly matches, overwrites with `lineLayout: "compact"`,
and deletes the user's settings.

## Fix

- Add `typeof` guard: only run legacy string migration when `layout` is a string
- When `layout` is an object, extract nested `lineLayout`, `showSeparators`,
  `pathLevels` to top level (graceful migration)
- Widen `LegacyConfig` type to accept `Record<string, unknown>`
- Export `mergeConfig` for direct testing of migration paths
- Add test cases for all migration scenarios

## Testing

- Legacy `layout: "default"` → migrates to compact (unchanged behavior)
- Legacy `layout: "separators"` → migrates to compact + separators (unchanged)
- Object `layout: { lineLayout: "expanded" }` → extracts to top level (new)
- Empty object `layout: {}` → falls back to defaults, no crash (new)
- No `layout` key → no migration (unchanged)
- Both `layout` and `lineLayout` present → `layout` ignored (unchanged)

All 164 tests pass (1 skipped — Windows-only path test).