### PR TITLE
fix(setup): guard against empty plugin_dir from mangled awk command

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -131,8 +131,12 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
 5. Generate command (quotes around runtime path handle spaces):
    ```
-   bash -c 'plugin_dir=$(ls -d "$HOME"/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $0 }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
+   bash -c 'plugin_dir=$(ls -d "$HOME"/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $0 }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); [ -d "$plugin_dir" ] && exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
    ```
+
+   **CRITICAL**: The awk command MUST include `$0` to output the full path: `{ print $(NF-1) "\t" $0 }`.
+   Without `$0`, `plugin_dir` resolves to empty and node runs from the wrong directory.
+   After generating, verify: `echo "$plugin_dir"` should print a full absolute path like `/Users/.../.claude/plugins/cache/claude-hud/claude-hud/0.0.10/`.
 
 **Windows** (Platform: `win32`):
 
@@ -165,7 +169,13 @@ Choose instructions by `Shell:` value before running any commands:
 
 ## Step 2: Test Command
 
-Run the generated command. It should produce output (the HUD lines) within a few seconds.
+**First**, verify the path resolution works by extracting and testing `plugin_dir`:
+```bash
+plugin_dir=$(ls -d "$HOME"/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '{ print $(NF-1) "\t" $0 }' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); echo "plugin_dir='${plugin_dir}'"
+```
+This MUST print a full absolute path (e.g. `plugin_dir='/Users/.../.claude/plugins/cache/claude-hud/claude-hud/0.0.10/'`). If it prints `plugin_dir=''`, the awk command in Step 1 is wrong — go back and fix it.
+
+**Then** run the full generated command. It should produce output (the HUD lines) within a few seconds.
 
 - If it errors, do not proceed to Step 3.
 - If it hangs for more than a few seconds, cancel and debug.


### PR DESCRIPTION
## Summary

The `/claude-hud:setup` skill generates a `statusLine` command that dynamically resolves the latest plugin version directory using an `awk` pipeline. A subtle but critical bug can occur when the awk command loses its `$0` argument during LLM template substitution, causing the HUD to silently fail with no output and no error message.

## The Bug

The generated `statusLine` command in `settings.json` uses this pipeline to find the latest plugin version:

```bash
ls -d "$HOME"/.claude/plugins/cache/claude-hud/claude-hud/*/ \
  | awk -F/ '{ print $(NF-1) "\t" $0 }' \
  | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n \
  | tail -1 | cut -f2-
```

The awk command must output **both** the version number (`$(NF-1)`) for sorting **and** the full path (`$0`) for `cut -f2-` to extract. However, the command template in `setup.md` uses heavily nested single-quote escaping (`'"'"'`) around the awk expression, which makes it fragile during LLM processing.

**What happened**: When Claude ran `/claude-hud:setup`, the awk `$0` was dropped during template substitution, producing:

```bash
awk -F/ '{ print $(NF-1) "\t"  }'  # ← missing $0
```

This causes `plugin_dir` to resolve to an **empty string**. Node then runs `dist/index.js` relative to the current working directory instead of the plugin directory, resulting in:

```
Error: Cannot find module '/Users/.../current-project/dist/index.js'
```

The HUD produces no output, and since `statusLine` commands fail silently in Claude Code, users see no error — just no HUD. This is particularly hard to debug because:
- The setup "succeeds" (config is written)
- No error is shown to the user
- The root cause (empty `plugin_dir`) is hidden inside the shell pipeline

## Fix Strategy

Three defensive layers added to `commands/setup.md`:

### 1. Runtime guard: `[ -d "$plugin_dir" ]` (line 134)

The generated command template now includes a directory existence check before `exec`:

```bash
# Before (fails silently with wrong path)
...); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'

# After (exits gracefully if plugin_dir is invalid)
...); [ -d "$plugin_dir" ] && exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
```

If `plugin_dir` is empty or not a valid directory, the command exits with no output rather than running node from the wrong location.

### 2. Path verification substep in Step 2

Added an explicit verification command before the full integration test:

```bash
plugin_dir=$(...); echo "plugin_dir='${plugin_dir}'"
```

This MUST print a full absolute path. If it prints `plugin_dir=''`, the setup process catches the issue before writing to `settings.json`.

### 3. CRITICAL warning annotation

Added a prominent warning directly below the command template explaining that `$0` is required in the awk expression, why it matters, and how to verify it — so that future LLM executions of this skill are less likely to drop it.

## Test plan

- [ ] Run `/claude-hud:setup` on a fresh install and verify `plugin_dir` resolves correctly
- [ ] Manually test the guard by removing `$0` from the awk — confirm the command produces no output (instead of a node error)
- [ ] Verify the path verification substep catches an empty `plugin_dir` before proceeding to Step 3


🤖 Generated with [Claude Code](https://claude.com/claude-code)