### PR TITLE
Fix extraLabel not displayed in expanded layout

### DIFF
--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -73,6 +73,10 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     parts.push(dim(ctx.transcript.sessionName));
   }
 
+  if (ctx.extraLabel) {
+    parts.push(dim(ctx.extraLabel));
+  }
+
   if (parts.length === 0) {
     return null;
   }

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -239,6 +239,22 @@ test('renderProjectLine includes session name when showSessionName is true', () 
   assert.ok(line?.includes('Renamed Session'));
 });
 
+test('renderProjectLine includes extraLabel when present', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.extraLabel = 'user [MAX]';
+  const line = renderProjectLine(ctx);
+  assert.ok(line?.includes('user [MAX]'));
+});
+
+test('renderProjectLine omits extraLabel when null', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.extraLabel = null;
+  const line = renderProjectLine(ctx);
+  assert.ok(!line?.includes('user [MAX]'));
+});
+
 test('renderProjectLine hides session name by default', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = '/tmp/my-project';


### PR DESCRIPTION
## Summary

- `--extra-cmd` labels were only rendered in compact mode (`renderSessionLine`)
- In the default expanded layout, `extraLabel` was collected but never displayed
- Appends `extraLabel` to the project line in expanded mode, matching its compact placement

Fixes #242

## Test plan

- [x] Added `renderProjectLine includes extraLabel when present` test
- [x] Added `renderProjectLine omits extraLabel when null` test
- [x] All 75 existing tests pass