### PR TITLE
fix: surface stale usage syncing during rate limits

### DIFF
--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -55,6 +55,9 @@ export function renderUsageLine(ctx: RenderContext): string | null {
         : `5h: ${fiveHourDisplay}`);
 
   const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
+  const syncingSuffix = ctx.usageData.apiError === 'rate-limited'
+    ? ` ${dim('(syncing...)')}`
+    : '';
   if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
     const sevenDayDisplay = formatUsagePercent(sevenDay, colors);
     const sevenDayReset = formatResetTime(ctx.usageData.sevenDayResetAt);
@@ -65,10 +68,10 @@ export function renderUsageLine(ctx: RenderContext): string | null {
       : (sevenDayReset
           ? `7d: ${sevenDayDisplay} (${sevenDayReset})`
           : `7d: ${sevenDayDisplay}`);
-    return `${label} ${fiveHourPart} | ${sevenDayPart}`;
+    return `${label} ${fiveHourPart} | ${sevenDayPart}${syncingSuffix}`;
   }
 
-  return `${label} ${fiveHourPart}`;
+  return `${label} ${fiveHourPart}${syncingSuffix}`;
 }
 
 function formatUsagePercent(percent: number | null, colors?: RenderContext['config']['colors']): string {

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -155,6 +155,9 @@ export function renderSessionLine(ctx: RenderContext): string {
       const effectiveUsage = Math.max(fiveHour ?? 0, sevenDay ?? 0);
 
       if (effectiveUsage >= usageThreshold) {
+        const syncingSuffix = ctx.usageData.apiError === 'rate-limited'
+          ? ` ${dim('(syncing...)')}`
+          : '';
         const fiveHourDisplay = formatUsagePercent(fiveHour, colors);
         const fiveHourReset = formatResetTime(ctx.usageData.fiveHourResetAt);
 
@@ -178,9 +181,9 @@ export function renderSessionLine(ctx: RenderContext): string {
             : (sevenDayReset
                 ? `7d: ${sevenDayDisplay} (${sevenDayReset})`
                 : `7d: ${sevenDayDisplay}`);
-          parts.push(`${fiveHourPart} | ${sevenDayPart}`);
+          parts.push(`${fiveHourPart} | ${sevenDayPart}${syncingSuffix}`);
         } else {
-          parts.push(fiveHourPart);
+          parts.push(`${fiveHourPart}${syncingSuffix}`);
         }
       }
     }

--- a/src/usage-api.ts
+++ b/src/usage-api.ts
@@ -138,6 +138,13 @@ function getRateLimitedRetryUntil(cache: CacheFile): number | null {
   return null;
 }
 
+function withRateLimitedSyncing(data: UsageData): UsageData {
+  return {
+    ...data,
+    apiError: 'rate-limited',
+  };
+}
+
 function readCacheState(homeDir: string, now: number, ttls: CacheTtls): CacheState | null {
   try {
     const cachePath = getCachePath(homeDir);
@@ -148,7 +155,7 @@ function readCacheState(homeDir: string, now: number, ttls: CacheTtls): CacheSta
 
     // Only serve lastGoodData during rate-limit backoff. Other failures should remain visible.
     const displayData = (cache.data.apiError === 'rate-limited' && cache.lastGoodData)
-      ? cache.lastGoodData
+      ? withRateLimitedSyncing(cache.lastGoodData)
       : cache.data;
 
     const rateLimitedRetryUntil = getRateLimitedRetryUntil(cache);
@@ -432,9 +439,10 @@ export async function getUsage(overrides: Partial<UsageApiDeps> = {}): Promise<U
           : lastGood;
 
         if (goodData) {
-          // Preserve the backoff state in cache, but keep rendering the last successful values.
+          // Preserve the backoff state in cache, but keep rendering the last successful values
+          // with a syncing hint so stale data is visible to the user.
           writeCache(homeDir, failureResult, now, { ...backoffOpts, lastGoodData: goodData });
-          return goodData;
+          return withRateLimitedSyncing(goodData);
         }
       }
 
@@ -1008,17 +1016,11 @@ function fetchUsageApi(accessToken: string): Promise<UsageApiResult> {
           const error = res.statusCode === 429
             ? 'rate-limited'
             : res.statusCode ? `http-${res.statusCode}` : 'http-error';
-          // Parse Retry-After header (seconds) from 429 responses
-          let retryAfterSec: number | undefined;
-          if (res.statusCode === 429) {
-            const raw = res.headers['retry-after'];
-            if (raw) {
-              const parsed = parseInt(String(raw), 10);
-              if (Number.isFinite(parsed) && parsed > 0) {
-                retryAfterSec = parsed;
-                debug('Retry-After:', retryAfterSec, 'seconds');
-              }
-            }
+          const retryAfterSec = res.statusCode === 429
+            ? parseRetryAfterSeconds(res.headers['retry-after'])
+            : undefined;
+          if (retryAfterSec) {
+            debug('Retry-After:', retryAfterSec, 'seconds');
           }
           resolve({ data: null, error, retryAfterSec });
           return;
@@ -1046,6 +1048,27 @@ function fetchUsageApi(accessToken: string): Promise<UsageApiResult> {
 
     req.end();
   });
+}
+
+export function parseRetryAfterSeconds(
+  raw: string | string[] | undefined,
+  nowMs: number = Date.now(),
+): number | undefined {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (!value) return undefined;
+
+  const parsedSeconds = Number.parseInt(value, 10);
+  if (Number.isFinite(parsedSeconds) && parsedSeconds > 0) {
+    return parsedSeconds;
+  }
+
+  const retryAtMs = Date.parse(value);
+  if (!Number.isFinite(retryAtMs)) {
+    return undefined;
+  }
+
+  const retryAfterSeconds = Math.ceil((retryAtMs - nowMs) / 1000);
+  return retryAfterSeconds > 0 ? retryAfterSeconds : undefined;
 }
 
 // Export for testing

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -793,6 +793,27 @@ test('renderSessionLine shows syncing hint when usage API is rate-limited', () =
   assert.ok(!line.includes('rate-limited'), 'should not expose raw rate-limit error key');
 });
 
+test('renderSessionLine keeps stale usage visible while rate-limited', () => {
+  const ctx = baseContext();
+  ctx.usageData = {
+    planName: 'Max',
+    fiveHour: 25,
+    sevenDay: 85,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    apiError: 'rate-limited',
+  };
+  const compactLine = renderSessionLine(ctx);
+  assert.ok(compactLine.includes('25%'), 'should keep the last successful 5h usage visible');
+  assert.ok(compactLine.includes('85%'), 'should keep the last successful 7d usage visible');
+  assert.ok(compactLine.includes('syncing...'), 'should show syncing hint alongside stale usage');
+
+  const usageLine = renderUsageLine(ctx);
+  assert.ok(usageLine?.includes('25%'), 'expanded usage line should keep stale 5h usage visible');
+  assert.ok(usageLine?.includes('85%'), 'expanded usage line should keep stale 7d usage visible');
+  assert.ok(usageLine?.includes('syncing...'), 'expanded usage line should show syncing hint');
+});
+
 test('renderSessionLine uses custom warning and critical colors for usage states', () => {
   const ctx = baseContext();
   ctx.config.colors = {

--- a/tests/usage-api.test.js
+++ b/tests/usage-api.test.js
@@ -19,6 +19,7 @@ let resolveKeychainCredentials;
 let getUsageApiTimeoutMs;
 let isNoProxy;
 let getProxyUrl;
+let parseRetryAfterSeconds;
 let USAGE_API_USER_AGENT;
 
 function ensureUsageApiDistIsCurrent() {
@@ -54,6 +55,7 @@ before(async () => {
     getUsageApiTimeoutMs,
     isNoProxy,
     getProxyUrl,
+    parseRetryAfterSeconds,
     USAGE_API_USER_AGENT,
   } = await import(`../dist/usage-api.js?cacheBust=${Date.now()}`));
 });
@@ -1133,6 +1135,8 @@ describe('getUsage caching behavior', { concurrency: false }, () => {
       readKeychain: () => null,
     });
     assert.equal(rateLimited?.fiveHour, 25);
+    assert.equal(rateLimited?.apiUnavailable, undefined);
+    assert.equal(rateLimited?.apiError, 'rate-limited');
     assert.equal(fetchCalls, 2);
 
     nowValue += 60_000;
@@ -1143,6 +1147,8 @@ describe('getUsage caching behavior', { concurrency: false }, () => {
       readKeychain: () => null,
     });
     assert.equal(cachedDuringBackoff?.fiveHour, 25);
+    assert.equal(cachedDuringBackoff?.apiUnavailable, undefined);
+    assert.equal(cachedDuringBackoff?.apiError, 'rate-limited');
     assert.equal(fetchCalls, 2);
   });
 
@@ -1391,6 +1397,26 @@ describe('getUsage caching behavior', { concurrency: false }, () => {
     } finally {
       restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
     }
+  });
+});
+
+describe('parseRetryAfterSeconds', () => {
+  test('parses numeric Retry-After values', () => {
+    assert.equal(parseRetryAfterSeconds('120', 0), 120);
+  });
+
+  test('parses HTTP-date Retry-After values', () => {
+    const nowMs = Date.parse('2026-03-14T00:00:00Z');
+    assert.equal(
+      parseRetryAfterSeconds('Sat, 14 Mar 2026 00:02:30 GMT', nowMs),
+      150,
+    );
+  });
+
+  test('ignores expired or invalid Retry-After values', () => {
+    const nowMs = Date.parse('2026-03-14T00:00:00Z');
+    assert.equal(parseRetryAfterSeconds('Sat, 14 Mar 2026 00:00:00 GMT', nowMs), undefined);
+    assert.equal(parseRetryAfterSeconds('not-a-date', nowMs), undefined);
   });
 });
 


### PR DESCRIPTION
## Summary
- keep stale usage values visible while marking rate-limited refreshes as syncing
- honor HTTP-date Retry-After headers in addition to numeric seconds
- add render and cache coverage for the stale-syncing path and Retry-After parsing
