### PR TITLE
feat(config): add remaining contextValue display mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You can also edit the config file directly at `~/.claude/plugins/claude-hud/conf
 | `gitStatus.showFileStats` | boolean | false | Show file change counts `!M +A ✘D ?U` |
 | `display.showModel` | boolean | true | Show model name `[Opus]` |
 | `display.showContextBar` | boolean | true | Show visual context bar `████░░░░░░` |
-| `display.contextValue` | `percent` \| `tokens` | `percent` | Context display format (`45%` or `45k/200k`) |
+| `display.contextValue` | `percent` \| `tokens` \| `remaining` | `percent` | Context display format (`45%`, `45k/200k`, or `55%` remaining) |
 | `display.showConfigCounts` | boolean | false | Show CLAUDE.md, rules, MCPs, hooks counts |
 | `display.showDuration` | boolean | false | Show session duration `⏱️ 5m` |
 | `display.showSpeed` | boolean | false | Show output token speed `out: 42.1 tok/s` |

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import * as os from 'node:os';
 export type LineLayoutType = 'compact' | 'expanded';
 
 export type AutocompactBufferMode = 'enabled' | 'disabled';
-export type ContextValueMode = 'percent' | 'tokens';
+export type ContextValueMode = 'percent' | 'tokens' | 'remaining';
 
 export interface HudConfig {
   lineLayout: LineLayoutType;
@@ -85,7 +85,7 @@ function validateAutocompactBuffer(value: unknown): value is AutocompactBufferMo
 }
 
 function validateContextValue(value: unknown): value is ContextValueMode {
-  return value === 'percent' || value === 'tokens';
+  return value === 'percent' || value === 'tokens' || value === 'remaining';
 }
 
 interface LegacyConfig {

--- a/src/render/lines/identity.ts
+++ b/src/render/lines/identity.ts
@@ -45,7 +45,7 @@ function formatTokens(n: number): string {
   return n.toString();
 }
 
-function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent' | 'tokens'): string {
+function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent' | 'tokens' | 'remaining'): string {
   if (mode === 'tokens') {
     const totalTokens = getTotalTokens(ctx.stdin);
     const size = ctx.stdin.context_window?.context_window_size ?? 0;
@@ -53,6 +53,10 @@ function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent'
       return `${formatTokens(totalTokens)}/${formatTokens(size)}`;
     }
     return formatTokens(totalTokens);
+  }
+
+  if (mode === 'remaining') {
+    return `${Math.max(0, 100 - percent)}%`;
   }
 
   return `${percent}%`;

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -216,7 +216,7 @@ function formatTokens(n: number): string {
   return n.toString();
 }
 
-function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent' | 'tokens'): string {
+function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent' | 'tokens' | 'remaining'): string {
   if (mode === 'tokens') {
     const totalTokens = getTotalTokens(ctx.stdin);
     const size = ctx.stdin.context_window?.context_window_size ?? 0;
@@ -224,6 +224,10 @@ function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent'
       return `${formatTokens(totalTokens)}/${formatTokens(size)}`;
     }
     return formatTokens(totalTokens);
+  }
+
+  if (mode === 'remaining') {
+    return `${Math.max(0, 100 - percent)}%`;
   }
 
   return `${percent}%`;

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -27,7 +27,7 @@ test('loadConfig returns valid config structure', async () => {
   assert.equal(typeof config.display, 'object');
   assert.equal(typeof config.display.showModel, 'boolean');
   assert.equal(typeof config.display.showContextBar, 'boolean');
-  assert.ok(['percent', 'tokens'].includes(config.display.contextValue), 'contextValue should be valid');
+  assert.ok(['percent', 'tokens', 'remaining'].includes(config.display.contextValue), 'contextValue should be valid');
   assert.equal(typeof config.display.showConfigCounts, 'boolean');
   assert.equal(typeof config.display.showDuration, 'boolean');
   assert.equal(typeof config.display.showSpeed, 'boolean');
@@ -86,4 +86,22 @@ test('both layout and lineLayout present -> layout ignored', () => {
   // When lineLayout is already present, migration should not run
   assert.equal(config.lineLayout, 'expanded');
   assert.equal(config.showSeparators, DEFAULT_CONFIG.showSeparators);
+});
+
+test('mergeConfig accepts contextValue=remaining', () => {
+  const config = mergeConfig({
+    display: {
+      contextValue: 'remaining',
+    },
+  });
+  assert.equal(config.display.contextValue, 'remaining');
+});
+
+test('mergeConfig falls back to default for invalid contextValue', () => {
+  const config = mergeConfig({
+    display: {
+      contextValue: 'invalid-mode',
+    },
+  });
+  assert.equal(config.display.contextValue, DEFAULT_CONFIG.display.contextValue);
 });

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -135,6 +135,34 @@ test('renderSessionLine supports token-based context display', () => {
   assert.ok(line.includes('12k/200k'), 'should include token counts');
 });
 
+test('renderSessionLine supports remaining-based context display', () => {
+  const ctx = baseContext();
+  ctx.config.display.contextValue = 'remaining';
+  ctx.stdin.context_window.context_window_size = 200000;
+  ctx.stdin.context_window.current_usage.input_tokens = 12345;
+  const line = renderSessionLine(ctx);
+  assert.ok(line.includes('71%'), 'should include remaining percentage');
+});
+
+test('render expanded layout supports remaining-based context display', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.config.display.contextValue = 'remaining';
+  ctx.stdin.context_window.context_window_size = 200000;
+  ctx.stdin.context_window.current_usage.input_tokens = 12345;
+
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (line) => logs.push(line);
+  try {
+    render(ctx);
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.ok(logs.some(line => line.includes('Context') && line.includes('71%')), 'expected remaining percentage on context line');
+});
+
 test('renderSessionLine omits project name when cwd is undefined', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = undefined;


### PR DESCRIPTION
## Summary
- add `display.contextValue: "remaining"` as a valid config mode
- render remaining context as `100 - usedPercent` in both compact and expanded layouts
- update docs and tests for the new mode

## Validation
- npm test

Closes #118