### PR TITLE
fix: prevent Bun from auto-loading project .env files

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -133,6 +133,13 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
    If result is "bun", use `src/index.ts` (bun has native TypeScript support). Otherwise use `dist/index.js` (pre-compiled).
 
 5. Generate command (quotes around runtime path handle spaces):
+
+   **When runtime is bun** — add `--env-file /dev/null` to prevent Bun from auto-loading project `.env` files (which can inject `ANTHROPIC_API_KEY`/`ANTHROPIC_BASE_URL` and break plan detection):
+   ```
+   bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $0 }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
+   ```
+
+   **When runtime is node**:
    ```
    bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $0 }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
    ```
@@ -160,6 +167,13 @@ Choose instructions by `Shell:` value before running any commands:
 3. Check if runtime is bun (by filename). If bun, use `src\index.ts`. Otherwise use `dist\index.js`.
 
 4. Generate command (note: quotes around runtime path handle spaces in paths):
+
+   **When runtime is bun** — add `--env-file NUL` to prevent Bun from auto-loading project `.env` files:
+   ```
+   powershell -Command "& {$p=(Get-ChildItem $env:USERPROFILE\.claude\plugins\cache\claude-hud\claude-hud -Directory | Where-Object { $_.Name -match '^\d+(\.\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName; & '{RUNTIME_PATH}' '--env-file' 'NUL' (Join-Path $p '{SOURCE}')}"
+   ```
+
+   **When runtime is node**:
    ```
    powershell -Command "& {$p=(Get-ChildItem $env:USERPROFILE\.claude\plugins\cache\claude-hud\claude-hud -Directory | Where-Object { $_.Name -match '^\d+(\.\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName; & '{RUNTIME_PATH}' (Join-Path $p '{SOURCE}')}"
    ```


### PR DESCRIPTION
## Summary

- Adds `--env-file /dev/null` (bash) / `--env-file NUL` (PowerShell) to the Bun command generated by the setup skill
- Prevents Bun from auto-loading project `.env` files that can inject `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` into `process.env`
- Node.js commands are unchanged (Node does not auto-load `.env`)

## Problem

Bun [automatically loads `.env` files](https://bun.sh/docs/runtime/env) from the working directory on startup. Since Claude Code runs the statusline command with `cwd` set to the current project directory, Bun picks up the project's `.env` and injects its variables into `process.env`.

This causes two issues:
1. `isUsingCustomApiEndpoint()` sees `ANTHROPIC_BASE_URL` → returns `true` → `getUsage()` bails out → **usage line disappears**
2. `hasApiKey` check sees `ANTHROPIC_API_KEY` → shows red **"API"** instead of the actual plan name (e.g., "Pro")

## Changes

**`commands/setup.md`**:
- Split the generated command templates into **bun** and **node** variants
- Bun variant includes `--env-file /dev/null` (bash) or `--env-file NUL` (PowerShell) to disable automatic `.env` loading
- Applies to both macOS/Linux and Windows PowerShell command templates

## Test plan

- [x] Verified on Windows 11 (Bun 1.3.7): without flag, `.env` vars are loaded; with `--env-file /dev/null`, they are blocked
- [x] Existing users need to re-run `/claude-hud:setup` to get the updated command

## Workaround for existing users

Manually add `--env-file /dev/null` to the statusLine command in `~/.claude/settings.json`:

```diff
- exec bun "${plugin_dir}src/index.ts"
+ exec bun --env-file /dev/null "${plugin_dir}src/index.ts"
```

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)