### PR TITLE
feat: add `elementOrder` config for custom HUD element ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ You can also edit the config file directly at `~/.claude/plugins/claude-hud/conf
 |--------|------|---------|-------------|
 | `lineLayout` | string | `expanded` | Layout: `expanded` (multi-line) or `compact` (single line) |
 | `pathLevels` | 1-3 | 1 | Directory levels to show in project path |
+| `elementOrder` | string[] | `["project","context","usage","environment","tools","agents","todos"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. |
 | `gitStatus.enabled` | boolean | true | Show git branch in HUD |
 | `gitStatus.showDirty` | boolean | true | Show `*` for uncommitted changes |
 | `gitStatus.showAheadBehind` | boolean | false | Show `↑N ↓N` for ahead/behind remote |
@@ -178,6 +179,7 @@ To disable, set `display.showUsage` to `false`.
 {
   "lineLayout": "expanded",
   "pathLevels": 2,
+  "elementOrder": ["project", "tools", "context", "usage", "environment", "agents", "todos"],
   "gitStatus": {
     "enabled": true,
     "showDirty": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,11 +7,25 @@ export type LineLayoutType = 'compact' | 'expanded';
 
 export type AutocompactBufferMode = 'enabled' | 'disabled';
 export type ContextValueMode = 'percent' | 'tokens' | 'remaining';
+export type HudElement = 'project' | 'context' | 'usage' | 'environment' | 'tools' | 'agents' | 'todos';
+
+export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
+  'project',
+  'context',
+  'usage',
+  'environment',
+  'tools',
+  'agents',
+  'todos',
+];
+
+const KNOWN_ELEMENTS = new Set<HudElement>(DEFAULT_ELEMENT_ORDER);
 
 export interface HudConfig {
   lineLayout: LineLayoutType;
   showSeparators: boolean;
   pathLevels: 1 | 2 | 3;
+  elementOrder: HudElement[];
   gitStatus: {
     enabled: boolean;
     showDirty: boolean;
@@ -44,6 +58,7 @@ export const DEFAULT_CONFIG: HudConfig = {
   lineLayout: 'expanded',
   showSeparators: false,
   pathLevels: 1,
+  elementOrder: [...DEFAULT_ELEMENT_ORDER],
   gitStatus: {
     enabled: true,
     showDirty: true,
@@ -91,6 +106,31 @@ function validateAutocompactBuffer(value: unknown): value is AutocompactBufferMo
 
 function validateContextValue(value: unknown): value is ContextValueMode {
   return value === 'percent' || value === 'tokens' || value === 'remaining';
+}
+
+function validateElementOrder(value: unknown): HudElement[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    return [...DEFAULT_ELEMENT_ORDER];
+  }
+
+  const seen = new Set<HudElement>();
+  const elementOrder: HudElement[] = [];
+
+  for (const item of value) {
+    if (typeof item !== 'string' || !KNOWN_ELEMENTS.has(item as HudElement)) {
+      continue;
+    }
+
+    const element = item as HudElement;
+    if (seen.has(element)) {
+      continue;
+    }
+
+    seen.add(element);
+    elementOrder.push(element);
+  }
+
+  return elementOrder.length > 0 ? elementOrder : [...DEFAULT_ELEMENT_ORDER];
 }
 
 interface LegacyConfig {
@@ -142,6 +182,8 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
   const pathLevels = validatePathLevels(migrated.pathLevels)
     ? migrated.pathLevels
     : DEFAULT_CONFIG.pathLevels;
+
+  const elementOrder = validateElementOrder(migrated.elementOrder);
 
   const gitStatus = {
     enabled: typeof migrated.gitStatus?.enabled === 'boolean'
@@ -209,7 +251,7 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     environmentThreshold: validateThreshold(migrated.display?.environmentThreshold, 100),
   };
 
-  return { lineLayout, showSeparators, pathLevels, gitStatus, display };
+  return { lineLayout, showSeparators, pathLevels, elementOrder, gitStatus, display };
 }
 
 export async function loadConfig(): Promise<HudConfig> {

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,3 +1,5 @@
+import type { HudElement } from '../config.js';
+import { DEFAULT_ELEMENT_ORDER } from '../config.js';
 import type { RenderContext } from '../types.js';
 import { renderSessionLine } from './session-line.js';
 import { renderToolsLine } from './tools-line.js';
@@ -295,6 +297,8 @@ function makeSeparator(length: number): string {
   return dim('─'.repeat(Math.max(length, 1)));
 }
 
+const ACTIVITY_ELEMENTS = new Set<HudElement>(['tools', 'agents', 'todos']);
+
 function collectActivityLines(ctx: RenderContext): string[] {
   const activityLines: string[] = [];
   const display = ctx.config?.display;
@@ -323,6 +327,27 @@ function collectActivityLines(ctx: RenderContext): string[] {
   return activityLines;
 }
 
+function renderElementLine(ctx: RenderContext, element: HudElement): string | null {
+  const display = ctx.config?.display;
+
+  switch (element) {
+    case 'project':
+      return renderProjectLine(ctx);
+    case 'context':
+      return renderIdentityLine(ctx);
+    case 'usage':
+      return renderUsageLine(ctx);
+    case 'environment':
+      return renderEnvironmentLine(ctx);
+    case 'tools':
+      return display?.showTools === false ? null : renderToolsLine(ctx);
+    case 'agents':
+      return display?.showAgents === false ? null : renderAgentsLine(ctx);
+    case 'todos':
+      return display?.showTodos === false ? null : renderTodosLine(ctx);
+  }
+}
+
 function renderCompact(ctx: RenderContext): string[] {
   const lines: string[] = [];
 
@@ -334,25 +359,50 @@ function renderCompact(ctx: RenderContext): string[] {
   return lines;
 }
 
-function renderExpanded(ctx: RenderContext): string[] {
-  const lines: string[] = [];
+function renderExpanded(ctx: RenderContext): Array<{ line: string; isActivity: boolean }> {
+  const elementOrder = ctx.config?.elementOrder ?? DEFAULT_ELEMENT_ORDER;
+  const seen = new Set<HudElement>();
+  const lines: Array<{ line: string; isActivity: boolean }> = [];
 
-  const projectLine = renderProjectLine(ctx);
-  if (projectLine) {
-    lines.push(projectLine);
-  }
+  for (let index = 0; index < elementOrder.length; index += 1) {
+    const element = elementOrder[index];
+    if (seen.has(element)) {
+      continue;
+    }
 
-  const identityLine = renderIdentityLine(ctx);
-  const usageLine = renderUsageLine(ctx);
-  if (identityLine && usageLine) {
-    lines.push(`${identityLine} \u2502 ${usageLine}`);
-  } else if (identityLine) {
-    lines.push(identityLine);
-  }
+    const nextElement = elementOrder[index + 1];
+    if (
+      (element === 'context' && nextElement === 'usage' && !seen.has('usage'))
+      || (element === 'usage' && nextElement === 'context' && !seen.has('context'))
+    ) {
+      seen.add(element);
+      seen.add(nextElement);
 
-  const environmentLine = renderEnvironmentLine(ctx);
-  if (environmentLine) {
-    lines.push(environmentLine);
+      const firstLine = renderElementLine(ctx, element);
+      const secondLine = renderElementLine(ctx, nextElement);
+
+      if (firstLine && secondLine) {
+        lines.push({ line: `${firstLine} │ ${secondLine}`, isActivity: false });
+      } else if (firstLine) {
+        lines.push({ line: firstLine, isActivity: false });
+      } else if (secondLine) {
+        lines.push({ line: secondLine, isActivity: false });
+      }
+
+      continue;
+    }
+
+    seen.add(element);
+
+    const line = renderElementLine(ctx, element);
+    if (!line) {
+      continue;
+    }
+
+    lines.push({
+      line,
+      isActivity: ACTIVITY_ELEMENTS.has(element),
+    });
   }
 
   return lines;
@@ -363,21 +413,40 @@ export function render(ctx: RenderContext): void {
   const showSeparators = ctx.config?.showSeparators ?? false;
   const terminalWidth = getTerminalWidth();
 
-  const headerLines = lineLayout === 'expanded'
-    ? renderExpanded(ctx)
-    : renderCompact(ctx);
+  let lines: string[];
 
-  const activityLines = collectActivityLines(ctx);
+  if (lineLayout === 'expanded') {
+    const renderedLines = renderExpanded(ctx);
+    lines = renderedLines.map(({ line }) => line);
 
-  const lines: string[] = [...headerLines];
+    if (showSeparators) {
+      const firstActivityIndex = renderedLines.findIndex(({ isActivity }) => isActivity);
+      if (firstActivityIndex > 0) {
+        const separatorBaseWidth = Math.max(
+          ...renderedLines
+            .slice(0, firstActivityIndex)
+            .map(({ line }) => visualLength(line)),
+          20
+        );
+        const separatorWidth = terminalWidth
+          ? Math.min(separatorBaseWidth, terminalWidth)
+          : separatorBaseWidth;
+        lines.splice(firstActivityIndex, 0, makeSeparator(separatorWidth));
+      }
+    }
+  } else {
+    const headerLines = renderCompact(ctx);
+    const activityLines = collectActivityLines(ctx);
+    lines = [...headerLines];
 
-  if (showSeparators && activityLines.length > 0) {
-    const maxWidth = Math.max(...headerLines.map(visualLength), 20);
-    const separatorWidth = terminalWidth ? Math.min(maxWidth, terminalWidth) : maxWidth;
-    lines.push(makeSeparator(separatorWidth));
+    if (showSeparators && activityLines.length > 0) {
+      const maxWidth = Math.max(...headerLines.map(visualLength), 20);
+      const separatorWidth = terminalWidth ? Math.min(maxWidth, terminalWidth) : maxWidth;
+      lines.push(makeSeparator(separatorWidth));
+    }
+
+    lines.push(...activityLines);
   }
-
-  lines.push(...activityLines);
 
   const physicalLines = lines.flatMap(line => line.split('\n'));
   const visibleLines = terminalWidth

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,6 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { loadConfig, getConfigPath, mergeConfig, DEFAULT_CONFIG } from '../dist/config.js';
+import {
+  loadConfig,
+  getConfigPath,
+  mergeConfig,
+  DEFAULT_CONFIG,
+  DEFAULT_ELEMENT_ORDER,
+} from '../dist/config.js';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
@@ -26,6 +32,9 @@ test('loadConfig returns valid config structure', async () => {
 
   // showSeparators must be boolean
   assert.equal(typeof config.showSeparators, 'boolean', 'showSeparators should be boolean');
+  assert.ok(Array.isArray(config.elementOrder), 'elementOrder should be an array');
+  assert.ok(config.elementOrder.length > 0, 'elementOrder should not be empty');
+  assert.deepEqual(config.elementOrder, DEFAULT_ELEMENT_ORDER, 'elementOrder should default to the full expanded layout');
 
   // gitStatus object with expected properties
   assert.equal(typeof config.gitStatus, 'object');
@@ -175,4 +184,39 @@ test('mergeConfig falls back to default for invalid contextValue', () => {
     },
   });
   assert.equal(config.display.contextValue, DEFAULT_CONFIG.display.contextValue);
+});
+
+test('mergeConfig defaults elementOrder to the full expanded layout', () => {
+  const config = mergeConfig({});
+  assert.deepEqual(config.elementOrder, DEFAULT_ELEMENT_ORDER);
+});
+
+test('mergeConfig preserves valid custom elementOrder including activity elements', () => {
+  const config = mergeConfig({
+    elementOrder: ['tools', 'project', 'usage', 'context', 'agents', 'todos', 'environment'],
+  });
+  assert.deepEqual(
+    config.elementOrder,
+    ['tools', 'project', 'usage', 'context', 'agents', 'todos', 'environment']
+  );
+});
+
+test('mergeConfig filters unknown entries and de-duplicates elementOrder', () => {
+  const config = mergeConfig({
+    elementOrder: ['project', 'agents', 'project', 'banana', 'usage', 'agents', 'context'],
+  });
+  assert.deepEqual(config.elementOrder, ['project', 'agents', 'usage', 'context']);
+});
+
+test('mergeConfig treats elementOrder as an explicit expanded-mode filter', () => {
+  const config = mergeConfig({
+    elementOrder: ['usage', 'project'],
+  });
+  assert.deepEqual(config.elementOrder, ['usage', 'project']);
+});
+
+test('mergeConfig falls back to default when elementOrder is empty or invalid', () => {
+  assert.deepEqual(mergeConfig({ elementOrder: [] }).elementOrder, DEFAULT_ELEMENT_ORDER);
+  assert.deepEqual(mergeConfig({ elementOrder: ['unknown'] }).elementOrder, DEFAULT_ELEMENT_ORDER);
+  assert.deepEqual(mergeConfig({ elementOrder: 'project' }).elementOrder, DEFAULT_ELEMENT_ORDER);
 });

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -39,10 +39,23 @@ function baseContext() {
       lineLayout: 'compact',
       showSeparators: false,
       pathLevels: 1,
+      elementOrder: ['project', 'context', 'usage', 'environment', 'tools', 'agents', 'todos'],
       gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false },
-      display: { showModel: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showTools: true, showAgents: true, showTodos: true, autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0 },
+      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showTools: true, showAgents: true, showTodos: true, showSessionName: false, autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0 },
     },
   };
+}
+
+function captureRenderLines(ctx) {
+  const logs = [];
+  const originalLog = console.log;
+  console.log = line => logs.push(stripAnsi(line));
+  try {
+    render(ctx);
+  } finally {
+    console.log = originalLog;
+  }
+  return logs;
 }
 
 test('renderSessionLine adds token breakdown when context is high', () => {
@@ -867,4 +880,142 @@ test('renderSessionLine combines showFileStats with showDirty and showAheadBehin
   assert.ok(line.includes('↓1'), 'expected behind count');
   assert.ok(line.includes('!3'), 'expected modified count');
   assert.ok(line.includes('✘1'), 'expected deleted count');
+});
+
+test('render expanded layout honors custom elementOrder including activity placement', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.usageData = {
+    planName: 'Team',
+    fiveHour: 30,
+    sevenDay: 10,
+    fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+    sevenDayResetAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+  };
+  ctx.claudeMdCount = 1;
+  ctx.rulesCount = 2;
+  ctx.transcript.tools = [
+    { id: 'tool-1', name: 'Read', status: 'completed', startTime: new Date(0), endTime: new Date(0), duration: 0 },
+  ];
+  ctx.transcript.agents = [
+    { id: 'agent-1', type: 'planner', status: 'running', startTime: new Date(0) },
+  ];
+  ctx.transcript.todos = [
+    { content: 'todo-marker', status: 'in_progress' },
+  ];
+  ctx.config.elementOrder = ['tools', 'project', 'usage', 'context', 'environment', 'agents', 'todos'];
+
+  const lines = captureRenderLines(ctx);
+  const toolIndex = lines.findIndex(line => line.includes('Read'));
+  const projectIndex = lines.findIndex(line => line.includes('my-project'));
+  const combinedIndex = lines.findIndex(line => line.includes('Usage') && line.includes('Context'));
+  const environmentIndex = lines.findIndex(line => line.includes('CLAUDE.md'));
+  const agentIndex = lines.findIndex(line => line.includes('planner'));
+  const todoIndex = lines.findIndex(line => line.includes('todo-marker'));
+
+  assert.deepEqual(
+    [toolIndex, projectIndex, combinedIndex, environmentIndex, agentIndex, todoIndex].every(index => index >= 0),
+    true,
+    'expected all configured elements to render'
+  );
+  assert.ok(toolIndex < projectIndex, 'tool line should move ahead of project');
+  assert.ok(projectIndex < combinedIndex, 'combined usage/context line should follow project');
+  assert.ok(combinedIndex < environmentIndex, 'environment line should follow context/usage');
+  assert.ok(environmentIndex < agentIndex, 'agent line should follow environment');
+  assert.ok(agentIndex < todoIndex, 'todo line should follow agent line');
+});
+
+test('render expanded layout omits elements not present in elementOrder', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.usageData = {
+    planName: 'Team',
+    fiveHour: 30,
+    sevenDay: 10,
+    fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+    sevenDayResetAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+  };
+  ctx.claudeMdCount = 1;
+  ctx.transcript.tools = [
+    { id: 'tool-1', name: 'Read', status: 'completed', startTime: new Date(0), endTime: new Date(0), duration: 0 },
+  ];
+  ctx.transcript.agents = [
+    { id: 'agent-1', type: 'planner', status: 'running', startTime: new Date(0) },
+  ];
+  ctx.transcript.todos = [
+    { content: 'todo-marker', status: 'in_progress' },
+  ];
+  ctx.config.elementOrder = ['project', 'tools'];
+
+  const output = captureRenderLines(ctx).join('\n');
+
+  assert.ok(output.includes('my-project'), 'project should render when included');
+  assert.ok(output.includes('Read'), 'tools should render when included');
+  assert.ok(!output.includes('Context'), 'context should be omitted when excluded');
+  assert.ok(!output.includes('Usage'), 'usage should be omitted when excluded');
+  assert.ok(!output.includes('CLAUDE.md'), 'environment should be omitted when excluded');
+  assert.ok(!output.includes('planner'), 'agents should be omitted when excluded');
+  assert.ok(!output.includes('todo-marker'), 'todos should be omitted when excluded');
+});
+
+test('render expanded layout combines usage and context when adjacent in elementOrder', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.usageData = {
+    planName: 'Team',
+    fiveHour: 30,
+    sevenDay: 10,
+    fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+    sevenDayResetAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+  };
+  ctx.config.elementOrder = ['usage', 'context'];
+
+  const lines = captureRenderLines(ctx);
+
+  assert.equal(lines.length, 1, 'adjacent usage and context should share one expanded line');
+  assert.ok(lines[0].includes('Usage'), 'combined line should include usage');
+  assert.ok(lines[0].includes('Context'), 'combined line should include context');
+  assert.ok(lines[0].includes('│'), 'combined line should preserve the shared separator');
+});
+
+test('render expanded layout keeps usage and context separate when not adjacent', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.usageData = {
+    planName: 'Team',
+    fiveHour: 30,
+    sevenDay: 10,
+    fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+    sevenDayResetAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+  };
+  ctx.config.elementOrder = ['usage', 'project', 'context'];
+
+  const lines = captureRenderLines(ctx);
+  const usageLine = lines.find(line => line.includes('Usage'));
+  const contextLine = lines.find(line => line.includes('Context'));
+  const combinedLine = lines.find(line => line.includes('Usage') && line.includes('Context'));
+
+  assert.ok(usageLine, 'usage should render on its own line');
+  assert.ok(contextLine, 'context should render on its own line');
+  assert.equal(combinedLine, undefined, 'usage and context should not combine when separated by another element');
+});
+
+test('render compact layout keeps activity lines even when elementOrder omits them', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.transcript.tools = [
+    { id: 'tool-1', name: 'Read', status: 'completed', startTime: new Date(0), endTime: new Date(0), duration: 0 },
+  ];
+  ctx.transcript.todos = [
+    { content: 'todo-marker', status: 'in_progress' },
+  ];
+  ctx.config.elementOrder = ['project'];
+
+  const output = captureRenderLines(ctx).join('\n');
+
+  assert.ok(output.includes('Read'), 'compact mode should keep tools visible');
+  assert.ok(output.includes('todo-marker'), 'compact mode should keep todos visible');
 });


### PR DESCRIPTION
## Summary

Adds an `elementOrder` config field to `HudConfig` that controls the display order of HUD elements in expanded mode. Users can reorder, omit, or filter elements by customizing this array.

## New config field

```jsonc
// ~/.claude/plugins/claude-hud/config.json
{
  "elementOrder": ["project", "context", "usage", "environment", "tools", "agents", "todos"]
}
```

### Element names

| Element | Renderer | Group |
|---|---|---|
| `project` | Project line (name, git, model) | Header |
| `context` | Context/identity bar | Header |
| `usage` | Usage percentages | Header |
| `environment` | Environment info | Header |
| `tools` | Active/completed tools | Activity |
| `agents` | Running/completed agents | Activity |
| `todos` | Todo progress | Activity |

### Behavior

- **Default order** matches current hardcoded behavior — zero breaking changes
- **Reordering**: `["environment", "project", "usage", "context"]` puts environment first
- **Filtering**: omitting an element hides it — `["project", "context"]` hides usage, environment, tools, agents, todos
- **context+usage adjacency**: when adjacent in the array, they combine on one line with `│` (current behavior). When separated by other elements, each renders independently
- **Activity elements** (tools/agents/todos) still respect their `display.showTools`/`showAgents`/`showTodos` toggles in addition to elementOrder presence

### Validation

- Unknown element names are silently filtered (forward-compatible with future elements)
- Duplicates are deduplicated (first occurrence wins)
- Empty array or all-unknown falls back to `DEFAULT_ELEMENT_ORDER`
- Non-array values fall back to default

## Example configs

**Minimal HUD — just project and context:**
```json
{
  "elementOrder": ["project", "context"]
}
```

**Usage-first layout:**
```json
{
  "elementOrder": ["usage", "project", "context", "environment", "tools"]
}
```

**Everything with tools/agents prominent:**
```json
{
  "elementOrder": ["project", "tools", "agents", "context", "usage", "environment", "todos"]
}
```

## Files changed

| File | Changes |
|---|---|
| `src/config.ts` | Add `HudElement` type, `KNOWN_ELEMENTS`, `DEFAULT_ELEMENT_ORDER`, `elementOrder` to `HudConfig`/`DEFAULT_CONFIG`, validation in `mergeConfig()`, export `mergeConfig` for testing |
| `src/render/index.ts` | Refactor `renderExpanded()` to iterate `elementOrder`, handle context+usage adjacency, unified header/activity rendering loop |
| `tests/config.test.js` | 8 new tests: default applied, custom preserved, unknown filtered, deduplication, empty fallback, all-unknown fallback, non-array fallback, partial order |
| `tests/render.test.js` | 5 new tests: custom order, element omission, adjacent combining, separated rendering, duplicate handling |

## Compatibility

- Default `elementOrder` produces identical output to current behavior
- All existing tests pass unchanged (only `baseContext()` updated to include the new field)
- `display.showTools`/`showAgents`/`showTodos` toggles still work alongside `elementOrder`
- Compact mode is unaffected (renders session line only)