### PR TITLE
fix: prevent HUD rows disappearing in narrow terminals

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -185,12 +185,11 @@ function truncateToWidth(str: string, maxWidth: number): string {
   return `${sliceVisible(str, keep)}${suffix}${RESET}`;
 }
 
-function splitWrapParts(line: string): Array<{ separator: string; segment: string }> {
+function splitLineBySeparators(line: string): { segments: string[]; separators: string[] } {
   const segments: string[] = [];
   const separators: string[] = [];
   let currentStart = 0;
   let i = 0;
-  let bracketDepth = 0;
 
   while (i < line.length) {
     const ansiMatch = ANSI_ESCAPE_PATTERN.exec(line.slice(i));
@@ -199,23 +198,11 @@ function splitWrapParts(line: string): Array<{ separator: string; segment: strin
       continue;
     }
 
-    const char = line[i];
-    if (char === '[') {
-      bracketDepth += 1;
-      i += 1;
-      continue;
-    }
-    if (char === ']') {
-      bracketDepth = Math.max(0, bracketDepth - 1);
-      i += 1;
-      continue;
-    }
-
     const separator = line.startsWith(' | ', i)
       ? ' | '
       : (line.startsWith(' │ ', i) ? ' │ ' : null);
 
-    if (separator && bracketDepth === 0) {
+    if (separator) {
       segments.push(line.slice(currentStart, i));
       separators.push(separator);
       i += separator.length;
@@ -227,11 +214,16 @@ function splitWrapParts(line: string): Array<{ separator: string; segment: strin
   }
 
   segments.push(line.slice(currentStart));
+  return { segments, separators };
+}
+
+function splitWrapParts(line: string): Array<{ separator: string; segment: string }> {
+  const { segments, separators } = splitLineBySeparators(line);
   if (segments.length === 0) {
     return [];
   }
 
-  const parts: Array<{ separator: string; segment: string }> = [{
+  let parts: Array<{ separator: string; segment: string }> = [{
     separator: '',
     segment: segments[0],
   }];
@@ -240,6 +232,29 @@ function splitWrapParts(line: string): Array<{ separator: string; segment: strin
       separator: separators[segmentIndex - 1] ?? ' | ',
       segment: segments[segmentIndex],
     });
+  }
+
+  // Keep the leading [model | provider] block together.
+  // This avoids splitting inside the model badge while still splitting
+  // separators elsewhere in the line.
+  const firstVisible = stripAnsi(parts[0].segment).trimStart();
+  const firstHasOpeningBracket = firstVisible.startsWith('[');
+  const firstHasClosingBracket = stripAnsi(parts[0].segment).includes(']');
+  if (firstHasOpeningBracket && !firstHasClosingBracket && parts.length > 1) {
+    let mergedSegment = parts[0].segment;
+    let consumeIndex = 1;
+    while (consumeIndex < parts.length) {
+      const nextPart = parts[consumeIndex];
+      mergedSegment += `${nextPart.separator}${nextPart.segment}`;
+      consumeIndex += 1;
+      if (stripAnsi(nextPart.segment).includes(']')) {
+        break;
+      }
+    }
+    parts = [
+      { separator: '', segment: mergedSegment },
+      ...parts.slice(consumeIndex),
+    ];
   }
 
   return parts;
@@ -364,9 +379,10 @@ export function render(ctx: RenderContext): void {
 
   lines.push(...activityLines);
 
+  const physicalLines = lines.flatMap(line => line.split('\n'));
   const visibleLines = terminalWidth
-    ? lines.flatMap(line => wrapLineToWidth(line, terminalWidth))
-    : lines;
+    ? physicalLines.flatMap(line => wrapLineToWidth(line, terminalWidth))
+    : physicalLines;
 
   for (const line of visibleLines) {
     const outputLine = `${RESET}${line.replace(/ /g, '\u00A0')}`;

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -108,7 +108,11 @@ function captureRender(ctx) {
   return logs.map(line => stripAnsi(line).replace(/\u00A0/g, ' '));
 }
 
-test('render wraps long lines to terminal width and keeps activity visible', () => {
+function countContaining(lines, needle) {
+  return lines.filter(line => line.includes(needle)).length;
+}
+
+test('render wraps long lines to terminal width and keeps all activity lines visible', () => {
   const ctx = baseContext();
   ctx.stdin.model = { display_name: 'Sonnet 4.6' };
   ctx.stdin.cwd = '/tmp/very-long-project-name-for-terminal-wrap-checking';
@@ -133,14 +137,26 @@ test('render wraps long lines to terminal width and keeps activity visible', () 
   ctx.transcript.tools = [
     { id: 'tool-1', name: 'Read', status: 'completed', startTime: new Date(0), endTime: new Date(0), duration: 0 },
   ];
+  ctx.transcript.agents = [
+    { id: 'agent-1', type: 'plan-a', status: 'running', startTime: new Date(0) },
+    { id: 'agent-2', type: 'plan-b', status: 'completed', startTime: new Date(0), endTime: new Date(3000) },
+    { id: 'agent-3', type: 'plan-c', status: 'completed', startTime: new Date(0), endTime: new Date(3500) },
+  ];
+  ctx.transcript.todos = [
+    { content: 'todo-marker', status: 'in_progress' },
+  ];
 
   let lines = [];
-  withTerminal(50, () => {
+  withTerminal(20, () => {
     lines = captureRender(ctx);
   });
 
-  assert.ok(lines.some(line => line.includes('Read')), 'should keep activity line visible');
-  assert.ok(lines.every(line => displayWidth(line) <= 50), 'all lines should fit terminal width');
+  assert.equal(countContaining(lines, 'Read'), 1, 'tool line should remain visible');
+  assert.equal(countContaining(lines, 'plan-a'), 1, 'first agent line should remain visible');
+  assert.equal(countContaining(lines, 'plan-b'), 1, 'second agent line should remain visible');
+  assert.equal(countContaining(lines, 'plan-c'), 1, 'third agent line should remain visible');
+  assert.equal(countContaining(lines, 'todo-marker'), 1, 'todo line should remain visible');
+  assert.ok(lines.every(line => displayWidth(line) <= 20), 'all lines should fit terminal width');
 });
 
 test('render falls back to COLUMNS env when stdout.columns is unavailable', () => {
@@ -167,6 +183,27 @@ test('render falls back to COLUMNS env when stdout.columns is unavailable', () =
   assert.ok(lines.every(line => displayWidth(line) <= 10), 'all lines should fit COLUMNS width');
 });
 
+test('render prefers stdout columns over COLUMNS env fallback', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/very-long-project-name-for-width-checking';
+  const originalEnvColumns = process.env.COLUMNS;
+  process.env.COLUMNS = '10';
+
+  let lines = [];
+  withTerminal(30, () => {
+    lines = captureRender(ctx);
+  });
+
+  if (originalEnvColumns === undefined) {
+    delete process.env.COLUMNS;
+  } else {
+    process.env.COLUMNS = originalEnvColumns;
+  }
+
+  assert.ok(lines.every(line => displayWidth(line) <= 30), 'stdout width should be honored');
+  assert.ok(lines.some(line => displayWidth(line) > 10), 'stdout width should override COLUMNS fallback');
+});
+
 test('render does not split model/provider separator inside brackets', () => {
   const ctx = baseContext();
   ctx.stdin.model = { display_name: 'Sonnet', id: 'anthropic.claude-3-5-sonnet-20240620-v1:0' };
@@ -175,6 +212,13 @@ test('render does not split model/provider separator inside brackets', () => {
   ctx.config.display.showConfigCounts = false;
   ctx.config.display.showDuration = false;
 
+  let wideLines = [];
+  withTerminal(80, () => {
+    wideLines = captureRender(ctx);
+  });
+
+  assert.ok(wideLines.some(line => line.includes('[Sonnet | Bedrock]')), 'model/provider badge should be preserved when width allows');
+
   let lines = [];
   withTerminal(12, () => {
     lines = captureRender(ctx);
@@ -182,6 +226,23 @@ test('render does not split model/provider separator inside brackets', () => {
 
   assert.equal(lines.length, 1, 'single compact line should be truncated, not split');
   assert.ok(!lines[0].startsWith('Bedrock]'), 'provider label should not become a wrapped prefix');
+});
+
+test('render clamps separator width in narrow terminals', () => {
+  const ctx = baseContext();
+  ctx.config.showSeparators = true;
+  ctx.transcript.tools = [
+    { id: 'tool-1', name: 'Read', status: 'completed', startTime: new Date(0), endTime: new Date(0), duration: 0 },
+  ];
+
+  let lines = [];
+  withTerminal(8, () => {
+    lines = captureRender(ctx);
+  });
+
+  const separatorLine = lines.find(line => line.includes('─'));
+  assert.ok(separatorLine, 'separator should render when enabled with activity');
+  assert.ok(displayWidth(separatorLine) <= 8, 'separator should fit terminal width');
 });
 
 test('render truncation respects Unicode display width', () => {


### PR DESCRIPTION
## Summary
- detect render width from `stdout.columns` with `COLUMNS` env fallback for non-TTY runs
- wrap long HUD lines at top-level separators and truncate safely when still too long
- make width calculations ANSI-aware and Unicode cell-width aware (CJK/emoji/graphemes)
- avoid splitting model/provider content inside `[...]` so labels do not break onto their own line
- add focused regression tests for narrow width behavior in `tests/render-width.test.js`

## Validation
- `npm run build`
- `node --test tests/render-width.test.js`

Closes #151