### PR TITLE
fix: resolve unknown skill error for plugin commands

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,10 @@
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"
   },
+  "commands": [
+    "./commands/setup.md",
+    "./commands/configure.md"
+  ],
   "homepage": "https://github.com/jarrodwatts/claude-hud",
   "repository": "https://github.com/jarrodwatts/claude-hud",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "Real-time statusline HUD for Claude Code",
   "type": "module",
   "main": "dist/index.js",
+  "files": [
+    "dist/",
+    "src/",
+    "commands/",
+    ".claude-plugin/"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",


### PR DESCRIPTION
## Summary

Fixes #222 — `/claude-hud:setup` and `/claude-hud:configure` fail with "unknown skill" after plugin installation.

**Root cause**: The npm package shipped ~481 kB / 165 files (including test suites, CI workflows, preview images, `.github/` configs), slowing extraction during `/plugin install`. Claude Code may attempt to register commands before files are fully written. Additionally, commands relied solely on auto-discovery from the `commands/` directory.

**Changes**:
- **`package.json`**: Added `files` whitelist (`dist/`, `src/`, `commands/`, `.claude-plugin/`) — package drops from **481 kB → 98 kB** (5x reduction), 165 → 127 files
- **`.claude-plugin/plugin.json`**: Added explicit `commands` array pointing to `setup.md` and `configure.md` so Claude Code doesn't have to rely solely on directory auto-discovery

## Test plan
- [x] All 272 existing tests pass
- [x] `npm pack --dry-run` confirms commands/, dist/, src/, .claude-plugin/ are included
- [ ] Install plugin via `/plugin install claude-hud` and verify `/claude-hud:setup` works without restart
