### PR TITLE
fix: increase failure cache TTL from 15s to 5min to prevent 429 retry storm

### DIFF
--- a/src/usage-api.ts
+++ b/src/usage-api.ts
@@ -44,7 +44,7 @@ interface UsageApiResult {
 
 // File-based cache (HUD runs as new process each render, so in-memory cache won't persist)
 const CACHE_TTL_MS = 60_000; // 60 seconds
-const CACHE_FAILURE_TTL_MS = 15_000; // 15 seconds for failed requests
+const CACHE_FAILURE_TTL_MS = 300_000; // 5 minutes for failed requests (avoids 429 retry storm)
 const CACHE_LOCK_STALE_MS = 30_000;
 const CACHE_LOCK_WAIT_MS = 2_000;
 const CACHE_LOCK_POLL_MS = 50;


### PR DESCRIPTION
Bumps 'CACHE_FAILURE_TTL_MS' from 15s to 5 minutes.

With the 15s failure TTL, a single 429 response leads to an infinite cycle where the HUD retries 4 times/minute, actively preventing recovery from a transient rate-limit and keeping the 'Usage ⚠ (429)' warning permanently in the status bar.

Fixes #188, related to #187