### PR TITLE
fix: treat null timestamp lock files as stale

### DIFF
--- a/dist/usage-api.js
+++ b/dist/usage-api.js
@@ -212,7 +212,7 @@ function tryAcquireCacheLock(homeDir) {
         }
         return tryAcquireCacheLock(homeDir);
     }
-    if (lockTimestamp != null && Date.now() - lockTimestamp > CACHE_LOCK_STALE_MS) {
+    if (lockTimestamp == null || Date.now() - lockTimestamp > CACHE_LOCK_STALE_MS) {
         try {
             fs.unlinkSync(lockPath);
         }

--- a/src/usage-api.ts
+++ b/src/usage-api.ts
@@ -289,7 +289,7 @@ function tryAcquireCacheLock(homeDir: string): CacheLockStatus {
     return tryAcquireCacheLock(homeDir);
   }
 
-  if (lockTimestamp != null && Date.now() - lockTimestamp > CACHE_LOCK_STALE_MS) {
+  if (lockTimestamp == null || Date.now() - lockTimestamp > CACHE_LOCK_STALE_MS) {
     try {
       fs.unlinkSync(lockPath);
     } catch {


### PR DESCRIPTION
Fixes #220 - 0-byte lock file permanently blocks usage display

When a lock file exists but is 0 bytes (created but not written to
due to process crash between fs.openSync and fs.writeFileSync),
readLockTimestamp returns null.

The stale-lock check was:
  if (lockTimestamp != null && Date.now() - lockTimestamp > CACHE_LOCK_STALE_MS)

Since lockTimestamp IS null for 0-byte files, the condition is FALSE
and the stale check is skipped entirely. This causes the lock to be
treated as 'busy' forever, silently blocking usage display.

The fix treats null timestamp (corrupt/empty lock file) as stale,
matching the intent of the stale-lock mechanism.