### PR TITLE
feat(usage): Add MiniMax usage tracking support

### DIFF
--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -15,7 +15,8 @@ export function renderUsageLine(ctx: RenderContext): string | null {
     return null;
   }
 
-  if (getProviderLabel(ctx.stdin)) {
+  const providerLabel = getProviderLabel(ctx.stdin);
+  if (providerLabel && providerLabel !== 'MiniMax') {
     return null;
   }
 

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -139,7 +139,7 @@ export function renderSessionLine(ctx: RenderContext): string {
   }
 
   // Usage limits display (shown when enabled in config, respects usageThreshold)
-  if (display?.showUsage !== false && ctx.usageData?.planName && !providerLabel) {
+  if (display?.showUsage !== false && ctx.usageData?.planName && providerLabel !== 'Bedrock') {
     if (ctx.usageData.apiUnavailable) {
       const errorHint = formatUsageError(ctx.usageData.apiError);
       parts.push(warning(`usage: ⚠${errorHint}`, colors));

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -111,9 +111,19 @@ export function isBedrockModelId(modelId?: string): boolean {
   return normalized.includes('anthropic.claude-');
 }
 
+function isMinimaxEndpoint(): boolean {
+  const baseUrl = process.env.ANTHROPIC_BASE_URL?.trim() || process.env.ANTHROPIC_API_BASE_URL?.trim();
+  if (!baseUrl) return false;
+  const lower = baseUrl.toLowerCase();
+  return lower.includes('minimaxi') || lower.includes('minimax');
+}
+
 export function getProviderLabel(stdin: StdinData): string | null {
   if (isBedrockModelId(stdin.model?.id)) {
     return 'Bedrock';
+  }
+  if (isMinimaxEndpoint()) {
+    return 'MiniMax';
   }
   return null;
 }

--- a/src/usage-api.ts
+++ b/src/usage-api.ts
@@ -58,10 +58,25 @@ const USAGE_API_TIMEOUT_MS_DEFAULT = 15_000;
 export const USAGE_API_USER_AGENT = 'claude-code/2.1';
 
 /**
+ * Check if the configured base URL points to a MiniMax endpoint.
+ */
+export function isMinimaxEndpoint(env: NodeJS.ProcessEnv = process.env): boolean {
+  const baseUrl = env.ANTHROPIC_BASE_URL?.trim() || env.ANTHROPIC_API_BASE_URL?.trim();
+  if (!baseUrl) return false;
+  const lower = baseUrl.toLowerCase();
+  return lower.includes('minimaxi') || lower.includes('minimax');
+}
+
+/**
  * Check if user is using a custom API endpoint instead of the default Anthropic API.
  * When using custom providers (e.g., via cc-switch), the OAuth usage API is not applicable.
+ * MiniMax endpoints are excluded — they have their own usage tracking path.
  */
 function isUsingCustomApiEndpoint(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (isMinimaxEndpoint(env)) {
+    return false;
+  }
+
   const baseUrl = env.ANTHROPIC_BASE_URL?.trim() || env.ANTHROPIC_API_BASE_URL?.trim();
 
   // No custom endpoint configured - using default Anthropic API
@@ -342,6 +357,7 @@ export type UsageApiDeps = {
   now: () => number;
   readKeychain: (now: number, homeDir: string) => { accessToken: string; subscriptionType: string } | null;
   ttls: CacheTtls;
+  fetchMiniMaxApi?: (apiKey: string) => Promise<UsageApiResult>;
 };
 
 const defaultDeps: UsageApiDeps = {
@@ -365,6 +381,12 @@ export async function getUsage(overrides: Partial<UsageApiDeps> = {}): Promise<U
   const deps = { ...defaultDeps, ...overrides };
   const now = deps.now();
   const homeDir = deps.homeDir();
+
+  // MiniMax has its own usage API — handle before the generic custom endpoint check
+  if (isMinimaxEndpoint()) {
+    debug('Detected MiniMax endpoint, using MiniMax usage API');
+    return getMiniMaxUsage(homeDir, deps.now, deps.ttls, deps.fetchMiniMaxApi);
+  }
 
   // Skip usage API if user is using a custom provider
   if (isUsingCustomApiEndpoint()) {
@@ -837,6 +859,224 @@ function parseDate(dateStr: string | undefined): Date | null {
     return null;
   }
   return date;
+}
+
+// --- MiniMax usage support ---
+
+interface MinimaxModelRemains {
+  model_name?: string;
+  current_interval_usage_count?: number;
+  total_count?: number;
+  remains_time?: number; // milliseconds until reset
+  current_weekly_usage_count?: number;
+  weekly_total_count?: number;
+  weekly_remains_time?: number; // milliseconds until weekly reset
+}
+
+interface MinimaxRawResponse {
+  model_remains?: MinimaxModelRemains[];
+  base_resp?: {
+    status_code?: number;
+    status_msg?: string;
+  };
+}
+
+function readMiniMaxApiKey(homeDir: string): string | null {
+  const fromAuthToken = process.env.ANTHROPIC_AUTH_TOKEN?.trim();
+  if (fromAuthToken) return fromAuthToken;
+
+  const fromApiKey = process.env.ANTHROPIC_API_KEY?.trim();
+  if (fromApiKey) return fromApiKey;
+
+  try {
+    const settingsPath = path.join(getClaudeConfigDir(homeDir), 'settings.json');
+    if (!fs.existsSync(settingsPath)) return null;
+    const content = fs.readFileSync(settingsPath, 'utf8');
+    const settings = JSON.parse(content);
+    const envToken = settings?.env?.ANTHROPIC_AUTH_TOKEN?.trim();
+    return envToken || null;
+  } catch {
+    return null;
+  }
+}
+
+function fetchMiniMaxUsage(apiKey: string): Promise<UsageApiResult> {
+  return new Promise((resolve) => {
+    const timeoutMs = getUsageApiTimeoutMs();
+    const options = {
+      hostname: 'www.minimaxi.com',
+      path: '/v1/api/openplatform/coding_plan/remains',
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'User-Agent': USAGE_API_USER_AGENT,
+      },
+      timeout: timeoutMs,
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+      res.on('end', () => {
+        if (res.statusCode !== 200) {
+          debug('MiniMax API returned non-200 status:', res.statusCode);
+          const error = res.statusCode === 429 ? 'rate-limited' : `http-${res.statusCode}`;
+          resolve({ data: null, error });
+          return;
+        }
+
+        try {
+          const raw: MinimaxRawResponse = JSON.parse(data);
+
+          if (raw.base_resp && raw.base_resp.status_code !== 0) {
+            debug('MiniMax API business error:', raw.base_resp.status_msg);
+            resolve({ data: null, error: `minimax-${raw.base_resp.status_code}` });
+            return;
+          }
+
+          const remains = raw.model_remains;
+          if (!remains || remains.length === 0) {
+            resolve({ data: null, error: 'minimax-empty' });
+            return;
+          }
+
+          const modelEnv = process.env.ANTHROPIC_MODEL?.trim()?.toLowerCase();
+          const matched = modelEnv
+            ? remains.find(r => r.model_name?.toLowerCase().includes(modelEnv))
+            : undefined;
+          const entry = matched ?? remains[0];
+
+          const total = entry.total_count ?? 0;
+          const used = entry.current_interval_usage_count ?? 0;
+          const fiveHourUtil = total > 0 ? (used / total) * 100 : 0;
+          const fiveHourResetMs = entry.remains_time;
+          const fiveHourResetAt = (fiveHourResetMs != null && fiveHourResetMs > 0)
+            ? new Date(Date.now() + fiveHourResetMs).toISOString()
+            : undefined;
+
+          const weeklyTotal = entry.weekly_total_count ?? 0;
+          const weeklyUsed = entry.current_weekly_usage_count ?? 0;
+          const sevenDayUtil = weeklyTotal > 0 ? (weeklyUsed / weeklyTotal) * 100 : 0;
+          const weeklyResetMs = entry.weekly_remains_time;
+          const sevenDayResetAt = (weeklyResetMs != null && weeklyResetMs > 0)
+            ? new Date(Date.now() + weeklyResetMs).toISOString()
+            : undefined;
+
+          const apiResponse: UsageApiResponse = {
+            five_hour: { utilization: fiveHourUtil, resets_at: fiveHourResetAt },
+            seven_day: { utilization: sevenDayUtil, resets_at: sevenDayResetAt },
+          };
+
+          resolve({ data: apiResponse });
+        } catch (e) {
+          debug('Failed to parse MiniMax API response:', e);
+          resolve({ data: null, error: 'parse' });
+        }
+      });
+    });
+
+    req.on('error', (error) => {
+      debug('MiniMax API request error:', error);
+      resolve({ data: null, error: 'network' });
+    });
+    req.on('timeout', () => {
+      debug('MiniMax API request timeout');
+      req.destroy();
+      resolve({ data: null, error: 'timeout' });
+    });
+
+    req.end();
+  });
+}
+
+async function getMiniMaxUsage(
+  homeDir: string,
+  nowFn: () => number,
+  ttls: CacheTtls,
+  fetchFn?: (apiKey: string) => Promise<UsageApiResult>,
+): Promise<UsageData | null> {
+  const now = nowFn();
+  const fetcher = fetchFn ?? fetchMiniMaxUsage;
+
+  const cacheState = readCacheState(homeDir, now, ttls);
+  if (cacheState?.isFresh) {
+    return cacheState.data;
+  }
+
+  let holdsCacheLock = false;
+  const lockStatus = tryAcquireCacheLock(homeDir);
+  if (lockStatus === 'busy') {
+    if (cacheState) return cacheState.data;
+    return await waitForFreshCache(homeDir, nowFn, ttls);
+  }
+  holdsCacheLock = lockStatus === 'acquired';
+
+  try {
+    const refreshedCache = readCache(homeDir, nowFn(), ttls);
+    if (refreshedCache) return refreshedCache;
+
+    const apiKey = readMiniMaxApiKey(homeDir);
+    if (!apiKey) {
+      debug('MiniMax API key not found');
+      return null;
+    }
+
+    const apiResult = await fetcher(apiKey);
+    if (!apiResult.data) {
+      const isRateLimited = apiResult.error === 'rate-limited';
+      const prevCount = readRateLimitedCount(homeDir);
+      const rateLimitedCount = isRateLimited ? prevCount + 1 : 0;
+      const backoffOpts: WriteCacheOpts = {
+        rateLimitedCount: isRateLimited ? rateLimitedCount : undefined,
+      };
+
+      const failureResult: UsageData = {
+        planName: 'MiniMax',
+        fiveHour: null,
+        sevenDay: null,
+        fiveHourResetAt: null,
+        sevenDayResetAt: null,
+        apiUnavailable: true,
+        apiError: apiResult.error,
+      };
+
+      if (isRateLimited) {
+        const staleCache = readCacheState(homeDir, now, ttls);
+        const lastGood = readLastGoodData(homeDir);
+        const goodData = (staleCache && !staleCache.data.apiUnavailable) ? staleCache.data : lastGood;
+        if (goodData) {
+          writeCache(homeDir, failureResult, now, { ...backoffOpts, lastGoodData: goodData });
+          return withRateLimitedSyncing(goodData);
+        }
+      }
+
+      writeCache(homeDir, failureResult, now, backoffOpts);
+      return failureResult;
+    }
+
+    const fiveHour = parseUtilization(apiResult.data.five_hour?.utilization);
+    const sevenDay = parseUtilization(apiResult.data.seven_day?.utilization);
+    const fiveHourResetAt = parseDate(apiResult.data.five_hour?.resets_at);
+    const sevenDayResetAt = parseDate(apiResult.data.seven_day?.resets_at);
+
+    const result: UsageData = {
+      planName: 'MiniMax',
+      fiveHour,
+      sevenDay,
+      fiveHourResetAt,
+      sevenDayResetAt,
+    };
+
+    writeCache(homeDir, result, now, { lastGoodData: result });
+    return result;
+  } catch (error) {
+    debug('getMiniMaxUsage failed:', error);
+    return null;
+  } finally {
+    if (holdsCacheLock) {
+      releaseCacheLock(homeDir);
+    }
+  }
 }
 
 export function getUsageApiTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -227,6 +227,52 @@ test('bedrock model detection recognizes bedrock ids', () => {
   assert.equal(getProviderLabel({ model: { id: 'claude-3-5-sonnet-20241022' } }), null);
 });
 
+test('getProviderLabel returns MiniMax when ANTHROPIC_BASE_URL contains minimaxi', () => {
+  const saved = process.env.ANTHROPIC_BASE_URL;
+  try {
+    process.env.ANTHROPIC_BASE_URL = 'https://api.minimaxi.com/v1';
+    assert.equal(getProviderLabel({ model: { id: 'claude-3-5-sonnet-20241022' } }), 'MiniMax');
+  } finally {
+    restoreEnvVar('ANTHROPIC_BASE_URL', saved);
+  }
+});
+
+test('getProviderLabel returns MiniMax when ANTHROPIC_API_BASE_URL contains minimaxi', () => {
+  const savedBase = process.env.ANTHROPIC_BASE_URL;
+  const savedApiBase = process.env.ANTHROPIC_API_BASE_URL;
+  try {
+    delete process.env.ANTHROPIC_BASE_URL;
+    process.env.ANTHROPIC_API_BASE_URL = 'https://api.minimaxi.com/v1';
+    assert.equal(getProviderLabel({ model: { id: 'claude-3-5-sonnet-20241022' } }), 'MiniMax');
+  } finally {
+    restoreEnvVar('ANTHROPIC_BASE_URL', savedBase);
+    restoreEnvVar('ANTHROPIC_API_BASE_URL', savedApiBase);
+  }
+});
+
+test('getProviderLabel returns null without MiniMax env vars', () => {
+  const savedBase = process.env.ANTHROPIC_BASE_URL;
+  const savedApiBase = process.env.ANTHROPIC_API_BASE_URL;
+  try {
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_API_BASE_URL;
+    assert.equal(getProviderLabel({ model: { id: 'claude-3-5-sonnet-20241022' } }), null);
+  } finally {
+    restoreEnvVar('ANTHROPIC_BASE_URL', savedBase);
+    restoreEnvVar('ANTHROPIC_API_BASE_URL', savedApiBase);
+  }
+});
+
+test('getProviderLabel prefers Bedrock over MiniMax when model ID is bedrock pattern', () => {
+  const saved = process.env.ANTHROPIC_BASE_URL;
+  try {
+    process.env.ANTHROPIC_BASE_URL = 'https://api.minimaxi.com/v1';
+    assert.equal(getProviderLabel({ model: { id: 'anthropic.claude-3-5-sonnet-20240620-v1:0' } }), 'Bedrock');
+  } finally {
+    restoreEnvVar('ANTHROPIC_BASE_URL', saved);
+  }
+});
+
 test('parseTranscript aggregates tools, agents, and todos', async () => {
   const fixturePath = fileURLToPath(new URL('./fixtures/transcript-basic.jsonl', import.meta.url));
   const result = await parseTranscript(fixturePath);

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1190,3 +1190,68 @@ test('render compact layout keeps activity lines even when elementOrder omits th
   assert.ok(output.includes('Read'), 'compact mode should keep tools visible');
   assert.ok(output.includes('todo-marker'), 'compact mode should keep todos visible');
 });
+
+// MiniMax provider tests
+function restoreEnvVar(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+test('renderSessionLine shows MiniMax label and displays usage for MiniMax provider', () => {
+  const savedBase = process.env.ANTHROPIC_BASE_URL;
+  try {
+    process.env.ANTHROPIC_BASE_URL = 'https://api.minimaxi.com/v1';
+    const ctx = baseContext();
+    ctx.usageData = {
+      planName: 'MiniMax',
+      fiveHour: 30,
+      sevenDay: 10,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+    };
+    const line = renderSessionLine(ctx);
+    assert.ok(line.includes('MiniMax'), 'should include MiniMax label');
+    assert.ok(line.includes('5h:'), 'should show usage for MiniMax');
+    assert.ok(line.includes('30%'), 'should show 5h percentage');
+  } finally {
+    restoreEnvVar('ANTHROPIC_BASE_URL', savedBase);
+  }
+});
+
+test('renderUsageLine renders usage for MiniMax provider', () => {
+  const savedBase = process.env.ANTHROPIC_BASE_URL;
+  try {
+    process.env.ANTHROPIC_BASE_URL = 'https://api.minimaxi.com/v1';
+    const ctx = baseContext();
+    ctx.usageData = {
+      planName: 'MiniMax',
+      fiveHour: 45,
+      sevenDay: 20,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+    };
+    const line = renderUsageLine(ctx);
+    assert.ok(line, 'should render usage line for MiniMax');
+    const plain = stripAnsi(line);
+    assert.ok(plain.includes('Usage'), 'should include Usage label');
+    assert.ok(plain.includes('45%'), 'should include 5h percentage');
+  } finally {
+    restoreEnvVar('ANTHROPIC_BASE_URL', savedBase);
+  }
+});
+
+test('renderUsageLine still returns null for Bedrock provider', () => {
+  const ctx = baseContext();
+  ctx.stdin.model = { display_name: 'Sonnet', id: 'anthropic.claude-3-5-sonnet-20240620-v1:0' };
+  ctx.usageData = {
+    planName: 'Max',
+    fiveHour: 23,
+    sevenDay: 45,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+  };
+  assert.equal(renderUsageLine(ctx), null, 'should return null for Bedrock');
+});

--- a/tests/usage-api.test.js
+++ b/tests/usage-api.test.js
@@ -21,6 +21,7 @@ let isNoProxy;
 let getProxyUrl;
 let parseRetryAfterSeconds;
 let USAGE_API_USER_AGENT;
+let isMinimaxEndpoint;
 
 function ensureUsageApiDistIsCurrent() {
   const testDir = path.dirname(fileURLToPath(import.meta.url));
@@ -57,6 +58,7 @@ before(async () => {
     getProxyUrl,
     parseRetryAfterSeconds,
     USAGE_API_USER_AGENT,
+    isMinimaxEndpoint,
   } = await import(`../dist/usage-api.js?cacheBust=${Date.now()}`));
 });
 
@@ -933,6 +935,251 @@ describe('getUsage', () => {
       await new Promise((resolve) => proxyServer.close(() => resolve()));
       restoreEnvVar('HTTPS_PROXY', originalHttpsProxy);
       restoreEnvVar('CLAUDE_HUD_USAGE_TIMEOUT_MS', originalUsageTimeout);
+    }
+  });
+});
+
+describe('isMinimaxEndpoint', () => {
+  test('returns true when ANTHROPIC_BASE_URL contains minimaxi.com', () => {
+    const saved = process.env.ANTHROPIC_BASE_URL;
+    try {
+      process.env.ANTHROPIC_BASE_URL = 'https://api.minimaxi.com/v1';
+      assert.equal(isMinimaxEndpoint(), true);
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', saved);
+    }
+  });
+
+  test('returns true when ANTHROPIC_API_BASE_URL contains minimax', () => {
+    const savedBase = process.env.ANTHROPIC_BASE_URL;
+    const savedApiBase = process.env.ANTHROPIC_API_BASE_URL;
+    try {
+      delete process.env.ANTHROPIC_BASE_URL;
+      process.env.ANTHROPIC_API_BASE_URL = 'https://api.minimax.chat/v1';
+      assert.equal(isMinimaxEndpoint(), true);
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', savedBase);
+      restoreEnvVar('ANTHROPIC_API_BASE_URL', savedApiBase);
+    }
+  });
+
+  test('returns false when no minimax URL is set', () => {
+    const savedBase = process.env.ANTHROPIC_BASE_URL;
+    const savedApiBase = process.env.ANTHROPIC_API_BASE_URL;
+    try {
+      delete process.env.ANTHROPIC_BASE_URL;
+      delete process.env.ANTHROPIC_API_BASE_URL;
+      assert.equal(isMinimaxEndpoint(), false);
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', savedBase);
+      restoreEnvVar('ANTHROPIC_API_BASE_URL', savedApiBase);
+    }
+  });
+
+  test('returns false for non-minimax custom endpoints', () => {
+    const saved = process.env.ANTHROPIC_BASE_URL;
+    try {
+      process.env.ANTHROPIC_BASE_URL = 'https://my-proxy.example.com';
+      assert.equal(isMinimaxEndpoint(), false);
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', saved);
+    }
+  });
+});
+
+describe('getUsage with MiniMax endpoint', () => {
+  beforeEach(async () => {
+    tempHome = await createTempHome();
+    clearCache(tempHome);
+  });
+
+  afterEach(async () => {
+    if (tempHome) {
+      await rm(tempHome, { recursive: true, force: true });
+      tempHome = null;
+    }
+  });
+
+  test('routes to MiniMax path when ANTHROPIC_BASE_URL is minimax', async () => {
+    const savedBase = process.env.ANTHROPIC_BASE_URL;
+    const savedAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
+    try {
+      process.env.ANTHROPIC_BASE_URL = 'https://api.minimaxi.com/v1';
+      process.env.ANTHROPIC_AUTH_TOKEN = 'mm-test-key';
+      let fetchCalls = 0;
+      const result = await getUsage({
+        homeDir: () => tempHome,
+        now: () => 1000,
+        readKeychain: () => null,
+        fetchMiniMaxApi: async (apiKey) => {
+          fetchCalls += 1;
+          assert.equal(apiKey, 'mm-test-key');
+          return buildApiResult();
+        },
+      });
+
+      assert.equal(fetchCalls, 1);
+      assert.equal(result?.planName, 'MiniMax');
+      assert.equal(result?.fiveHour, 25);
+      assert.equal(result?.sevenDay, 10);
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', savedBase);
+      restoreEnvVar('ANTHROPIC_AUTH_TOKEN', savedAuthToken);
+    }
+  });
+
+  test('routes to MiniMax path via ANTHROPIC_API_BASE_URL', async () => {
+    const savedBase = process.env.ANTHROPIC_BASE_URL;
+    const savedApiBase = process.env.ANTHROPIC_API_BASE_URL;
+    const savedAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
+    try {
+      delete process.env.ANTHROPIC_BASE_URL;
+      process.env.ANTHROPIC_API_BASE_URL = 'https://api.minimaxi.com/v1';
+      process.env.ANTHROPIC_AUTH_TOKEN = 'mm-test-key';
+      let fetchCalls = 0;
+      const result = await getUsage({
+        homeDir: () => tempHome,
+        now: () => 1000,
+        readKeychain: () => null,
+        fetchMiniMaxApi: async () => {
+          fetchCalls += 1;
+          return buildApiResult();
+        },
+      });
+
+      assert.equal(fetchCalls, 1);
+      assert.equal(result?.planName, 'MiniMax');
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', savedBase);
+      restoreEnvVar('ANTHROPIC_API_BASE_URL', savedApiBase);
+      restoreEnvVar('ANTHROPIC_AUTH_TOKEN', savedAuthToken);
+    }
+  });
+
+  test('MiniMax is not skipped by isUsingCustomApiEndpoint', async () => {
+    const savedBase = process.env.ANTHROPIC_BASE_URL;
+    const savedAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
+    try {
+      process.env.ANTHROPIC_BASE_URL = 'https://api.minimaxi.com/v1';
+      process.env.ANTHROPIC_AUTH_TOKEN = 'mm-test-key';
+      let fetchCalls = 0;
+      const result = await getUsage({
+        homeDir: () => tempHome,
+        now: () => 1000,
+        readKeychain: () => null,
+        fetchMiniMaxApi: async () => {
+          fetchCalls += 1;
+          return buildApiResult();
+        },
+      });
+      assert.ok(result !== null, 'should not return null for MiniMax endpoint');
+      assert.equal(fetchCalls, 1);
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', savedBase);
+      restoreEnvVar('ANTHROPIC_AUTH_TOKEN', savedAuthToken);
+    }
+  });
+
+  test('returns null when MiniMax API key is missing', async () => {
+    const savedBase = process.env.ANTHROPIC_BASE_URL;
+    const savedAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
+    const savedApiKey = process.env.ANTHROPIC_API_KEY;
+    try {
+      process.env.ANTHROPIC_BASE_URL = 'https://api.minimaxi.com/v1';
+      delete process.env.ANTHROPIC_AUTH_TOKEN;
+      delete process.env.ANTHROPIC_API_KEY;
+      let fetchCalls = 0;
+      const result = await getUsage({
+        homeDir: () => tempHome,
+        now: () => 1000,
+        readKeychain: () => null,
+        fetchMiniMaxApi: async () => {
+          fetchCalls += 1;
+          return buildApiResult();
+        },
+      });
+      assert.equal(result, null);
+      assert.equal(fetchCalls, 0);
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', savedBase);
+      restoreEnvVar('ANTHROPIC_AUTH_TOKEN', savedAuthToken);
+      restoreEnvVar('ANTHROPIC_API_KEY', savedApiKey);
+    }
+  });
+
+  test('MiniMax success: returns planName MiniMax with usage data', async () => {
+    const savedBase = process.env.ANTHROPIC_BASE_URL;
+    const savedAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
+    try {
+      process.env.ANTHROPIC_BASE_URL = 'https://api.minimaxi.com/v1';
+      process.env.ANTHROPIC_AUTH_TOKEN = 'mm-key';
+      const result = await getUsage({
+        homeDir: () => tempHome,
+        now: () => 1000,
+        readKeychain: () => null,
+        fetchMiniMaxApi: async () => ({
+          data: {
+            five_hour: { utilization: 40, resets_at: '2026-01-06T15:00:00Z' },
+            seven_day: { utilization: 15, resets_at: '2026-01-13T00:00:00Z' },
+          },
+        }),
+      });
+      assert.equal(result?.planName, 'MiniMax');
+      assert.equal(result?.fiveHour, 40);
+      assert.equal(result?.sevenDay, 15);
+      assert.ok(result?.fiveHourResetAt instanceof Date);
+      assert.ok(result?.sevenDayResetAt instanceof Date);
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', savedBase);
+      restoreEnvVar('ANTHROPIC_AUTH_TOKEN', savedAuthToken);
+    }
+  });
+
+  test('MiniMax failure: returns apiUnavailable when fetch fails', async () => {
+    const savedBase = process.env.ANTHROPIC_BASE_URL;
+    const savedAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
+    try {
+      process.env.ANTHROPIC_BASE_URL = 'https://api.minimaxi.com/v1';
+      process.env.ANTHROPIC_AUTH_TOKEN = 'mm-key';
+      const result = await getUsage({
+        homeDir: () => tempHome,
+        now: () => 1000,
+        readKeychain: () => null,
+        fetchMiniMaxApi: async () => ({ data: null, error: 'network' }),
+      });
+      assert.equal(result?.planName, 'MiniMax');
+      assert.equal(result?.apiUnavailable, true);
+      assert.equal(result?.apiError, 'network');
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', savedBase);
+      restoreEnvVar('ANTHROPIC_AUTH_TOKEN', savedAuthToken);
+    }
+  });
+
+  test('MiniMax reads API key from ANTHROPIC_API_KEY as fallback', async () => {
+    const savedBase = process.env.ANTHROPIC_BASE_URL;
+    const savedAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
+    const savedApiKey = process.env.ANTHROPIC_API_KEY;
+    try {
+      process.env.ANTHROPIC_BASE_URL = 'https://api.minimaxi.com/v1';
+      delete process.env.ANTHROPIC_AUTH_TOKEN;
+      process.env.ANTHROPIC_API_KEY = 'mm-api-key';
+      let usedKey = null;
+      const result = await getUsage({
+        homeDir: () => tempHome,
+        now: () => 1000,
+        readKeychain: () => null,
+        fetchMiniMaxApi: async (apiKey) => {
+          usedKey = apiKey;
+          return buildApiResult();
+        },
+      });
+      assert.equal(usedKey, 'mm-api-key');
+      assert.equal(result?.planName, 'MiniMax');
+    } finally {
+      restoreEnvVar('ANTHROPIC_BASE_URL', savedBase);
+      restoreEnvVar('ANTHROPIC_AUTH_TOKEN', savedAuthToken);
+      restoreEnvVar('ANTHROPIC_API_KEY', savedApiKey);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Detect MiniMax endpoints via `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_BASE_URL` containing `minimax` or `minimaxi`
- Fetch usage data from MiniMax API (`/v1/api/openplatform/coding_plan/remains`), convert response to the existing `UsageApiResponse` format so parsing/caching/rendering logic is fully reused
- Allow MiniMax usage to render in both compact (`session-line.ts`) and expanded (`usage.ts`) layouts while continuing to skip Bedrock
- API key resolution uses three-tier fallback: `ANTHROPIC_AUTH_TOKEN` → `ANTHROPIC_API_KEY` → `settings.json`'s `env.ANTHROPIC_AUTH_TOKEN`
- Extended `UsageApiDeps` with optional `fetchMiniMaxApi` for test injection
- 19 new tests across `usage-api.test.js`, `core.test.js`, and `render.test.js`

## Design

This follows the approach from PR #219 (MiniMax raw response → `UsageApiResponse` conversion) while fixing its gaps (missing tests, incomplete env var checks, `remains_time` unit handling). The MiniMax branch is inserted before the generic "custom endpoint" check in `getUsage()`, preventing MiniMax URLs from being incorrectly skipped.

```
getUsage() → isMinimaxEndpoint()? → getMiniMaxUsage() → fetchMiniMaxUsage()
                                                          ↓
                                                  convert to UsageApiResponse
                                                          ↓
                                              reuse parseUtilization / parseDate
```

## Test plan

- [x] `npm run build` compiles without errors
- [x] `npm test` — all 290 tests pass (1 skipped: Windows-only)
- [x] New tests cover: endpoint detection, API key fallback, success/failure paths, render layer MiniMax/Bedrock behavior, Bedrock-MiniMax priority