### PR TITLE
feat: add showAccountEmail display option

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,7 @@ export interface HudConfig {
     showAgents: boolean;
     showTodos: boolean;
     showSessionName: boolean;
+    showAccountEmail: boolean;
     autocompactBuffer: AutocompactBufferMode;
     usageThreshold: number;
     sevenDayThreshold: number;
@@ -101,6 +102,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showAgents: false,
     showTodos: false,
     showSessionName: false,
+    showAccountEmail: false,
     autocompactBuffer: 'enabled',
     usageThreshold: 0,
     sevenDayThreshold: 80,
@@ -290,6 +292,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showSessionName: typeof migrated.display?.showSessionName === 'boolean'
       ? migrated.display.showSessionName
       : DEFAULT_CONFIG.display.showSessionName,
+    showAccountEmail: typeof migrated.display?.showAccountEmail === 'boolean'
+      ? migrated.display.showAccountEmail
+      : DEFAULT_CONFIG.display.showAccountEmail,
     autocompactBuffer: validateAutocompactBuffer(migrated.display?.autocompactBuffer)
       ? migrated.display.autocompactBuffer
       : DEFAULT_CONFIG.display.autocompactBuffer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { parseTranscript } from './transcript.js';
 import { render } from './render/index.js';
 import { countConfigs } from './config-reader.js';
 import { getGitStatus } from './git.js';
-import { getUsage } from './usage-api.js';
+import { getUsage, getAccountEmail } from './usage-api.js';
 import { loadConfig } from './config.js';
 import { parseExtraCmdArg, runExtraCmd } from './extra-cmd.js';
 import type { RenderContext } from './types.js';
@@ -68,6 +68,11 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
         })
       : null;
 
+    // Only fetch account email if enabled in config
+    const accountEmail = config.display.showAccountEmail
+      ? await getAccountEmail()
+      : null;
+
     const extraCmd = deps.parseExtraCmdArg();
     const extraLabel = extraCmd ? await deps.runExtraCmd(extraCmd) : null;
 
@@ -83,6 +88,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       sessionDuration,
       gitStatus,
       usageData,
+      accountEmail,
       config,
       extraLabel,
     };

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -69,6 +69,10 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     parts.push(gitPart);
   }
 
+  if (display?.showAccountEmail && ctx.accountEmail) {
+    parts.push(dim(ctx.accountEmail));
+  }
+
   if (display?.showSessionName && ctx.transcript.sessionName) {
     parts.push(dim(ctx.transcript.sessionName));
   }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -109,6 +109,11 @@ export function renderSessionLine(ctx: RenderContext): string {
     parts.push(gitPart);
   }
 
+  // Account email
+  if (display?.showAccountEmail && ctx.accountEmail) {
+    parts.push(dim(ctx.accountEmail));
+  }
+
   // Session name (custom title from /rename, or auto-generated slug)
   if (display?.showSessionName && ctx.transcript.sessionName) {
     parts.push(dim(ctx.transcript.sessionName));

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,7 @@ export interface RenderContext {
   sessionDuration: string;
   gitStatus: GitStatus | null;
   usageData: UsageData | null;
+  accountEmail: string | null;
   config: HudConfig;
   extraLabel: string | null;
 }

--- a/src/usage-api.ts
+++ b/src/usage-api.ts
@@ -1071,6 +1071,143 @@ export function parseRetryAfterSeconds(
   return retryAfterSeconds > 0 ? retryAfterSeconds : undefined;
 }
 
+// --- Account Email ---
+
+const EMAIL_CACHE_TTL_MS = 60 * 60_000; // 1 hour — email rarely changes
+const EMAIL_FAILURE_CACHE_TTL_MS = 5 * 60_000; // 5 min on failure
+
+interface EmailCacheFile {
+  email: string | null;
+  timestamp: number;
+  isFailure?: boolean;
+}
+
+function getEmailCachePath(homeDir: string): string {
+  return path.join(getHudPluginDir(homeDir), '.email-cache.json');
+}
+
+function readEmailCache(homeDir: string, now: number): string | null | undefined {
+  try {
+    const cachePath = getEmailCachePath(homeDir);
+    if (!fs.existsSync(cachePath)) return undefined;
+
+    const content = fs.readFileSync(cachePath, 'utf8');
+    const cache: EmailCacheFile = JSON.parse(content);
+    const ttl = cache.isFailure ? EMAIL_FAILURE_CACHE_TTL_MS : EMAIL_CACHE_TTL_MS;
+
+    if (now - cache.timestamp < ttl) {
+      return cache.email;
+    }
+    return undefined; // cache expired
+  } catch {
+    return undefined;
+  }
+}
+
+function writeEmailCache(homeDir: string, email: string | null, timestamp: number, isFailure?: boolean): void {
+  try {
+    const cachePath = getEmailCachePath(homeDir);
+    const cacheDir = path.dirname(cachePath);
+    if (!fs.existsSync(cacheDir)) {
+      fs.mkdirSync(cacheDir, { recursive: true });
+    }
+    const cache: EmailCacheFile = { email, timestamp, isFailure };
+    fs.writeFileSync(cachePath, JSON.stringify(cache), 'utf8');
+  } catch {
+    // Ignore cache write failures
+  }
+}
+
+function fetchEmailApi(accessToken: string): Promise<{ email: string | null; error?: string }> {
+  return new Promise((resolve) => {
+    const host = 'api.anthropic.com';
+    const timeoutMs = getUsageApiTimeoutMs();
+    const proxyUrl = getProxyUrl(host);
+    const options = {
+      hostname: host,
+      path: '/api/oauth/userinfo',
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'anthropic-beta': 'oauth-2025-04-20',
+        'User-Agent': USAGE_API_USER_AGENT,
+      },
+      timeout: timeoutMs,
+      agent: proxyUrl ? createProxyTunnelAgent(proxyUrl) : undefined,
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk: Buffer) => {
+        data += chunk.toString();
+      });
+      res.on('end', () => {
+        if (res.statusCode !== 200) {
+          debug('Email API returned non-200 status:', res.statusCode);
+          resolve({ email: null, error: `http-${res.statusCode}` });
+          return;
+        }
+        try {
+          const parsed = JSON.parse(data) as { email?: string };
+          resolve({ email: parsed.email ?? null });
+        } catch {
+          debug('Failed to parse email API response');
+          resolve({ email: null, error: 'parse' });
+        }
+      });
+    });
+
+    req.on('error', (error) => {
+      debug('Email API request error:', error);
+      resolve({ email: null, error: 'network' });
+    });
+    req.on('timeout', () => {
+      debug('Email API request timeout');
+      req.destroy();
+      resolve({ email: null, error: 'timeout' });
+    });
+
+    req.end();
+  });
+}
+
+/**
+ * Get the account email associated with the current OAuth credentials.
+ * Uses the Anthropic userinfo endpoint with file-based caching (1 hour TTL).
+ * Returns null if unavailable (API user, endpoint not found, etc.).
+ */
+export async function getAccountEmail(): Promise<string | null> {
+  const homeDir = os.homedir();
+  const now = Date.now();
+
+  // Skip if using custom API endpoint
+  if (isUsingCustomApiEndpoint()) {
+    return null;
+  }
+
+  // Check cache first
+  const cached = readEmailCache(homeDir, now);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  // Read credentials
+  const credentials = readCredentials(homeDir, now, readKeychainCredentials);
+  if (!credentials) {
+    return null;
+  }
+
+  // Fetch from API
+  const result = await fetchEmailApi(credentials.accessToken);
+  if (result.error) {
+    writeEmailCache(homeDir, null, now, true);
+    return null;
+  }
+
+  writeEmailCache(homeDir, result.email, now);
+  return result.email;
+}
+
 // Export for testing
 export function clearCache(homeDir?: string): void {
   if (homeDir) {


### PR DESCRIPTION
Add ability to display the Claude account email in the HUD status line. This helps identify which account is active, especially when switching between accounts or using shared machines.

- Add `showAccountEmail` boolean to display config (default: false)
- Fetch email from Anthropic OAuth userinfo API with 1-hour file cache
- Display in both compact (session line) and expanded (project line) layouts
- Reuse existing credential-reading and proxy/HTTPS infrastructure

## Summary

## Testing

- [ ] `npm test`
- [ ] `npm run test:coverage`

## Checklist

- [ ] Tests updated or not needed
- [ ] Docs updated if behavior changed
