### PR TITLE
Skip usage api for custom provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ To disable, set `display.showUsage` to `false`.
 - Check `display.showUsage` is not set to `false` in config
 - API users see no usage display (they have pay-per-token, not rate limits)
 - AWS Bedrock models display `Bedrock` and hide usage limits (usage is managed in AWS)
-- Custom API providers (e.g., via `ANTHROPIC_BASE_URL` or `ANTHROPIC_API_BASE_URL`) skip usage display, as the Anthropic usage API is not applicable
+- Non-default `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_BASE_URL` settings skip usage display, because the Anthropic OAuth usage API may not apply
 - If you are behind a proxy, set `HTTPS_PROXY` (or `HTTP_PROXY`/`ALL_PROXY`) and optional `NO_PROXY`
 - For high-latency environments, increase usage API timeout with `CLAUDE_HUD_USAGE_TIMEOUT_MS` (milliseconds)
 

--- a/src/usage-api.ts
+++ b/src/usage-api.ts
@@ -58,16 +58,18 @@ export const USAGE_API_USER_AGENT = 'claude-hud';
  * When using custom providers (e.g., via cc-switch), the OAuth usage API is not applicable.
  */
 function isUsingCustomApiEndpoint(env: NodeJS.ProcessEnv = process.env): boolean {
-  const baseUrl = env.ANTHROPIC_BASE_URL ?? env.ANTHROPIC_API_BASE_URL;
+  const baseUrl = env.ANTHROPIC_BASE_URL?.trim() || env.ANTHROPIC_API_BASE_URL?.trim();
 
   // No custom endpoint configured - using default Anthropic API
   if (!baseUrl) {
     return false;
   }
 
-  // Normalize and check if it's the default Anthropic API
-  const normalized = baseUrl.replace(/\/$/, '').toLowerCase();
-  return normalized !== 'https://api.anthropic.com';
+  try {
+    return new URL(baseUrl).origin !== 'https://api.anthropic.com';
+  } catch {
+    return true;
+  }
 }
 
 interface CacheFile {

--- a/tests/usage-api.test.js
+++ b/tests/usage-api.test.js
@@ -511,6 +511,50 @@ describe('getUsage', () => {
     }
   });
 
+  test('falls back to ANTHROPIC_API_BASE_URL when ANTHROPIC_BASE_URL is empty', async () => {
+    const originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
+    const originalApiBaseUrl = process.env.ANTHROPIC_API_BASE_URL;
+    process.env.ANTHROPIC_BASE_URL = '';
+    process.env.ANTHROPIC_API_BASE_URL = 'https://my-proxy.example.com';
+    await writeCredentials(tempHome, buildCredentials());
+    let fetchCalls = 0;
+    try {
+      const result = await getUsage({
+        homeDir: () => tempHome,
+        fetchApi: async () => { fetchCalls += 1; return buildApiResult(); },
+        now: () => 1000,
+        readKeychain: () => null,
+      });
+      assert.equal(result, null);
+      assert.equal(fetchCalls, 0);
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', originalBaseUrl);
+      restoreEnvVar('ANTHROPIC_API_BASE_URL', originalApiBaseUrl);
+    }
+  });
+
+  test('falls back to ANTHROPIC_API_BASE_URL when ANTHROPIC_BASE_URL is whitespace', async () => {
+    const originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
+    const originalApiBaseUrl = process.env.ANTHROPIC_API_BASE_URL;
+    process.env.ANTHROPIC_BASE_URL = '   ';
+    process.env.ANTHROPIC_API_BASE_URL = 'https://my-proxy.example.com';
+    await writeCredentials(tempHome, buildCredentials());
+    let fetchCalls = 0;
+    try {
+      const result = await getUsage({
+        homeDir: () => tempHome,
+        fetchApi: async () => { fetchCalls += 1; return buildApiResult(); },
+        now: () => 1000,
+        readKeychain: () => null,
+      });
+      assert.equal(result, null);
+      assert.equal(fetchCalls, 0);
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', originalBaseUrl);
+      restoreEnvVar('ANTHROPIC_API_BASE_URL', originalApiBaseUrl);
+    }
+  });
+
   test('proceeds normally when ANTHROPIC_BASE_URL is the default Anthropic endpoint', async () => {
     const originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
     process.env.ANTHROPIC_BASE_URL = 'https://api.anthropic.com';
@@ -544,6 +588,74 @@ describe('getUsage', () => {
       });
       assert.equal(fetchCalls, 1);
       assert.ok(result !== null);
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', originalBaseUrl);
+    }
+  });
+
+  test('proceeds normally when ANTHROPIC_BASE_URL is the default endpoint with /v1 path', async () => {
+    const originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
+    process.env.ANTHROPIC_BASE_URL = 'https://api.anthropic.com/v1/';
+    await writeCredentials(tempHome, buildCredentials());
+    let fetchCalls = 0;
+    try {
+      const result = await getUsage({
+        homeDir: () => tempHome,
+        fetchApi: async () => { fetchCalls += 1; return buildApiResult(); },
+        now: () => 1000,
+        readKeychain: () => null,
+      });
+      assert.equal(fetchCalls, 1);
+      assert.ok(result !== null);
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', originalBaseUrl);
+    }
+  });
+
+  test('prefers non-empty ANTHROPIC_BASE_URL over ANTHROPIC_API_BASE_URL', async () => {
+    const originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
+    const originalApiBaseUrl = process.env.ANTHROPIC_API_BASE_URL;
+    process.env.ANTHROPIC_BASE_URL = 'https://api.anthropic.com';
+    process.env.ANTHROPIC_API_BASE_URL = 'https://my-proxy.example.com';
+    await writeCredentials(tempHome, buildCredentials());
+    let fetchCalls = 0;
+    try {
+      const result = await getUsage({
+        homeDir: () => tempHome,
+        fetchApi: async () => { fetchCalls += 1; return buildApiResult(); },
+        now: () => 1000,
+        readKeychain: () => null,
+      });
+      assert.equal(fetchCalls, 1);
+      assert.ok(result !== null);
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', originalBaseUrl);
+      restoreEnvVar('ANTHROPIC_API_BASE_URL', originalApiBaseUrl);
+    }
+  });
+
+  test('ignores cached Anthropic usage when a custom API endpoint is active', async () => {
+    const originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
+    await writeCredentials(tempHome, buildCredentials());
+    try {
+      const cachedResult = await getUsage({
+        homeDir: () => tempHome,
+        fetchApi: async () => buildApiResult(),
+        now: () => 1000,
+        readKeychain: () => null,
+      });
+      assert.ok(cachedResult !== null);
+
+      process.env.ANTHROPIC_BASE_URL = 'https://my-proxy.example.com';
+      let fetchCalls = 0;
+      const result = await getUsage({
+        homeDir: () => tempHome,
+        fetchApi: async () => { fetchCalls += 1; return buildApiResult(); },
+        now: () => 1500,
+        readKeychain: () => null,
+      });
+      assert.equal(result, null);
+      assert.equal(fetchCalls, 0);
     } finally {
       restoreEnvVar('ANTHROPIC_BASE_URL', originalBaseUrl);
     }


### PR DESCRIPTION
When a user is using both Anthropic and a third-party provider (such as via [cc-switch](https://github.com/farion1231/cc-switch)) in Claude Code, the current HUD continuously requests the Anthropic Usage API when switching to the third-party provider, triggering failed retries (15s) and indirectly causing 429 rate limiting. The purpose of this PR is to avoid using queries when the user is on a non-Anthropic provider.

## Summary
- Detects ANTHROPIC_BASE_URL / ANTHROPIC_API_BASE_URL env vars and skips the Anthropic OAuth usage API call when a custom provider is configured
- Prevents unnecessary API failures and error noise for users routing through custom/proxy endpoints
- The default https://api.anthropic.com endpoint (with or without trailing slash) continues to work normally; empty string is treated as unset

## Testing

- [x] `npm test`  
  - ANTHROPIC_BASE_URL set to custom URL → getUsage returns null, no fetch attempted
  - ANTHROPIC_API_BASE_URL set to custom URL → same behavior
  - ANTHROPIC_BASE_URL set to empty string → proceeds normally (treated as unset)
  - ANTHROPIC_BASE_URL=https://api.anthropic.com → proceeds normally
  - ANTHROPIC_BASE_URL=https://api.anthropic.com/ (trailing slash) → proceeds normally
- [x] `npm run test:coverage`

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed
