### PR TITLE
fix(render): stop replacing spaces with non-breaking spaces

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -385,7 +385,7 @@ export function render(ctx: RenderContext): void {
     : physicalLines;
 
   for (const line of visibleLines) {
-    const outputLine = `${RESET}${line.replace(/ /g, '\u00A0')}`;
+    const outputLine = `${RESET}${line}`;
     console.log(outputLine);
   }
 }

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -756,6 +756,23 @@ test('render omits separator when showSeparators is true but no activity', () =>
   assert.ok(!logs.some(l => l.includes('─')), 'should not include separator');
 });
 
+test('render preserves regular spaces instead of non-breaking spaces', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (line) => logs.push(line);
+  try {
+    render(ctx);
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.ok(logs.length > 0, 'should render at least one line');
+  assert.ok(logs.every(line => !line.includes('\u00A0')), 'output should not include non-breaking spaces');
+});
+
 // fileStats tests
 test('renderSessionLine displays file stats when showFileStats is true', () => {
   const ctx = baseContext();


### PR DESCRIPTION
## Summary
- Remove non-breaking-space substitution in `render()` output.
- Keep normal spaces in status line output to avoid renderer incompatibilities on startup.
- Add regression test to assert rendered output does not contain `\u00A0`.

## Validation
- `npm run build`
- `node --test tests/render.test.js`
- `npm test` (213 pass, 0 fail, 1 skip)

## Closes
- Closes #142