### PR TITLE
feat: add customLine config option for user-defined HUD labels

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,21 +1,28 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as os from 'node:os';
-import { getHudPluginDir } from './claude-config-dir.js';
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { getHudPluginDir } from "./claude-config-dir.js";
 
-export type LineLayoutType = 'compact' | 'expanded';
+export type LineLayoutType = "compact" | "expanded";
 
-export type AutocompactBufferMode = 'enabled' | 'disabled';
-export type ContextValueMode = 'percent' | 'tokens' | 'remaining';
-export type HudElement = 'project' | 'context' | 'usage' | 'environment' | 'tools' | 'agents' | 'todos';
+export type AutocompactBufferMode = "enabled" | "disabled";
+export type ContextValueMode = "percent" | "tokens" | "remaining";
+export type HudElement =
+  | "project"
+  | "context"
+  | "usage"
+  | "environment"
+  | "tools"
+  | "agents"
+  | "todos";
 export type HudColorName =
-  | 'red'
-  | 'green'
-  | 'yellow'
-  | 'magenta'
-  | 'cyan'
-  | 'brightBlue'
-  | 'brightMagenta';
+  | "red"
+  | "green"
+  | "yellow"
+  | "magenta"
+  | "cyan"
+  | "brightBlue"
+  | "brightMagenta";
 
 export interface HudColorOverrides {
   context: HudColorName;
@@ -26,13 +33,13 @@ export interface HudColorOverrides {
 }
 
 export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
-  'project',
-  'context',
-  'usage',
-  'environment',
-  'tools',
-  'agents',
-  'todos',
+  "project",
+  "context",
+  "usage",
+  "environment",
+  "tools",
+  "agents",
+  "todos",
 ];
 
 const KNOWN_ELEMENTS = new Set<HudElement>(DEFAULT_ELEMENT_ORDER);
@@ -68,6 +75,7 @@ export interface HudConfig {
     sevenDayThreshold: number;
     environmentThreshold: number;
   };
+  customLine: string | null;
   usage: {
     cacheTtlSeconds: number;
     failureCacheTtlSeconds: number;
@@ -76,7 +84,7 @@ export interface HudConfig {
 }
 
 export const DEFAULT_CONFIG: HudConfig = {
-  lineLayout: 'expanded',
+  lineLayout: "expanded",
   showSeparators: false,
   pathLevels: 1,
   elementOrder: [...DEFAULT_ELEMENT_ORDER],
@@ -90,7 +98,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showModel: true,
     showProject: true,
     showContextBar: true,
-    contextValue: 'percent',
+    contextValue: "percent",
     showConfigCounts: false,
     showDuration: false,
     showSpeed: false,
@@ -101,27 +109,28 @@ export const DEFAULT_CONFIG: HudConfig = {
     showAgents: false,
     showTodos: false,
     showSessionName: false,
-    autocompactBuffer: 'enabled',
+    autocompactBuffer: "enabled",
     usageThreshold: 0,
     sevenDayThreshold: 80,
     environmentThreshold: 0,
   },
+  customLine: null,
   usage: {
     cacheTtlSeconds: 60,
     failureCacheTtlSeconds: 15,
   },
   colors: {
-    context: 'green',
-    usage: 'brightBlue',
-    warning: 'yellow',
-    usageWarning: 'brightMagenta',
-    critical: 'red',
+    context: "green",
+    usage: "brightBlue",
+    warning: "yellow",
+    usageWarning: "brightMagenta",
+    critical: "red",
   },
 };
 
 export function getConfigPath(): string {
   const homeDir = os.homedir();
-  return path.join(getHudPluginDir(homeDir), 'config.json');
+  return path.join(getHudPluginDir(homeDir), "config.json");
 }
 
 function validatePathLevels(value: unknown): value is 1 | 2 | 3 {
@@ -129,25 +138,29 @@ function validatePathLevels(value: unknown): value is 1 | 2 | 3 {
 }
 
 function validateLineLayout(value: unknown): value is LineLayoutType {
-  return value === 'compact' || value === 'expanded';
+  return value === "compact" || value === "expanded";
 }
 
-function validateAutocompactBuffer(value: unknown): value is AutocompactBufferMode {
-  return value === 'enabled' || value === 'disabled';
+function validateAutocompactBuffer(
+  value: unknown,
+): value is AutocompactBufferMode {
+  return value === "enabled" || value === "disabled";
 }
 
 function validateContextValue(value: unknown): value is ContextValueMode {
-  return value === 'percent' || value === 'tokens' || value === 'remaining';
+  return value === "percent" || value === "tokens" || value === "remaining";
 }
 
 function validateColorName(value: unknown): value is HudColorName {
-  return value === 'red'
-    || value === 'green'
-    || value === 'yellow'
-    || value === 'magenta'
-    || value === 'cyan'
-    || value === 'brightBlue'
-    || value === 'brightMagenta';
+  return (
+    value === "red" ||
+    value === "green" ||
+    value === "yellow" ||
+    value === "magenta" ||
+    value === "cyan" ||
+    value === "brightBlue" ||
+    value === "brightMagenta"
+  );
 }
 
 function validateElementOrder(value: unknown): HudElement[] {
@@ -159,7 +172,7 @@ function validateElementOrder(value: unknown): HudElement[] {
   const elementOrder: HudElement[] = [];
 
   for (const item of value) {
-    if (typeof item !== 'string' || !KNOWN_ELEMENTS.has(item as HudElement)) {
+    if (typeof item !== "string" || !KNOWN_ELEMENTS.has(item as HudElement)) {
       continue;
     }
 
@@ -176,28 +189,36 @@ function validateElementOrder(value: unknown): HudElement[] {
 }
 
 interface LegacyConfig {
-  layout?: 'default' | 'separators' | Record<string, unknown>;
+  layout?: "default" | "separators" | Record<string, unknown>;
 }
 
-function migrateConfig(userConfig: Partial<HudConfig> & LegacyConfig): Partial<HudConfig> {
+function migrateConfig(
+  userConfig: Partial<HudConfig> & LegacyConfig,
+): Partial<HudConfig> {
   const migrated = { ...userConfig } as Partial<HudConfig> & LegacyConfig;
 
-  if ('layout' in userConfig && !('lineLayout' in userConfig)) {
-    if (typeof userConfig.layout === 'string') {
+  if ("layout" in userConfig && !("lineLayout" in userConfig)) {
+    if (typeof userConfig.layout === "string") {
       // Legacy string migration (v0.0.x → v0.1.x)
-      if (userConfig.layout === 'separators') {
-        migrated.lineLayout = 'compact';
+      if (userConfig.layout === "separators") {
+        migrated.lineLayout = "compact";
         migrated.showSeparators = true;
       } else {
-        migrated.lineLayout = 'compact';
+        migrated.lineLayout = "compact";
         migrated.showSeparators = false;
       }
-    } else if (typeof userConfig.layout === 'object' && userConfig.layout !== null) {
+    } else if (
+      typeof userConfig.layout === "object" &&
+      userConfig.layout !== null
+    ) {
       // Object layout written by third-party tools — extract nested fields
       const obj = userConfig.layout as Record<string, unknown>;
-      if (typeof obj.lineLayout === 'string') migrated.lineLayout = obj.lineLayout as any;
-      if (typeof obj.showSeparators === 'boolean') migrated.showSeparators = obj.showSeparators;
-      if (typeof obj.pathLevels === 'number') migrated.pathLevels = obj.pathLevels as any;
+      if (typeof obj.lineLayout === "string")
+        migrated.lineLayout = obj.lineLayout as any;
+      if (typeof obj.showSeparators === "boolean")
+        migrated.showSeparators = obj.showSeparators;
+      if (typeof obj.pathLevels === "number")
+        migrated.pathLevels = obj.pathLevels as any;
     }
     delete migrated.layout;
   }
@@ -206,12 +227,13 @@ function migrateConfig(userConfig: Partial<HudConfig> & LegacyConfig): Partial<H
 }
 
 function validateThreshold(value: unknown, max = 100): number {
-  if (typeof value !== 'number') return 0;
+  if (typeof value !== "number") return 0;
   return Math.max(0, Math.min(max, value));
 }
 
 function validatePositiveInt(value: unknown, defaultValue: number): number {
-  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) return defaultValue;
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0)
+    return defaultValue;
   return value;
 }
 
@@ -222,90 +244,121 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     ? migrated.lineLayout
     : DEFAULT_CONFIG.lineLayout;
 
-  const showSeparators = typeof migrated.showSeparators === 'boolean'
-    ? migrated.showSeparators
-    : DEFAULT_CONFIG.showSeparators;
+  const showSeparators =
+    typeof migrated.showSeparators === "boolean"
+      ? migrated.showSeparators
+      : DEFAULT_CONFIG.showSeparators;
 
   const pathLevels = validatePathLevels(migrated.pathLevels)
     ? migrated.pathLevels
     : DEFAULT_CONFIG.pathLevels;
 
+  const customLine =
+    typeof migrated.customLine === "string"
+      ? migrated.customLine
+      : DEFAULT_CONFIG.customLine;
+
   const elementOrder = validateElementOrder(migrated.elementOrder);
 
   const gitStatus = {
-    enabled: typeof migrated.gitStatus?.enabled === 'boolean'
-      ? migrated.gitStatus.enabled
-      : DEFAULT_CONFIG.gitStatus.enabled,
-    showDirty: typeof migrated.gitStatus?.showDirty === 'boolean'
-      ? migrated.gitStatus.showDirty
-      : DEFAULT_CONFIG.gitStatus.showDirty,
-    showAheadBehind: typeof migrated.gitStatus?.showAheadBehind === 'boolean'
-      ? migrated.gitStatus.showAheadBehind
-      : DEFAULT_CONFIG.gitStatus.showAheadBehind,
-    showFileStats: typeof migrated.gitStatus?.showFileStats === 'boolean'
-      ? migrated.gitStatus.showFileStats
-      : DEFAULT_CONFIG.gitStatus.showFileStats,
+    enabled:
+      typeof migrated.gitStatus?.enabled === "boolean"
+        ? migrated.gitStatus.enabled
+        : DEFAULT_CONFIG.gitStatus.enabled,
+    showDirty:
+      typeof migrated.gitStatus?.showDirty === "boolean"
+        ? migrated.gitStatus.showDirty
+        : DEFAULT_CONFIG.gitStatus.showDirty,
+    showAheadBehind:
+      typeof migrated.gitStatus?.showAheadBehind === "boolean"
+        ? migrated.gitStatus.showAheadBehind
+        : DEFAULT_CONFIG.gitStatus.showAheadBehind,
+    showFileStats:
+      typeof migrated.gitStatus?.showFileStats === "boolean"
+        ? migrated.gitStatus.showFileStats
+        : DEFAULT_CONFIG.gitStatus.showFileStats,
   };
 
   const display = {
-    showModel: typeof migrated.display?.showModel === 'boolean'
-      ? migrated.display.showModel
-      : DEFAULT_CONFIG.display.showModel,
-    showProject: typeof migrated.display?.showProject === 'boolean'
-      ? migrated.display.showProject
-      : DEFAULT_CONFIG.display.showProject,
-    showContextBar: typeof migrated.display?.showContextBar === 'boolean'
-      ? migrated.display.showContextBar
-      : DEFAULT_CONFIG.display.showContextBar,
+    showModel:
+      typeof migrated.display?.showModel === "boolean"
+        ? migrated.display.showModel
+        : DEFAULT_CONFIG.display.showModel,
+    showProject:
+      typeof migrated.display?.showProject === "boolean"
+        ? migrated.display.showProject
+        : DEFAULT_CONFIG.display.showProject,
+    showContextBar:
+      typeof migrated.display?.showContextBar === "boolean"
+        ? migrated.display.showContextBar
+        : DEFAULT_CONFIG.display.showContextBar,
     contextValue: validateContextValue(migrated.display?.contextValue)
       ? migrated.display.contextValue
       : DEFAULT_CONFIG.display.contextValue,
-    showConfigCounts: typeof migrated.display?.showConfigCounts === 'boolean'
-      ? migrated.display.showConfigCounts
-      : DEFAULT_CONFIG.display.showConfigCounts,
-    showDuration: typeof migrated.display?.showDuration === 'boolean'
-      ? migrated.display.showDuration
-      : DEFAULT_CONFIG.display.showDuration,
-    showSpeed: typeof migrated.display?.showSpeed === 'boolean'
-      ? migrated.display.showSpeed
-      : DEFAULT_CONFIG.display.showSpeed,
-    showTokenBreakdown: typeof migrated.display?.showTokenBreakdown === 'boolean'
-      ? migrated.display.showTokenBreakdown
-      : DEFAULT_CONFIG.display.showTokenBreakdown,
-    showUsage: typeof migrated.display?.showUsage === 'boolean'
-      ? migrated.display.showUsage
-      : DEFAULT_CONFIG.display.showUsage,
-    usageBarEnabled: typeof migrated.display?.usageBarEnabled === 'boolean'
-      ? migrated.display.usageBarEnabled
-      : DEFAULT_CONFIG.display.usageBarEnabled,
-    showTools: typeof migrated.display?.showTools === 'boolean'
-      ? migrated.display.showTools
-      : DEFAULT_CONFIG.display.showTools,
-    showAgents: typeof migrated.display?.showAgents === 'boolean'
-      ? migrated.display.showAgents
-      : DEFAULT_CONFIG.display.showAgents,
-    showTodos: typeof migrated.display?.showTodos === 'boolean'
-      ? migrated.display.showTodos
-      : DEFAULT_CONFIG.display.showTodos,
-    showSessionName: typeof migrated.display?.showSessionName === 'boolean'
-      ? migrated.display.showSessionName
-      : DEFAULT_CONFIG.display.showSessionName,
-    autocompactBuffer: validateAutocompactBuffer(migrated.display?.autocompactBuffer)
+    showConfigCounts:
+      typeof migrated.display?.showConfigCounts === "boolean"
+        ? migrated.display.showConfigCounts
+        : DEFAULT_CONFIG.display.showConfigCounts,
+    showDuration:
+      typeof migrated.display?.showDuration === "boolean"
+        ? migrated.display.showDuration
+        : DEFAULT_CONFIG.display.showDuration,
+    showSpeed:
+      typeof migrated.display?.showSpeed === "boolean"
+        ? migrated.display.showSpeed
+        : DEFAULT_CONFIG.display.showSpeed,
+    showTokenBreakdown:
+      typeof migrated.display?.showTokenBreakdown === "boolean"
+        ? migrated.display.showTokenBreakdown
+        : DEFAULT_CONFIG.display.showTokenBreakdown,
+    showUsage:
+      typeof migrated.display?.showUsage === "boolean"
+        ? migrated.display.showUsage
+        : DEFAULT_CONFIG.display.showUsage,
+    usageBarEnabled:
+      typeof migrated.display?.usageBarEnabled === "boolean"
+        ? migrated.display.usageBarEnabled
+        : DEFAULT_CONFIG.display.usageBarEnabled,
+    showTools:
+      typeof migrated.display?.showTools === "boolean"
+        ? migrated.display.showTools
+        : DEFAULT_CONFIG.display.showTools,
+    showAgents:
+      typeof migrated.display?.showAgents === "boolean"
+        ? migrated.display.showAgents
+        : DEFAULT_CONFIG.display.showAgents,
+    showTodos:
+      typeof migrated.display?.showTodos === "boolean"
+        ? migrated.display.showTodos
+        : DEFAULT_CONFIG.display.showTodos,
+    showSessionName:
+      typeof migrated.display?.showSessionName === "boolean"
+        ? migrated.display.showSessionName
+        : DEFAULT_CONFIG.display.showSessionName,
+    autocompactBuffer: validateAutocompactBuffer(
+      migrated.display?.autocompactBuffer,
+    )
       ? migrated.display.autocompactBuffer
       : DEFAULT_CONFIG.display.autocompactBuffer,
     usageThreshold: validateThreshold(migrated.display?.usageThreshold, 100),
-    sevenDayThreshold: validateThreshold(migrated.display?.sevenDayThreshold, 100),
-    environmentThreshold: validateThreshold(migrated.display?.environmentThreshold, 100),
+    sevenDayThreshold: validateThreshold(
+      migrated.display?.sevenDayThreshold,
+      100,
+    ),
+    environmentThreshold: validateThreshold(
+      migrated.display?.environmentThreshold,
+      100,
+    ),
   };
 
   const usage = {
     cacheTtlSeconds: validatePositiveInt(
       migrated.usage?.cacheTtlSeconds,
-      DEFAULT_CONFIG.usage.cacheTtlSeconds
+      DEFAULT_CONFIG.usage.cacheTtlSeconds,
     ),
     failureCacheTtlSeconds: validatePositiveInt(
       migrated.usage?.failureCacheTtlSeconds,
-      DEFAULT_CONFIG.usage.failureCacheTtlSeconds
+      DEFAULT_CONFIG.usage.failureCacheTtlSeconds,
     ),
   };
 
@@ -327,7 +380,17 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
       : DEFAULT_CONFIG.colors.critical,
   };
 
-  return { lineLayout, showSeparators, pathLevels, elementOrder, gitStatus, display, usage, colors };
+  return {
+    lineLayout,
+    showSeparators,
+    pathLevels,
+    customLine,
+    elementOrder,
+    gitStatus,
+    display,
+    usage,
+    colors,
+  };
 }
 
 export async function loadConfig(): Promise<HudConfig> {
@@ -338,7 +401,7 @@ export async function loadConfig(): Promise<HudConfig> {
       return DEFAULT_CONFIG;
     }
 
-    const content = fs.readFileSync(configPath, 'utf-8');
+    const content = fs.readFileSync(configPath, "utf-8");
     const userConfig = JSON.parse(content) as Partial<HudConfig>;
     return mergeConfig(userConfig);
   } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,14 @@
-import { readStdin } from './stdin.js';
-import { parseTranscript } from './transcript.js';
-import { render } from './render/index.js';
-import { countConfigs } from './config-reader.js';
-import { getGitStatus } from './git.js';
-import { getUsage } from './usage-api.js';
-import { loadConfig } from './config.js';
-import { parseExtraCmdArg, runExtraCmd } from './extra-cmd.js';
-import type { RenderContext } from './types.js';
-import { fileURLToPath } from 'node:url';
-import { realpathSync } from 'node:fs';
+import { readStdin } from "./stdin.js";
+import { parseTranscript } from "./transcript.js";
+import { render } from "./render/index.js";
+import { countConfigs } from "./config-reader.js";
+import { getGitStatus } from "./git.js";
+import { getUsage } from "./usage-api.js";
+import { loadConfig } from "./config.js";
+import { parseExtraCmdArg, runExtraCmd } from "./extra-cmd.js";
+import type { RenderContext } from "./types.js";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 export type MainDeps = {
   readStdin: typeof readStdin;
@@ -44,14 +44,15 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     const stdin = await deps.readStdin();
 
     if (!stdin) {
-      deps.log('[claude-hud] Initializing...');
+      deps.log("[claude-hud] Initializing...");
       return;
     }
 
-    const transcriptPath = stdin.transcript_path ?? '';
+    const transcriptPath = stdin.transcript_path ?? "";
     const transcript = await deps.parseTranscript(transcriptPath);
 
-    const { claudeMdCount, rulesCount, mcpCount, hooksCount } = await deps.countConfigs(stdin.cwd);
+    const { claudeMdCount, rulesCount, mcpCount, hooksCount } =
+      await deps.countConfigs(stdin.cwd);
 
     const config = await deps.loadConfig();
     const gitStatus = config.gitStatus.enabled
@@ -59,19 +60,23 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       : null;
 
     // Only fetch usage if enabled in config (replaces env var requirement)
-    const usageData = config.display.showUsage !== false
-      ? await deps.getUsage({
-          ttls: {
-            cacheTtlMs: config.usage.cacheTtlSeconds * 1000,
-            failureCacheTtlMs: config.usage.failureCacheTtlSeconds * 1000,
-          },
-        })
-      : null;
+    const usageData =
+      config.display.showUsage !== false
+        ? await deps.getUsage({
+            ttls: {
+              cacheTtlMs: config.usage.cacheTtlSeconds * 1000,
+              failureCacheTtlMs: config.usage.failureCacheTtlSeconds * 1000,
+            },
+          })
+        : null;
 
-    const extraCmd = deps.parseExtraCmdArg();
+    const extraCmd = deps.parseExtraCmdArg() ?? config.customLine;
     const extraLabel = extraCmd ? await deps.runExtraCmd(extraCmd) : null;
 
-    const sessionDuration = formatSessionDuration(transcript.sessionStart, deps.now);
+    const sessionDuration = formatSessionDuration(
+      transcript.sessionStart,
+      deps.now,
+    );
 
     const ctx: RenderContext = {
       stdin,
@@ -89,19 +94,25 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
 
     deps.render(ctx);
   } catch (error) {
-    deps.log('[claude-hud] Error:', error instanceof Error ? error.message : 'Unknown error');
+    deps.log(
+      "[claude-hud] Error:",
+      error instanceof Error ? error.message : "Unknown error",
+    );
   }
 }
 
-export function formatSessionDuration(sessionStart?: Date, now: () => number = () => Date.now()): string {
+export function formatSessionDuration(
+  sessionStart?: Date,
+  now: () => number = () => Date.now(),
+): string {
   if (!sessionStart) {
-    return '';
+    return "";
   }
 
   const ms = now() - sessionStart.getTime();
   const mins = Math.floor(ms / 60000);
 
-  if (mins < 1) return '<1m';
+  if (mins < 1) return "<1m";
   if (mins < 60) return `${mins}m`;
 
   const hours = Math.floor(mins / 60);

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,16 +1,16 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test } from "node:test";
+import assert from "node:assert/strict";
 import {
   loadConfig,
   getConfigPath,
   mergeConfig,
   DEFAULT_CONFIG,
   DEFAULT_ELEMENT_ORDER,
-} from '../dist/config.js';
-import * as path from 'node:path';
-import * as os from 'node:os';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+} from "../dist/config.js";
+import * as path from "node:path";
+import * as os from "node:os";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 
 function restoreEnvVar(name, value) {
   if (value === undefined) {
@@ -20,112 +20,142 @@ function restoreEnvVar(name, value) {
   process.env[name] = value;
 }
 
-test('loadConfig returns valid config structure', async () => {
+test("loadConfig returns valid config structure", async () => {
   const config = await loadConfig();
 
   // pathLevels must be 1, 2, or 3
-  assert.ok([1, 2, 3].includes(config.pathLevels), 'pathLevels should be 1, 2, or 3');
+  assert.ok(
+    [1, 2, 3].includes(config.pathLevels),
+    "pathLevels should be 1, 2, or 3",
+  );
 
   // lineLayout must be valid
-  const validLineLayouts = ['compact', 'expanded'];
-  assert.ok(validLineLayouts.includes(config.lineLayout), 'lineLayout should be valid');
+  const validLineLayouts = ["compact", "expanded"];
+  assert.ok(
+    validLineLayouts.includes(config.lineLayout),
+    "lineLayout should be valid",
+  );
 
   // showSeparators must be boolean
-  assert.equal(typeof config.showSeparators, 'boolean', 'showSeparators should be boolean');
-  assert.ok(Array.isArray(config.elementOrder), 'elementOrder should be an array');
-  assert.ok(config.elementOrder.length > 0, 'elementOrder should not be empty');
-  assert.deepEqual(config.elementOrder, DEFAULT_ELEMENT_ORDER, 'elementOrder should default to the full expanded layout');
+  assert.equal(
+    typeof config.showSeparators,
+    "boolean",
+    "showSeparators should be boolean",
+  );
+  assert.ok(
+    Array.isArray(config.elementOrder),
+    "elementOrder should be an array",
+  );
+  assert.ok(config.elementOrder.length > 0, "elementOrder should not be empty");
+  assert.deepEqual(
+    config.elementOrder,
+    DEFAULT_ELEMENT_ORDER,
+    "elementOrder should default to the full expanded layout",
+  );
 
   // gitStatus object with expected properties
-  assert.equal(typeof config.gitStatus, 'object');
-  assert.equal(typeof config.gitStatus.enabled, 'boolean');
-  assert.equal(typeof config.gitStatus.showDirty, 'boolean');
-  assert.equal(typeof config.gitStatus.showAheadBehind, 'boolean');
+  assert.equal(typeof config.gitStatus, "object");
+  assert.equal(typeof config.gitStatus.enabled, "boolean");
+  assert.equal(typeof config.gitStatus.showDirty, "boolean");
+  assert.equal(typeof config.gitStatus.showAheadBehind, "boolean");
 
   // display object with expected properties
-  assert.equal(typeof config.display, 'object');
-  assert.equal(typeof config.display.showModel, 'boolean');
-  assert.equal(typeof config.display.showContextBar, 'boolean');
-  assert.ok(['percent', 'tokens', 'remaining'].includes(config.display.contextValue), 'contextValue should be valid');
-  assert.equal(typeof config.display.showConfigCounts, 'boolean');
-  assert.equal(typeof config.display.showDuration, 'boolean');
-  assert.equal(typeof config.display.showSpeed, 'boolean');
-  assert.equal(typeof config.display.showTokenBreakdown, 'boolean');
-  assert.equal(typeof config.display.showUsage, 'boolean');
-  assert.equal(typeof config.display.showTools, 'boolean');
-  assert.equal(typeof config.display.showAgents, 'boolean');
-  assert.equal(typeof config.display.showTodos, 'boolean');
-  assert.equal(typeof config.display.showSessionName, 'boolean');
-  assert.equal(typeof config.colors, 'object');
-  assert.equal(typeof config.colors.context, 'string');
-  assert.equal(typeof config.colors.usage, 'string');
-  assert.equal(typeof config.colors.warning, 'string');
-  assert.equal(typeof config.colors.usageWarning, 'string');
-  assert.equal(typeof config.colors.critical, 'string');
+  assert.equal(typeof config.display, "object");
+  assert.equal(typeof config.display.showModel, "boolean");
+  assert.equal(typeof config.display.showContextBar, "boolean");
+  assert.ok(
+    ["percent", "tokens", "remaining"].includes(config.display.contextValue),
+    "contextValue should be valid",
+  );
+  assert.equal(typeof config.display.showConfigCounts, "boolean");
+  assert.equal(typeof config.display.showDuration, "boolean");
+  assert.equal(typeof config.display.showSpeed, "boolean");
+  assert.equal(typeof config.display.showTokenBreakdown, "boolean");
+  assert.equal(typeof config.display.showUsage, "boolean");
+  assert.equal(typeof config.display.showTools, "boolean");
+  assert.equal(typeof config.display.showAgents, "boolean");
+  assert.equal(typeof config.display.showTodos, "boolean");
+  assert.equal(typeof config.display.showSessionName, "boolean");
+  assert.equal(typeof config.colors, "object");
+  assert.equal(typeof config.colors.context, "string");
+  assert.equal(typeof config.colors.usage, "string");
+  assert.equal(typeof config.colors.warning, "string");
+  assert.equal(typeof config.colors.usageWarning, "string");
+  assert.equal(typeof config.colors.critical, "string");
 });
 
-test('getConfigPath returns correct path', () => {
+test("getConfigPath returns correct path", () => {
   const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
   delete process.env.CLAUDE_CONFIG_DIR;
 
   try {
     const configPath = getConfigPath();
     const homeDir = os.homedir();
-    assert.equal(configPath, path.join(homeDir, '.claude', 'plugins', 'claude-hud', 'config.json'));
+    assert.equal(
+      configPath,
+      path.join(homeDir, ".claude", "plugins", "claude-hud", "config.json"),
+    );
   } finally {
-    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    restoreEnvVar("CLAUDE_CONFIG_DIR", originalConfigDir);
   }
 });
 
-test('mergeConfig defaults showSessionName to false', () => {
+test("mergeConfig defaults showSessionName to false", () => {
   const config = mergeConfig({});
   assert.equal(config.display.showSessionName, false);
   assert.equal(DEFAULT_CONFIG.display.showSessionName, false);
 });
 
-test('mergeConfig preserves explicit showSessionName=true', () => {
+test("mergeConfig preserves explicit showSessionName=true", () => {
   const config = mergeConfig({ display: { showSessionName: true } });
   assert.equal(config.display.showSessionName, true);
 });
 
-test('getConfigPath respects CLAUDE_CONFIG_DIR', async () => {
+test("getConfigPath respects CLAUDE_CONFIG_DIR", async () => {
   const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
-  const customConfigDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-config-dir-'));
+  const customConfigDir = await mkdtemp(
+    path.join(tmpdir(), "claude-hud-config-dir-"),
+  );
 
   try {
     process.env.CLAUDE_CONFIG_DIR = customConfigDir;
     const configPath = getConfigPath();
-    assert.equal(configPath, path.join(customConfigDir, 'plugins', 'claude-hud', 'config.json'));
+    assert.equal(
+      configPath,
+      path.join(customConfigDir, "plugins", "claude-hud", "config.json"),
+    );
   } finally {
-    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    restoreEnvVar("CLAUDE_CONFIG_DIR", originalConfigDir);
     await rm(customConfigDir, { recursive: true, force: true });
   }
 });
 
-test('loadConfig reads user config from CLAUDE_CONFIG_DIR', async () => {
+test("loadConfig reads user config from CLAUDE_CONFIG_DIR", async () => {
   const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
-  const customConfigDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-config-load-'));
+  const customConfigDir = await mkdtemp(
+    path.join(tmpdir(), "claude-hud-config-load-"),
+  );
 
   try {
     process.env.CLAUDE_CONFIG_DIR = customConfigDir;
-    const pluginDir = path.join(customConfigDir, 'plugins', 'claude-hud');
+    const pluginDir = path.join(customConfigDir, "plugins", "claude-hud");
     await mkdir(pluginDir, { recursive: true });
     await writeFile(
-      path.join(pluginDir, 'config.json'),
+      path.join(pluginDir, "config.json"),
       JSON.stringify({
-        lineLayout: 'compact',
+        lineLayout: "compact",
         pathLevels: 2,
         display: { showSpeed: true },
       }),
-      'utf8'
+      "utf8",
     );
 
     const config = await loadConfig();
-    assert.equal(config.lineLayout, 'compact');
+    assert.equal(config.lineLayout, "compact");
     assert.equal(config.pathLevels, 2);
     assert.equal(config.display.showSpeed, true);
   } finally {
-    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    restoreEnvVar("CLAUDE_CONFIG_DIR", originalConfigDir);
     await rm(customConfigDir, { recursive: true, force: true });
   }
 });
@@ -133,27 +163,27 @@ test('loadConfig reads user config from CLAUDE_CONFIG_DIR', async () => {
 // --- migrateConfig tests (via mergeConfig) ---
 
 test('migrate legacy layout: "default" -> compact, no separators', () => {
-  const config = mergeConfig({ layout: 'default' });
-  assert.equal(config.lineLayout, 'compact');
+  const config = mergeConfig({ layout: "default" });
+  assert.equal(config.lineLayout, "compact");
   assert.equal(config.showSeparators, false);
 });
 
 test('migrate legacy layout: "separators" -> compact, with separators', () => {
-  const config = mergeConfig({ layout: 'separators' });
-  assert.equal(config.lineLayout, 'compact');
+  const config = mergeConfig({ layout: "separators" });
+  assert.equal(config.lineLayout, "compact");
   assert.equal(config.showSeparators, true);
 });
 
-test('migrate object layout: extracts nested fields to top level', () => {
+test("migrate object layout: extracts nested fields to top level", () => {
   const config = mergeConfig({
-    layout: { lineLayout: 'expanded', showSeparators: true, pathLevels: 2 },
+    layout: { lineLayout: "expanded", showSeparators: true, pathLevels: 2 },
   });
-  assert.equal(config.lineLayout, 'expanded');
+  assert.equal(config.lineLayout, "expanded");
   assert.equal(config.showSeparators, true);
   assert.equal(config.pathLevels, 2);
 });
 
-test('migrate object layout: empty object does not crash', () => {
+test("migrate object layout: empty object does not crash", () => {
   const config = mergeConfig({ layout: {} });
   // Should fall back to defaults since no fields were extracted
   assert.equal(config.lineLayout, DEFAULT_CONFIG.lineLayout);
@@ -161,106 +191,144 @@ test('migrate object layout: empty object does not crash', () => {
   assert.equal(config.pathLevels, DEFAULT_CONFIG.pathLevels);
 });
 
-test('no layout key -> no migration, uses defaults', () => {
+test("no layout key -> no migration, uses defaults", () => {
   const config = mergeConfig({});
   assert.equal(config.lineLayout, DEFAULT_CONFIG.lineLayout);
   assert.equal(config.showSeparators, DEFAULT_CONFIG.showSeparators);
 });
 
-test('both layout and lineLayout present -> layout ignored', () => {
-  const config = mergeConfig({ layout: 'separators', lineLayout: 'expanded' });
+test("both layout and lineLayout present -> layout ignored", () => {
+  const config = mergeConfig({ layout: "separators", lineLayout: "expanded" });
   // When lineLayout is already present, migration should not run
-  assert.equal(config.lineLayout, 'expanded');
+  assert.equal(config.lineLayout, "expanded");
   assert.equal(config.showSeparators, DEFAULT_CONFIG.showSeparators);
 });
 
-test('mergeConfig accepts contextValue=remaining', () => {
+test("mergeConfig accepts contextValue=remaining", () => {
   const config = mergeConfig({
     display: {
-      contextValue: 'remaining',
+      contextValue: "remaining",
     },
   });
-  assert.equal(config.display.contextValue, 'remaining');
+  assert.equal(config.display.contextValue, "remaining");
 });
 
-test('mergeConfig falls back to default for invalid contextValue', () => {
+test("mergeConfig falls back to default for invalid contextValue", () => {
   const config = mergeConfig({
     display: {
-      contextValue: 'invalid-mode',
+      contextValue: "invalid-mode",
     },
   });
-  assert.equal(config.display.contextValue, DEFAULT_CONFIG.display.contextValue);
+  assert.equal(
+    config.display.contextValue,
+    DEFAULT_CONFIG.display.contextValue,
+  );
 });
 
-test('mergeConfig defaults elementOrder to the full expanded layout', () => {
+test("mergeConfig defaults elementOrder to the full expanded layout", () => {
   const config = mergeConfig({});
   assert.deepEqual(config.elementOrder, DEFAULT_ELEMENT_ORDER);
 });
 
-test('mergeConfig preserves valid custom elementOrder including activity elements', () => {
+test("mergeConfig preserves valid custom elementOrder including activity elements", () => {
   const config = mergeConfig({
-    elementOrder: ['tools', 'project', 'usage', 'context', 'agents', 'todos', 'environment'],
+    elementOrder: [
+      "tools",
+      "project",
+      "usage",
+      "context",
+      "agents",
+      "todos",
+      "environment",
+    ],
   });
+  assert.deepEqual(config.elementOrder, [
+    "tools",
+    "project",
+    "usage",
+    "context",
+    "agents",
+    "todos",
+    "environment",
+  ]);
+});
+
+test("mergeConfig filters unknown entries and de-duplicates elementOrder", () => {
+  const config = mergeConfig({
+    elementOrder: [
+      "project",
+      "agents",
+      "project",
+      "banana",
+      "usage",
+      "agents",
+      "context",
+    ],
+  });
+  assert.deepEqual(config.elementOrder, [
+    "project",
+    "agents",
+    "usage",
+    "context",
+  ]);
+});
+
+test("mergeConfig treats elementOrder as an explicit expanded-mode filter", () => {
+  const config = mergeConfig({
+    elementOrder: ["usage", "project"],
+  });
+  assert.deepEqual(config.elementOrder, ["usage", "project"]);
+});
+
+test("mergeConfig falls back to default when elementOrder is empty or invalid", () => {
   assert.deepEqual(
-    config.elementOrder,
-    ['tools', 'project', 'usage', 'context', 'agents', 'todos', 'environment']
+    mergeConfig({ elementOrder: [] }).elementOrder,
+    DEFAULT_ELEMENT_ORDER,
+  );
+  assert.deepEqual(
+    mergeConfig({ elementOrder: ["unknown"] }).elementOrder,
+    DEFAULT_ELEMENT_ORDER,
+  );
+  assert.deepEqual(
+    mergeConfig({ elementOrder: "project" }).elementOrder,
+    DEFAULT_ELEMENT_ORDER,
   );
 });
 
-test('mergeConfig filters unknown entries and de-duplicates elementOrder', () => {
-  const config = mergeConfig({
-    elementOrder: ['project', 'agents', 'project', 'banana', 'usage', 'agents', 'context'],
-  });
-  assert.deepEqual(config.elementOrder, ['project', 'agents', 'usage', 'context']);
-});
-
-test('mergeConfig treats elementOrder as an explicit expanded-mode filter', () => {
-  const config = mergeConfig({
-    elementOrder: ['usage', 'project'],
-  });
-  assert.deepEqual(config.elementOrder, ['usage', 'project']);
-});
-
-test('mergeConfig falls back to default when elementOrder is empty or invalid', () => {
-  assert.deepEqual(mergeConfig({ elementOrder: [] }).elementOrder, DEFAULT_ELEMENT_ORDER);
-  assert.deepEqual(mergeConfig({ elementOrder: ['unknown'] }).elementOrder, DEFAULT_ELEMENT_ORDER);
-  assert.deepEqual(mergeConfig({ elementOrder: 'project' }).elementOrder, DEFAULT_ELEMENT_ORDER);
-});
-
-test('mergeConfig defaults usage to expected values', () => {
+test("mergeConfig defaults usage to expected values", () => {
   const config = mergeConfig({});
   assert.equal(config.usage.cacheTtlSeconds, 60);
   assert.equal(config.usage.failureCacheTtlSeconds, 15);
 });
 
-test('mergeConfig defaults colors to expected semantic palette', () => {
+test("mergeConfig defaults colors to expected semantic palette", () => {
   const config = mergeConfig({});
-  assert.equal(config.colors.context, 'green');
-  assert.equal(config.colors.usage, 'brightBlue');
-  assert.equal(config.colors.warning, 'yellow');
-  assert.equal(config.colors.usageWarning, 'brightMagenta');
-  assert.equal(config.colors.critical, 'red');
+  assert.equal(config.colors.context, "green");
+  assert.equal(config.colors.usage, "brightBlue");
+  assert.equal(config.colors.warning, "yellow");
+  assert.equal(config.colors.usageWarning, "brightMagenta");
+  assert.equal(config.colors.critical, "red");
 });
 
-test('mergeConfig accepts valid color overrides and filters invalid values', () => {
+test("mergeConfig accepts valid color overrides and filters invalid values", () => {
   const config = mergeConfig({
     colors: {
-      context: 'cyan',
-      usage: 'magenta',
-      warning: 'brightBlue',
-      usageWarning: 'yellow',
-      critical: 'not-a-color',
+      context: "cyan",
+      usage: "magenta",
+      warning: "brightBlue",
+      usageWarning: "yellow",
+      critical: "not-a-color",
     },
   });
 
-  assert.equal(config.colors.context, 'cyan');
-  assert.equal(config.colors.usage, 'magenta');
-  assert.equal(config.colors.warning, 'brightBlue');
-  assert.equal(config.colors.usageWarning, 'yellow');
+  assert.equal(config.colors.context, "cyan");
+  assert.equal(config.colors.usage, "magenta");
+  assert.equal(config.colors.warning, "brightBlue");
+  assert.equal(config.colors.usageWarning, "yellow");
   assert.equal(config.colors.critical, DEFAULT_CONFIG.colors.critical);
 });
 
-test('mergeConfig accepts custom usage TTL values', () => {
+test("mergeConfig accepts custom usage TTL values", () => {
   const config = mergeConfig({
     usage: { cacheTtlSeconds: 120, failureCacheTtlSeconds: 30 },
   });
@@ -268,10 +336,38 @@ test('mergeConfig accepts custom usage TTL values', () => {
   assert.equal(config.usage.failureCacheTtlSeconds, 30);
 });
 
-test('mergeConfig falls back to defaults for invalid usage values', () => {
+test("mergeConfig falls back to defaults for invalid usage values", () => {
   const config = mergeConfig({
     usage: { cacheTtlSeconds: -1, failureCacheTtlSeconds: 0 },
   });
-  assert.equal(config.usage.cacheTtlSeconds, DEFAULT_CONFIG.usage.cacheTtlSeconds);
-  assert.equal(config.usage.failureCacheTtlSeconds, DEFAULT_CONFIG.usage.failureCacheTtlSeconds);
+  assert.equal(
+    config.usage.cacheTtlSeconds,
+    DEFAULT_CONFIG.usage.cacheTtlSeconds,
+  );
+  assert.equal(
+    config.usage.failureCacheTtlSeconds,
+    DEFAULT_CONFIG.usage.failureCacheTtlSeconds,
+  );
+});
+
+// --- customLine tests ---
+
+test("mergeConfig defaults customLine to null", () => {
+  const config = mergeConfig({});
+  assert.equal(config.customLine, null);
+});
+
+test("mergeConfig preserves valid customLine string", () => {
+  const config = mergeConfig({ customLine: 'echo \'{"label": "hello"}\'' });
+  assert.equal(config.customLine, 'echo \'{"label": "hello"}\'');
+});
+
+test("mergeConfig rejects non-string customLine", () => {
+  const config = mergeConfig({ customLine: 123 });
+  assert.equal(config.customLine, null);
+});
+
+test("mergeConfig rejects boolean customLine", () => {
+  const config = mergeConfig({ customLine: true });
+  assert.equal(config.customLine, null);
 });


### PR DESCRIPTION
The existing --extra-cmd CLI argument lets users display custom labels, but requires modifying the statusLine command in settings.json. This adds a `customLine` config option that serves as a declarative alternative.

When set in config.json, it runs the specified shell command and displays the result as a dimmed label. The command must output JSON: {"label": "text"}. CLI --extra-cmd still takes priority when both are specified.

Example use case: displaying account email by resolving local credentials, since the Anthropic OAuth userinfo API is not yet available for individual users.

## Summary

## Testing

- [ ] `npm test`
- [ ] `npm run test:coverage`

## Checklist

- [ ] Tests updated or not needed
- [ ] Docs updated if behavior changed
