### PR TITLE
feat: add customLine display support

### DIFF
--- a/commands/configure.md
+++ b/commands/configure.md
@@ -26,11 +26,11 @@ Advanced settings such as `colors.*`, `pathLevels`, `display.usageThreshold`, an
 Questions: **Layout → Preset → Turn Off → Turn On**
 
 ### Flow B: Update Config (config exists)
-Questions: **Turn Off → Turn On → Git Style → Layout/Reset** (4 questions max)
+Questions: **Turn Off → Turn On → Git Style → Layout/Reset → Custom Line** (5 questions max)
 
 ---
 
-## Flow A: New User (4 Questions)
+## Flow A: New User (5 Questions)
 
 ### Q1: Layout
 - header: "Layout"
@@ -77,9 +77,19 @@ Questions: **Turn Off → Turn On → Git Style → Layout/Reset** (4 questions 
 **Note:** If preset has all items ON (Full), Q4 shows "Nothing to enable - Full preset has everything!"
 If preset has all items OFF (Minimal), Q3 shows "Nothing to disable - Minimal preset is already minimal!"
 
+### Q5: Custom Line (optional)
+- header: "Custom Line"
+- question: "Add a custom phrase to display in the HUD? (e.g. a motto, max 80 chars)"
+- multiSelect: false
+- options:
+  - "Skip" - No custom line
+  - "Enter custom text" - Ask user for their phrase via AskUserQuestion (free text input)
+
+If user chooses "Enter custom text", use AskUserQuestion to get their text. Save as `display.customLine` in config.
+
 ---
 
-## Flow B: Update Config (4 Questions)
+## Flow B: Update Config (5 Questions)
 
 ### Q1: Turn Off
 - header: "Turn Off"
@@ -132,6 +142,18 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
   - "Switch to Compact" - Everything on one line (if not current)
   - "Reset to Full" - Enable everything
   - "Reset to Essential" - Activity + git only
+
+### Q5: Custom Line (optional)
+- header: "Custom Line"
+- question: "Update your custom phrase? (currently: '{current customLine or none}')"
+- multiSelect: false
+- options:
+  - "Keep current" - No change (skip if no customLine set)
+  - "Enter custom text" - Set or update custom phrase (max 80 chars)
+  - "Remove" - Clear the custom line (only show if customLine is currently set)
+
+If user chooses "Enter custom text", use AskUserQuestion to get their text. Save as `display.customLine` in config.
+If user chooses "Remove", set `display.customLine` to `""` in config.
 
 ---
 
@@ -191,6 +213,7 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
 | Usage bar style | `display.usageBarEnabled` |
 | Session name | `display.showSessionName` |
 | Session duration | `display.showDuration` |
+| Custom line | `display.customLine` |
 
 **Always true (not configurable):**
 - `display.showModel: true`

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -213,6 +213,7 @@ Use AskUserQuestion:
   - "Agents & Todos" — Shows subagent status and todo progress
   - "Session info" — Shows session duration and config counts (CLAUDE.md, rules, MCPs)
   - "Session name" — Shows session slug or custom title from /rename
+  - "Custom line" — Display a custom phrase in the HUD
 
 **If user selects any options**, write `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/claude-hud/config.json` (create directories if needed):
 
@@ -222,6 +223,7 @@ Use AskUserQuestion:
 | Agents & Todos | `display.showAgents: true, display.showTodos: true` |
 | Session info | `display.showDuration: true, display.showConfigCounts: true` |
 | Session name | `display.showSessionName: true` |
+| Custom line | `display.customLine: "<user's text>"` — ask user for the text (max 80 chars) |
 
 Merge with existing config if the file already exists. Only write keys the user selected — don't write `false` for unselected items (defaults handle that).
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,6 +67,7 @@ export interface HudConfig {
     usageThreshold: number;
     sevenDayThreshold: number;
     environmentThreshold: number;
+    customLine: string;
   };
   usage: {
     cacheTtlSeconds: number;
@@ -105,6 +106,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     usageThreshold: 0,
     sevenDayThreshold: 80,
     environmentThreshold: 0,
+    customLine: '',
   },
   usage: {
     cacheTtlSeconds: 60,
@@ -296,6 +298,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     usageThreshold: validateThreshold(migrated.display?.usageThreshold, 100),
     sevenDayThreshold: validateThreshold(migrated.display?.sevenDayThreshold, 100),
     environmentThreshold: validateThreshold(migrated.display?.environmentThreshold, 100),
+    customLine: typeof migrated.display?.customLine === 'string'
+      ? migrated.display.customLine.slice(0, 80)
+      : DEFAULT_CONFIG.display.customLine,
   };
 
   const usage = {

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -10,6 +10,7 @@ const MAGENTA = '\x1b[35m';
 const CYAN = '\x1b[36m';
 const BRIGHT_BLUE = '\x1b[94m';
 const BRIGHT_MAGENTA = '\x1b[95m';
+const CLAUDE_ORANGE = '\x1b[38;5;208m';
 
 const ANSI_BY_NAME: Record<HudColorName, string> = {
   red: RED,
@@ -54,6 +55,10 @@ export function magenta(text: string): string {
 
 export function dim(text: string): string {
   return colorize(text, DIM);
+}
+
+export function claudeOrange(text: string): string {
+  return colorize(text, CLAUDE_ORANGE);
 }
 
 export function warning(text: string, colors?: Partial<HudColorOverrides>): string {

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -1,7 +1,7 @@
 import type { RenderContext } from '../../types.js';
 import { getModelName, getProviderLabel } from '../../stdin.js';
 import { getOutputSpeed } from '../../speed-tracker.js';
-import { cyan, dim, magenta, yellow, red } from '../colors.js';
+import { cyan, dim, magenta, yellow, red, claudeOrange } from '../colors.js';
 
 export function renderProjectLine(ctx: RenderContext): string | null {
   const display = ctx.config?.display;
@@ -87,6 +87,11 @@ export function renderProjectLine(ctx: RenderContext): string | null {
 
   if (display?.showDuration !== false && ctx.sessionDuration) {
     parts.push(dim(`⏱️  ${ctx.sessionDuration}`));
+  }
+
+  const customLine = display?.customLine;
+  if (customLine) {
+    parts.push(claudeOrange(customLine));
   }
 
   if (parts.length === 0) {

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -2,7 +2,7 @@ import type { RenderContext } from '../types.js';
 import { isLimitReached } from '../types.js';
 import { getContextPercent, getBufferedPercent, getModelName, getProviderLabel, getTotalTokens } from '../stdin.js';
 import { getOutputSpeed } from '../speed-tracker.js';
-import { coloredBar, critical, cyan, dim, magenta, red, warning, yellow, getContextColor, getQuotaColor, quotaBar, RESET } from './colors.js';
+import { coloredBar, critical, cyan, dim, magenta, red, warning, yellow, getContextColor, getQuotaColor, quotaBar, claudeOrange, RESET } from './colors.js';
 import { getAdaptiveBarWidth } from '../utils/terminal.js';
 
 const DEBUG = process.env.DEBUG?.includes('claude-hud') || process.env.DEBUG === '*';
@@ -205,6 +205,12 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   if (ctx.extraLabel) {
     parts.push(dim(ctx.extraLabel));
+  }
+
+  // Custom line (static user-defined text)
+  const customLine = display?.customLine;
+  if (customLine) {
+    parts.push(claudeOrange(customLine));
   }
 
   let line = parts.join(' | ');

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -88,6 +88,13 @@ test('mergeConfig preserves explicit showSessionName=true', () => {
   assert.equal(config.display.showSessionName, true);
 });
 
+test('mergeConfig preserves customLine and truncates long values', () => {
+  const customLine = 'x'.repeat(120);
+  const config = mergeConfig({ display: { customLine } });
+  assert.equal(config.display.customLine.length, 80);
+  assert.equal(config.display.customLine, customLine.slice(0, 80));
+});
+
 test('getConfigPath respects CLAUDE_CONFIG_DIR', async () => {
   const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
   const customConfigDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-config-dir-'));

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -257,6 +257,13 @@ test('renderSessionLine hides session name by default', () => {
   assert.ok(!line.includes('Renamed Session'));
 });
 
+test('renderSessionLine includes customLine when configured', () => {
+  const ctx = baseContext();
+  ctx.config.display.customLine = 'Ship it';
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('Ship it'));
+});
+
 test('renderProjectLine includes session name when showSessionName is true', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = '/tmp/my-project';
@@ -288,6 +295,14 @@ test('renderProjectLine hides session name by default', () => {
   ctx.transcript.sessionName = 'Renamed Session';
   const line = renderProjectLine(ctx);
   assert.ok(!line?.includes('Renamed Session'));
+});
+
+test('renderProjectLine includes customLine when configured', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.config.display.customLine = 'Stay sharp';
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(line.includes('Stay sharp'));
 });
 
 test('renderProjectLine includes duration when showDuration is true', () => {


### PR DESCRIPTION
## Summary

Add a static `display.customLine` config field that lets users display a custom phrase (motto, quote, etc.) directly in the HUD project line, rendered in Claude's signature orange color.

## Motivation

The existing `extraLabel` (via `--extra-cmd`) requires writing an external script that returns JSON — too heavy for a simple static phrase. This PR adds a lightweight `customLine` string field that just works from config.

## Changes

- **`src/config.ts`**: Add `customLine?: string` to `HudConfig.display` interface, default `''`, validated as string truncated to 80 chars
- **`src/render/colors.ts`**: Add `claudeOrange()` helper using 256-color escape (`\x1b[38;5;208m`)
- **`src/render/lines/project.ts`**: Append `customLine` as the last `│`-separated segment in expanded mode
- **`src/render/session-line.ts`**: Append `customLine` as the last `|`-separated part in compact mode
- **`commands/setup.md`**: Add "Custom line" option to Step 4 optional features
- **`commands/configure.md`**: Add Q5 "Custom Line" to both Flow A (new user) and Flow B (update config)

## Example

Config:
```json
{
  "display": {
    "customLine": "今日长缨在手 何时缚住苍龙"
  }
}
```

Output (expanded):
```
[Opus | Pro] │ my-project git:(main*) │ 今日长缨在手 何时缚住苍龙
Context ████░░░░░ 45% │ Usage ██░░░░░░░░ 25%
```

The custom text appears in Claude orange on the project line, consistent with the existing `│` separator style.

## Testing

```bash
echo '{"model":{"display_name":"Opus"},"context_window":{"current_usage":{"input_tokens":45000},"context_window_size":200000}}' | bun src/index.ts
```