### PR TITLE
fix: prefer subscription label over API env var in status bar

### DIFF
--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -9,9 +9,10 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   if (display?.showModel !== false) {
     const model = getModelName(ctx.stdin);
     const providerLabel = getProviderLabel(ctx.stdin);
-    const planName = display?.showUsage !== false ? ctx.usageData?.planName : undefined;
+    const showUsage = display?.showUsage !== false;
+    const planName = showUsage ? ctx.usageData?.planName : undefined;
     const hasApiKey = !!process.env.ANTHROPIC_API_KEY;
-    const billingLabel = hasApiKey ? red('API') : planName;
+    const billingLabel = showUsage ? (planName ?? (hasApiKey ? red('API') : undefined)) : undefined;
     const planDisplay = providerLabel ?? billingLabel;
     const modelDisplay = planDisplay ? `${model} | ${planDisplay}` : model;
     parts.push(cyan(`[${modelDisplay}]`));

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -33,9 +33,10 @@ export function renderSessionLine(ctx: RenderContext): string {
   // Model and context bar (FIRST)
   // Plan name only shows if showUsage is enabled (respects hybrid toggle)
   const providerLabel = getProviderLabel(ctx.stdin);
-  const planName = display?.showUsage !== false ? ctx.usageData?.planName : undefined;
+  const showUsage = display?.showUsage !== false;
+  const planName = showUsage ? ctx.usageData?.planName : undefined;
   const hasApiKey = !!process.env.ANTHROPIC_API_KEY;
-  const billingLabel = hasApiKey ? red('API') : planName;
+  const billingLabel = showUsage ? (planName ?? (hasApiKey ? red('API') : undefined)) : undefined;
   const planDisplay = providerLabel ?? billingLabel;
   const modelDisplay = planDisplay ? `${model} | ${planDisplay}` : model;
 

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -418,6 +418,56 @@ test('renderSessionLine displays plan name in model bracket', () => {
   assert.ok(line.includes('Max'), 'should include plan name');
 });
 
+test('renderSessionLine prefers subscription plan over API env var', () => {
+  const ctx = baseContext();
+  ctx.usageData = {
+    planName: 'Max',
+    fiveHour: 23,
+    sevenDay: 45,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+  };
+  const savedApiKey = process.env.ANTHROPIC_API_KEY;
+  process.env.ANTHROPIC_API_KEY = 'test-key';
+
+  try {
+    const line = renderSessionLine(ctx);
+    assert.ok(line.includes('Max'), 'should include plan label');
+    assert.ok(!line.includes('API'), 'should not include API label when plan is known');
+  } finally {
+    if (savedApiKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = savedApiKey;
+    }
+  }
+});
+
+test('renderProjectLine prefers subscription plan over API env var', () => {
+  const ctx = baseContext();
+  ctx.usageData = {
+    planName: 'Pro',
+    fiveHour: 10,
+    sevenDay: 20,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+  };
+  const savedApiKey = process.env.ANTHROPIC_API_KEY;
+  process.env.ANTHROPIC_API_KEY = 'test-key';
+
+  try {
+    const line = renderProjectLine(ctx);
+    assert.ok(line?.includes('Pro'), 'should include plan label');
+    assert.ok(!line?.includes('API'), 'should not include API label when plan is known');
+  } finally {
+    if (savedApiKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = savedApiKey;
+    }
+  }
+});
+
 test('renderSessionLine shows Bedrock label and hides usage for bedrock model ids', () => {
   const ctx = baseContext();
   ctx.stdin.model = { display_name: 'Sonnet', id: 'anthropic.claude-3-5-sonnet-20240620-v1:0' };


### PR DESCRIPTION
## Summary
- fix auth label precedence so subscription plans (Max/Pro/Team) are shown when known
- keep `API` as a fallback only when no subscription plan is available
- apply the fix in both compact and expanded render paths
- add regression tests for both render paths when `ANTHROPIC_API_KEY` is set

## Why
Issue #156 reports users logged in with Claude subscription still seeing `API` in the status bar when `ANTHROPIC_API_KEY` is present in shell env.

## Testing
- `npm run build && node --test tests/render.test.js`
- `npm test` currently fails only on existing `tests/integration.test.js` in this environment

Closes #156
