### PR TITLE
fix(context): adjust autocompact fallback buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Claude HUD will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- Update the fallback autocompact buffer estimate from `22.5%` (`45k/200k`) to `16.5%` (`33k/200k`) to match current Claude Code `/context` output.
+- Clarify in code comments that the fallback buffer is empirical and may change independently of documented Claude Code releases.
+
+---
+
 ## [0.0.9] - 2026-03-05
 
 ### Changed

--- a/dist/constants.d.ts
+++ b/dist/constants.d.ts
@@ -1,10 +1,10 @@
 /**
  * Autocompact buffer percentage.
  *
- * NOTE: This value (22.5% = 45k/200k) is empirically derived from community
- * observations of Claude Code's autocompact behavior. It is NOT officially
- * documented by Anthropic and may change in future Claude Code versions.
- * If users report mismatches, this value may need adjustment.
+ * NOTE: This value (16.5% = 33k/200k) is empirically derived from current
+ * Claude Code `/context` output. It is NOT officially documented by Anthropic
+ * and may change in future Claude Code versions. If users report mismatches,
+ * this value may need adjustment.
  */
-export declare const AUTOCOMPACT_BUFFER_PERCENT = 0.225;
+export declare const AUTOCOMPACT_BUFFER_PERCENT = 0.165;
 //# sourceMappingURL=constants.d.ts.map

--- a/dist/constants.js
+++ b/dist/constants.js
@@ -1,10 +1,10 @@
 /**
  * Autocompact buffer percentage.
  *
- * NOTE: This value (22.5% = 45k/200k) is empirically derived from community
- * observations of Claude Code's autocompact behavior. It is NOT officially
- * documented by Anthropic and may change in future Claude Code versions.
- * If users report mismatches, this value may need adjustment.
+ * NOTE: This value (16.5% = 33k/200k) is empirically derived from current
+ * Claude Code `/context` output. It is NOT officially documented by Anthropic
+ * and may change in future Claude Code versions. If users report mismatches,
+ * this value may need adjustment.
  */
-export const AUTOCOMPACT_BUFFER_PERCENT = 0.225;
+export const AUTOCOMPACT_BUFFER_PERCENT = 0.165;
 //# sourceMappingURL=constants.js.map

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,9 +1,9 @@
 /**
  * Autocompact buffer percentage.
  *
- * NOTE: This value (22.5% = 45k/200k) is empirically derived from community
- * observations of Claude Code's autocompact behavior. It is NOT officially
- * documented by Anthropic and may change in future Claude Code versions.
- * If users report mismatches, this value may need adjustment.
+ * NOTE: This value (16.5% = 33k/200k) is empirically derived from current
+ * Claude Code `/context` output. It is NOT officially documented by Anthropic
+ * and may change in future Claude Code versions. If users report mismatches,
+ * this value may need adjustment.
  */
-export const AUTOCOMPACT_BUFFER_PERCENT = 0.225;
+export const AUTOCOMPACT_BUFFER_PERCENT = 0.165;

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -40,8 +40,8 @@ test('getContextPercent returns raw percentage without buffer', () => {
   assert.equal(percent, 28);
 });
 
-test('getBufferedPercent includes 22.5% buffer', () => {
-  // 55000 / 200000 = 27.5%, + 22.5% buffer = 50%
+test('getBufferedPercent includes 16.5% buffer', () => {
+  // 55000 / 200000 = 27.5%, + 16.5% buffer = 44%
   const percent = getBufferedPercent({
     context_window: {
       context_window_size: 200000,
@@ -53,7 +53,7 @@ test('getBufferedPercent includes 22.5% buffer', () => {
     },
   });
 
-  assert.equal(percent, 50);
+  assert.equal(percent, 44);
 });
 
 test('getContextPercent handles missing input tokens', () => {
@@ -72,9 +72,9 @@ test('getContextPercent handles missing input tokens', () => {
 });
 
 test('getBufferedPercent scales to larger context windows', () => {
-  // Test with 1M context window: 45000 tokens + (1000000 * 0.225) buffer
+  // Test with 1M context window: 45000 tokens + (1000000 * 0.165) buffer
   // Raw: 45000 / 1000000 = 4.5% → 5%
-  // Buffered: (45000 + 225000) / 1000000 = 27% → 27%
+  // Buffered: (45000 + 165000) / 1000000 = 21% → 21%
   const rawPercent = getContextPercent({
     context_window: {
       context_window_size: 1000000,
@@ -89,7 +89,7 @@ test('getBufferedPercent scales to larger context windows', () => {
   });
 
   assert.equal(rawPercent, 5);
-  assert.equal(bufferedPercent, 27);
+  assert.equal(bufferedPercent, 21);
 });
 
 // Native percentage tests (Claude Code v2.1.6+)
@@ -108,7 +108,7 @@ test('getBufferedPercent prefers native used_percentage when available', () => {
   const percent = getBufferedPercent({
     context_window: {
       context_window_size: 200000,
-      current_usage: { input_tokens: 55000 }, // would be 50% buffered
+      current_usage: { input_tokens: 55000 }, // would be 44% buffered
       used_percentage: 47, // native value takes precedence
     },
   });
@@ -134,7 +134,7 @@ test('getBufferedPercent falls back when native is null', () => {
       used_percentage: null,
     },
   });
-  assert.equal(percent, 50); // buffered calculation
+  assert.equal(percent, 44); // buffered calculation
 });
 
 test('native percentage handles zero correctly', () => {

--- a/tests/fixtures/expected/render-basic.txt
+++ b/tests/fixtures/expected/render-basic.txt
@@ -1,2 +1,2 @@
 [Opus] │ my-project
-Context █████░░░░░ 45%
+Context ████░░░░░░ 39%

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -60,8 +60,8 @@ function captureRenderLines(ctx) {
 
 test('renderSessionLine adds token breakdown when context is high', () => {
   const ctx = baseContext();
-  // For 90%: (tokens + 45000) / 200000 = 0.9 → tokens = 135000
-  ctx.stdin.context_window.current_usage.input_tokens = 135000;
+  // For 90%: (tokens + 33000) / 200000 = 0.9 → tokens = 147000
+  ctx.stdin.context_window.current_usage.input_tokens = 147000;
   const line = renderSessionLine(ctx);
   assert.ok(line.includes('in:'), 'expected token breakdown');
   assert.ok(line.includes('cache:'), 'expected cache breakdown');
@@ -71,22 +71,22 @@ test('renderSessionLine includes duration and formats large tokens', () => {
   const ctx = baseContext();
   ctx.sessionDuration = '1m';
   // Use 1M context, need 85%+ to show breakdown
-  // For 85%: (tokens + 45000) / 1000000 = 0.85 → tokens = 805000
+  // For 85%: (tokens + 165000) / 1000000 = 0.85 → tokens = 685000
   ctx.stdin.context_window.context_window_size = 1000000;
-  ctx.stdin.context_window.current_usage.input_tokens = 805000;
+  ctx.stdin.context_window.current_usage.input_tokens = 685000;
   ctx.stdin.context_window.current_usage.cache_read_input_tokens = 1500;
   const line = renderSessionLine(ctx);
   assert.ok(line.includes('⏱️'));
-  assert.ok(line.includes('805k') || line.includes('805.0k'), 'expected large input token display');
+  assert.ok(line.includes('685k') || line.includes('685.0k'), 'expected large input token display');
   assert.ok(line.includes('2k'), 'expected cache token display');
 });
 
 test('renderSessionLine handles missing input tokens and cache creation usage', () => {
   const ctx = baseContext();
-  // For 90%: (tokens + 45000) / 200000 = 0.9 → tokens = 135000 (all from cache)
+  // For 90%: (tokens + 33000) / 200000 = 0.9 → tokens = 147000 (all from cache)
   ctx.stdin.context_window.context_window_size = 200000;
   ctx.stdin.context_window.current_usage = {
-    cache_creation_input_tokens: 135000,
+    cache_creation_input_tokens: 147000,
   };
   const line = renderSessionLine(ctx);
   assert.ok(line.includes('90%'));
@@ -95,10 +95,10 @@ test('renderSessionLine handles missing input tokens and cache creation usage', 
 
 test('renderSessionLine handles missing cache token fields', () => {
   const ctx = baseContext();
-  // For 90%: (tokens + 45000) / 200000 = 0.9 → tokens = 135000
+  // For 90%: (tokens + 33000) / 200000 = 0.9 → tokens = 147000
   ctx.stdin.context_window.context_window_size = 200000;
   ctx.stdin.context_window.current_usage = {
-    input_tokens: 135000,
+    input_tokens: 147000,
   };
   const line = renderSessionLine(ctx);
   assert.ok(line.includes('cache: 0'));
@@ -160,7 +160,7 @@ test('renderSessionLine supports remaining-based context display', () => {
   ctx.stdin.context_window.context_window_size = 200000;
   ctx.stdin.context_window.current_usage.input_tokens = 12345;
   const line = renderSessionLine(ctx);
-  assert.ok(line.includes('71%'), 'should include remaining percentage');
+  assert.ok(line.includes('77%'), 'should include remaining percentage');
 });
 
 test('render expanded layout supports remaining-based context display', () => {
@@ -179,7 +179,7 @@ test('render expanded layout supports remaining-based context display', () => {
     console.log = originalLog;
   }
 
-  assert.ok(logs.some(line => line.includes('Context') && line.includes('71%')), 'expected remaining percentage on context line');
+  assert.ok(logs.some(line => line.includes('Context') && line.includes('77%')), 'expected remaining percentage on context line');
 });
 
 test('renderSessionLine omits project name when cwd is undefined', () => {
@@ -733,12 +733,12 @@ test('renderSessionLine hides usage when showUsage config is false (hybrid toggl
 
 test('renderSessionLine uses buffered percent when autocompactBuffer is enabled', () => {
   const ctx = baseContext();
-  // 10000 tokens / 200000 = 5% raw, + 22.5% buffer = 28% buffered (rounded)
+  // 10000 tokens / 200000 = 5% raw, + 16.5% buffer = 22% buffered (rounded)
   ctx.stdin.context_window.current_usage.input_tokens = 10000;
   ctx.config.display.autocompactBuffer = 'enabled';
   const line = renderSessionLine(ctx);
-  // Should show ~28% (buffered), not 5% (raw)
-  assert.ok(line.includes('28%'), `expected buffered percent 28%, got: ${line}`);
+  // Should show ~22% (buffered), not 5% (raw)
+  assert.ok(line.includes('22%'), `expected buffered percent 22%, got: ${line}`);
 });
 
 test('renderSessionLine uses raw percent when autocompactBuffer is disabled', () => {
@@ -747,7 +747,7 @@ test('renderSessionLine uses raw percent when autocompactBuffer is disabled', ()
   ctx.stdin.context_window.current_usage.input_tokens = 10000;
   ctx.config.display.autocompactBuffer = 'disabled';
   const line = renderSessionLine(ctx);
-  // Should show 5% (raw), not 28% (buffered)
+  // Should show 5% (raw), not 22% (buffered)
   assert.ok(line.includes('5%'), `expected raw percent 5%, got: ${line}`);
 });
 


### PR DESCRIPTION
## Summary
- update the fallback autocompact buffer from 45k / 22.5% to 33k / 16.5%
- align render and integration expectations with current Claude Code `/context` output
- document that the fallback value is empirical rather than officially documented

## Testing
- npm test