### PR TITLE
feat: add memory usage HUD element

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export type LineLayoutType = 'compact' | 'expanded';
 
 export type AutocompactBufferMode = 'enabled' | 'disabled';
 export type ContextValueMode = 'percent' | 'tokens' | 'remaining';
-export type HudElement = 'project' | 'context' | 'usage' | 'environment' | 'tools' | 'agents' | 'todos';
+export type HudElement = 'project' | 'context' | 'usage' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos';
 export type HudColorName =
   | 'red'
   | 'green'
@@ -32,6 +32,7 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'project',
   'context',
   'usage',
+  'memory',
   'environment',
   'tools',
   'agents',
@@ -62,6 +63,8 @@ export interface HudConfig {
     showTokenBreakdown: boolean;
     showUsage: boolean;
     usageBarEnabled: boolean;
+    showMemoryUsage: boolean;
+    memoryThreshold: number;
     showTools: boolean;
     showAgents: boolean;
     showTodos: boolean;
@@ -101,6 +104,8 @@ export const DEFAULT_CONFIG: HudConfig = {
     showTokenBreakdown: true,
     showUsage: true,
     usageBarEnabled: true,
+    showMemoryUsage: false,
+    memoryThreshold: 80,
     showTools: false,
     showAgents: false,
     showTodos: false,
@@ -292,6 +297,10 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     usageBarEnabled: typeof migrated.display?.usageBarEnabled === 'boolean'
       ? migrated.display.usageBarEnabled
       : DEFAULT_CONFIG.display.usageBarEnabled,
+    showMemoryUsage: typeof migrated.display?.showMemoryUsage === 'boolean'
+      ? migrated.display.showMemoryUsage
+      : DEFAULT_CONFIG.display.showMemoryUsage,
+    memoryThreshold: validateThreshold(migrated.display?.memoryThreshold, 100),
     showTools: typeof migrated.display?.showTools === 'boolean'
       ? migrated.display.showTools
       : DEFAULT_CONFIG.display.showTools,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { render } from './render/index.js';
 import { countConfigs } from './config-reader.js';
 import { getGitStatus } from './git.js';
 import { getUsage } from './usage-api.js';
+import { getMemoryUsage } from './memory.js';
 import { loadConfig } from './config.js';
 import { parseExtraCmdArg, runExtraCmd } from './extra-cmd.js';
 import type { RenderContext } from './types.js';
@@ -16,6 +17,7 @@ export type MainDeps = {
   countConfigs: typeof countConfigs;
   getGitStatus: typeof getGitStatus;
   getUsage: typeof getUsage;
+  getMemoryUsage: typeof getMemoryUsage;
   loadConfig: typeof loadConfig;
   parseExtraCmdArg: typeof parseExtraCmdArg;
   runExtraCmd: typeof runExtraCmd;
@@ -31,6 +33,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     countConfigs,
     getGitStatus,
     getUsage,
+    getMemoryUsage,
     loadConfig,
     parseExtraCmdArg,
     runExtraCmd,
@@ -73,6 +76,10 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
         })
       : null;
 
+    const memoryUsage = config.display.showMemoryUsage
+      ? await deps.getMemoryUsage()
+      : null;
+
     const extraCmd = deps.parseExtraCmdArg();
     const extraLabel = extraCmd ? await deps.runExtraCmd(extraCmd) : null;
 
@@ -88,6 +95,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       sessionDuration,
       gitStatus,
       usageData,
+      memoryUsage,
       config,
       extraLabel,
     };

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,0 +1,29 @@
+import * as os from 'node:os';
+import type { MemoryInfo } from './types.js';
+
+export async function getMemoryUsage(): Promise<MemoryInfo | null> {
+  try {
+    const totalBytes = os.totalmem();
+    const freeBytes = os.freemem();
+    const usedBytes = totalBytes - freeBytes;
+    const percent = (usedBytes / totalBytes) * 100;
+
+    return {
+      totalBytes,
+      usedBytes,
+      freeBytes,
+      percent: Math.round(percent),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function formatBytes(bytes: number): string {
+  const gb = bytes / (1024 * 1024 * 1024);
+  if (gb >= 1) {
+    return `${gb.toFixed(1)} GB`;
+  }
+  const mb = bytes / (1024 * 1024);
+  return `${mb.toFixed(0)} MB`;
+}

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -10,6 +10,7 @@ import {
   renderProjectLine,
   renderEnvironmentLine,
   renderUsageLine,
+  renderMemoryLine,
 } from './lines/index.js';
 import { dim, RESET } from './colors.js';
 
@@ -344,6 +345,8 @@ function renderElementLine(ctx: RenderContext, element: HudElement): string | nu
       return renderIdentityLine(ctx);
     case 'usage':
       return renderUsageLine(ctx);
+    case 'memory':
+      return renderMemoryLine(ctx);
     case 'environment':
       return renderEnvironmentLine(ctx);
     case 'tools':

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -2,3 +2,4 @@ export { renderIdentityLine } from './identity.js';
 export { renderProjectLine } from './project.js';
 export { renderEnvironmentLine } from './environment.js';
 export { renderUsageLine } from './usage.js';
+export { renderMemoryLine } from './memory.js';

--- a/src/render/lines/memory.ts
+++ b/src/render/lines/memory.ts
@@ -1,0 +1,30 @@
+import type { RenderContext } from '../../types.js';
+import { formatBytes } from '../../memory.js';
+import { coloredBar, dim, getContextColor, RESET } from '../colors.js';
+import { getAdaptiveBarWidth } from '../../utils/terminal.js';
+
+export function renderMemoryLine(ctx: RenderContext): string | null {
+  const display = ctx.config?.display;
+  if (display?.showMemoryUsage !== true) {
+    return null;
+  }
+
+  const memory = ctx.memoryUsage;
+  if (!memory) {
+    return null;
+  }
+
+  const threshold = display?.memoryThreshold ?? 80;
+  const colors = ctx.config?.colors;
+  const color = memory.percent >= threshold
+    ? (colors?.critical ?? '\x1b[31m')
+    : getContextColor(memory.percent, colors);
+
+  const barWidth = Math.min(getAdaptiveBarWidth(), 10);
+  const bar = coloredBar(memory.percent, barWidth, colors);
+
+  const usedDisplay = formatBytes(memory.usedBytes);
+  const totalDisplay = formatBytes(memory.totalBytes);
+
+  return `${dim('RAM')} ${bar} ${color}${usedDisplay} / ${totalDisplay} (${memory.percent}%)${RESET}`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,13 @@ export interface TranscriptData {
   sessionName?: string;
 }
 
+export interface MemoryInfo {
+  totalBytes: number;
+  usedBytes: number;
+  freeBytes: number;
+  percent: number;
+}
+
 export interface RenderContext {
   stdin: StdinData;
   transcript: TranscriptData;
@@ -85,6 +92,7 @@ export interface RenderContext {
   sessionDuration: string;
   gitStatus: GitStatus | null;
   usageData: UsageData | null;
+  memoryUsage: MemoryInfo | null;
   config: HudConfig;
   extraLabel: string | null;
 }


### PR DESCRIPTION
<html><head></head><body><h1>feat: add memory usage HUD element</h1>
<h2>Summary</h2>
<p>Adds a new <code>memory</code> HUD element that displays real-time RAM usage as a progress bar with threshold-based color coding:</p>
<pre><code>RAM █████████░ 14.2 GB / 16.0 GB (89%)
</code></pre>

<h2>Configuration</h2>
<pre><code class="language-json">{
  "display": {
    "showMemoryUsage": true,
    "memoryThreshold": 80
  }
}
</code></pre>
<p>Add <code>"memory"</code> to <code>elementOrder</code> to control placement (default: after <code>"usage"</code>):</p>
<pre><code class="language-json">{ "elementOrder": ["project", "context", "usage", "memory", "environment"] }
</code></pre>
<h2>Changes</h2>

File | Change
-- | --
src/types.ts | Added MemoryInfo interface
src/config.ts | Added showMemoryUsage, memoryThreshold, and 'memory' to HudElement
src/memory.ts | (new) Reads RAM stats via Node.js os.totalmem() / os.freemem()
src/render/lines/memory.ts | (new) Renders the RAM progress bar with threshold coloring
src/render/index.ts | Added 'memory' case in renderElementLine()
src/render/lines/index.ts | Exports renderMemoryLine
src/index.ts | Imports getMemoryUsage, adds to deps, fetches memory data, passes to RenderContext


<h2>Color Thresholds</h2>
<ul>
<li><strong>Green</strong> — &lt; 70%</li>
<li><strong>Yellow</strong> — 70–85%</li>
<li><strong>Red</strong> — ≥ <code>memoryThreshold</code> (default 80%)</li>
</ul>
<p>Closes #258</p></body></html>