### PR TITLE
fix(context): don't inflate percentage at session start

### DIFF
--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -76,6 +76,9 @@ export function getBufferedPercent(stdin: StdinData): number {
   }
 
   const totalTokens = getTotalTokens(stdin);
+  if (totalTokens === 0) {
+    return 0;
+  }
   const buffer = size * AUTOCOMPACT_BUFFER_PERCENT;
   return Math.min(100, Math.round(((totalTokens + buffer) / size) * 100));
 }


### PR DESCRIPTION
## Summary

- At session start (before first API call), `getBufferedPercent()` was adding the 22.5% autocompact buffer to zero tokens, producing a fictional **23%** context reading
- Now returns 0% when `totalTokens === 0`, applying the buffer only when real token data exists
- Single 3-line change in `src/stdin.ts`

## Root Cause

Per the [official statusline documentation](https://docs.anthropic.com/en/docs/claude-code/statusline#context-window):

> `used_percentage` — "may be null early in the session"
> `current_usage` — "null before the first API call in a session"

This is documented, expected behavior — not a Claude Code bug.

When both fields are null:
1. `getNativePercent()` returns null (no native percentage)
2. `getTotalTokens()` returns 0 (no usage data)
3. Buffer: `200000 × 0.225 = 45000`
4. Result: `(0 + 45000) / 200000 × 100 = 22.5%` → rounds to **23%**

The 23% reflected no actual context usage — purely the buffer size applied to zero tokens.

## Test plan

- [x] Session start (null usage) → **0%** (was 23%)
- [x] Normal usage (45k tokens) → **45%** (buffer applied correctly)
- [x] Native `used_percentage` provided → uses native value (unchanged)
- [x] All existing `getBufferedPercent` tests pass