### PR TITLE
fix: prefer account-scoped keychain credentials

### DIFF
--- a/src/usage-api.ts
+++ b/src/usage-api.ts
@@ -575,16 +575,14 @@ export function resolveKeychainCredentials(
   accountName?: string | null,
 ): { credentials: { accessToken: string; subscriptionType: string } | null; shouldBackoff: boolean } {
   let shouldBackoff = false;
-  const servicesWithAccountScopedEntries = new Set<string>();
+  let allowGenericFallback = Boolean(accountName);
 
   for (const serviceName of serviceNames) {
     try {
       const keychainData = accountName
         ? loadService(serviceName, accountName)
         : loadService(serviceName);
-      if (accountName) {
-        servicesWithAccountScopedEntries.add(serviceName);
-      }
+      if (accountName) allowGenericFallback = false;
       const trimmedKeychainData = keychainData.trim();
       if (!trimmedKeychainData) continue;
 
@@ -595,25 +593,17 @@ export function resolveKeychainCredentials(
       }
     } catch (error) {
       if (!isMissingKeychainItemError(error)) {
-        if (accountName) {
-          servicesWithAccountScopedEntries.add(serviceName);
-        }
+        if (accountName) allowGenericFallback = false;
         shouldBackoff = true;
       }
     }
   }
 
-  if (!accountName) {
+  if (!accountName || !allowGenericFallback) {
     return { credentials: null, shouldBackoff };
   }
 
   for (const serviceName of serviceNames) {
-    if (servicesWithAccountScopedEntries.has(serviceName)) {
-      // Avoid cross-account leakage: if this service has an entry for the current user,
-      // do not fall back to whichever account the generic lookup returns first.
-      continue;
-    }
-
     try {
       const keychainData = loadService(serviceName).trim();
       if (!keychainData) continue;

--- a/tests/usage-api.test.js
+++ b/tests/usage-api.test.js
@@ -352,6 +352,41 @@ describe('resolveKeychainCredentials', () => {
     assert.equal(result.shouldBackoff, true);
     assert.deepEqual(calls, [{ serviceName: 'Claude Code-credentials', accountName: 'jarrod' }]);
   });
+
+  test('does not fall back to generic credentials from another service when a later account-scoped entry is unusable', () => {
+    const now = 1000;
+    const serviceNames = ['Claude Code-credentials-hashed', 'Claude Code-credentials'];
+    const calls = [];
+
+    const result = resolveKeychainCredentials(
+      serviceNames,
+      now,
+      (serviceName, accountName) => {
+        calls.push({ serviceName, accountName: accountName ?? null });
+        if (accountName === 'jarrod' && serviceName === 'Claude Code-credentials-hashed') {
+          throw buildMissingKeychainError();
+        }
+
+        if (accountName === 'jarrod' && serviceName === 'Claude Code-credentials') {
+          return JSON.stringify({ mcpOAuth: { accessToken: 'wrong-scope' } });
+        }
+
+        return JSON.stringify(buildCredentials({
+          accessToken: `generic-${serviceName}`,
+          subscriptionType: 'claude_pro_2024',
+          expiresAt: now + 60_000,
+        }));
+      },
+      'jarrod',
+    );
+
+    assert.equal(result.credentials, null);
+    assert.equal(result.shouldBackoff, false);
+    assert.deepEqual(calls, [
+      { serviceName: 'Claude Code-credentials-hashed', accountName: 'jarrod' },
+      { serviceName: 'Claude Code-credentials', accountName: 'jarrod' },
+    ]);
+  });
 });
 
 describe('getUsage', () => {


### PR DESCRIPTION
## Summary\n- prefer account-scoped macOS keychain lookups before generic service lookups\n- block generic fallback when the account-scoped entry exists but is empty, invalid, or errors in a non-missing way\n- add resolver regressions for empty secrets and non-missing account-scoped lookup errors\n\nCloses #204