### PR TITLE
feat: display Claude Code version in HUD (fixes #218)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export type LineLayoutType = 'compact' | 'expanded';
 
 export type AutocompactBufferMode = 'enabled' | 'disabled';
 export type ContextValueMode = 'percent' | 'tokens' | 'remaining';
-export type HudElement = 'project' | 'context' | 'usage' | 'environment' | 'tools' | 'agents' | 'todos';
+export type HudElement = 'project' | 'context' | 'usage' | 'environment' | 'version' | 'tools' | 'agents' | 'todos';
 export type HudColorName =
   | 'red'
   | 'green'
@@ -30,6 +30,7 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'context',
   'usage',
   'environment',
+  'version',
   'tools',
   'agents',
   'todos',
@@ -63,6 +64,7 @@ export interface HudConfig {
     showAgents: boolean;
     showTodos: boolean;
     showSessionName: boolean;
+    showClaudeCodeVersion: boolean;
     autocompactBuffer: AutocompactBufferMode;
     usageThreshold: number;
     sevenDayThreshold: number;
@@ -101,6 +103,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showAgents: false,
     showTodos: false,
     showSessionName: false,
+    showClaudeCodeVersion: false,
     autocompactBuffer: 'enabled',
     usageThreshold: 0,
     sevenDayThreshold: 80,
@@ -290,6 +293,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showSessionName: typeof migrated.display?.showSessionName === 'boolean'
       ? migrated.display.showSessionName
       : DEFAULT_CONFIG.display.showSessionName,
+    showClaudeCodeVersion: typeof migrated.display?.showClaudeCodeVersion === 'boolean'
+      ? migrated.display.showClaudeCodeVersion
+      : DEFAULT_CONFIG.display.showClaudeCodeVersion,
     autocompactBuffer: validateAutocompactBuffer(migrated.display?.autocompactBuffer)
       ? migrated.display.autocompactBuffer
       : DEFAULT_CONFIG.display.autocompactBuffer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,22 @@ import { parseExtraCmdArg, runExtraCmd } from './extra-cmd.js';
 import type { RenderContext } from './types.js';
 import { fileURLToPath } from 'node:url';
 import { realpathSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+let _cachedClaudeCodeVersion: string | undefined;
+
+function getClaudeCodeVersion(): string | undefined {
+  if (_cachedClaudeCodeVersion !== undefined) return _cachedClaudeCodeVersion || undefined;
+  try {
+    const output = execSync('claude --version', { timeout: 2000, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString().trim();
+    // Output is like "2.1.77 (Claude Code)" — extract just the version number
+    _cachedClaudeCodeVersion = output.split(' ')[0] ?? '';
+  } catch {
+    _cachedClaudeCodeVersion = '';
+  }
+  return _cachedClaudeCodeVersion || undefined;
+}
 
 export type MainDeps = {
   readStdin: typeof readStdin;
@@ -73,6 +89,8 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
 
     const sessionDuration = formatSessionDuration(transcript.sessionStart, deps.now);
 
+    const claudeCodeVersion = config.display.showClaudeCodeVersion ? getClaudeCodeVersion() : undefined;
+
     const ctx: RenderContext = {
       stdin,
       transcript,
@@ -85,6 +103,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       usageData,
       config,
       extraLabel,
+      claudeCodeVersion,
     };
 
     deps.render(ctx);

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -10,6 +10,7 @@ import {
   renderProjectLine,
   renderEnvironmentLine,
   renderUsageLine,
+  renderVersionLine,
 } from './lines/index.js';
 import { dim, RESET } from './colors.js';
 
@@ -339,6 +340,8 @@ function renderElementLine(ctx: RenderContext, element: HudElement): string | nu
       return renderUsageLine(ctx);
     case 'environment':
       return renderEnvironmentLine(ctx);
+    case 'version':
+      return renderVersionLine(ctx);
     case 'tools':
       return display?.showTools === false ? null : renderToolsLine(ctx);
     case 'agents':

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -2,3 +2,4 @@ export { renderIdentityLine } from './identity.js';
 export { renderProjectLine } from './project.js';
 export { renderEnvironmentLine } from './environment.js';
 export { renderUsageLine } from './usage.js';
+export { renderVersionLine } from './version.js';

--- a/src/render/lines/version.ts
+++ b/src/render/lines/version.ts
@@ -1,0 +1,14 @@
+import type { RenderContext } from '../../types.js';
+import { dim } from '../colors.js';
+
+export function renderVersionLine(ctx: RenderContext): string | null {
+  if (ctx.config?.display?.showClaudeCodeVersion !== true) {
+    return null;
+  }
+
+  if (!ctx.claudeCodeVersion) {
+    return null;
+  }
+
+  return dim(`CC v${ctx.claudeCodeVersion}`);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,4 +87,5 @@ export interface RenderContext {
   usageData: UsageData | null;
   config: HudConfig;
   extraLabel: string | null;
+  claudeCodeVersion?: string;
 }


### PR DESCRIPTION
Closes #218 

Adds a new 'showClaudeCodeVersion' option that displays running (C)laude (C)ode verison in the HUD (e.g. 'CC v2.1.77.')

Disabled by default, opt-in via config:
{ "display": { "showClaudeCodeVerison": true} }

<img width="804" height="77" alt="20260315_16h27m23s_grim" src="https://github.com/user-attachments/assets/e9ad66c2-74a0-41bf-bea8-644a3c346204" />

