### PR TITLE
feat: rate_limits support, 'both' display mode, free user bar fix, Bun/OAuth fixes

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -134,7 +134,7 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
 5. Generate command (quotes around runtime path handle spaces):
    ```
-   bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $0 }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
+   bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $0 }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" $([ "$(basename {RUNTIME_PATH})" = "bun" ] && echo "--env-file /dev/null") "${plugin_dir}{SOURCE}"'
    ```
 
 **Windows** (Platform: `win32`):

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ import { getHudPluginDir } from './claude-config-dir.js';
 export type LineLayoutType = 'compact' | 'expanded';
 
 export type AutocompactBufferMode = 'enabled' | 'disabled';
-export type ContextValueMode = 'percent' | 'tokens' | 'remaining';
+export type ContextValueMode = 'percent' | 'tokens' | 'remaining' | 'both';
 export type HudElement = 'project' | 'context' | 'usage' | 'environment' | 'tools' | 'agents' | 'todos';
 export type HudColorName =
   | 'red'
@@ -142,7 +142,7 @@ function validateAutocompactBuffer(value: unknown): value is AutocompactBufferMo
 }
 
 function validateContextValue(value: unknown): value is ContextValueMode {
-  return value === 'percent' || value === 'tokens' || value === 'remaining';
+  return value === 'percent' || value === 'tokens' || value === 'remaining' || value === 'both';
 }
 
 function validateColorName(value: unknown): value is HudColorName {

--- a/src/render/lines/identity.ts
+++ b/src/render/lines/identity.ts
@@ -47,7 +47,7 @@ function formatTokens(n: number): string {
   return n.toString();
 }
 
-function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent' | 'tokens' | 'remaining'): string {
+function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent' | 'tokens' | 'remaining' | 'both'): string {
   if (mode === 'tokens') {
     const totalTokens = getTotalTokens(ctx.stdin);
     const size = ctx.stdin.context_window?.context_window_size ?? 0;
@@ -59,6 +59,15 @@ function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent'
 
   if (mode === 'remaining') {
     return `${Math.max(0, 100 - percent)}%`;
+  }
+
+  if (mode === 'both') {
+    const totalTokens = getTotalTokens(ctx.stdin);
+    const size = ctx.stdin.context_window?.context_window_size ?? 0;
+    if (size > 0) {
+      return `${percent}% (${formatTokens(totalTokens)}/${formatTokens(size)})`;
+    }
+    return `${percent}% (${formatTokens(totalTokens)})`;
   }
 
   return `${percent}%`;

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -59,7 +59,13 @@ export function renderUsageLine(ctx: RenderContext): string | null {
   const syncingSuffix = ctx.usageData.apiError === 'rate-limited'
     ? ` ${dim('(syncing...)')}`
     : '';
-  if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
+
+  // For free/weekly-only users (fiveHour is null but sevenDay exists), always show the
+  // seven-day bar regardless of the threshold — it's their only usage indicator.
+  // For paid users, only show seven-day when it exceeds the threshold (default 80%).
+  const sevenDayVisible = sevenDay !== null && (fiveHour === null || sevenDay >= sevenDayThreshold);
+
+  if (sevenDayVisible) {
     const sevenDayDisplay = formatUsagePercent(sevenDay, colors);
     const sevenDayReset = formatResetTime(ctx.usageData.sevenDayResetAt);
     const sevenDayPart = usageBarEnabled
@@ -69,6 +75,11 @@ export function renderUsageLine(ctx: RenderContext): string | null {
       : (sevenDayReset
           ? `7d: ${sevenDayDisplay} (resets in ${sevenDayReset})`
           : `7d: ${sevenDayDisplay}`);
+
+    // Free users have no 5-hour window: show only the weekly bar without a leading placeholder
+    if (fiveHour === null) {
+      return `${label} ${sevenDayPart}${syncingSuffix}`;
+    }
     return `${label} ${fiveHourPart} | ${sevenDayPart}${syncingSuffix}`;
   }
 

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -238,7 +238,7 @@ function formatTokens(n: number): string {
   return n.toString();
 }
 
-function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent' | 'tokens' | 'remaining'): string {
+function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent' | 'tokens' | 'remaining' | 'both'): string {
   if (mode === 'tokens') {
     const totalTokens = getTotalTokens(ctx.stdin);
     const size = ctx.stdin.context_window?.context_window_size ?? 0;
@@ -250,6 +250,15 @@ function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent'
 
   if (mode === 'remaining') {
     return `${Math.max(0, 100 - percent)}%`;
+  }
+
+  if (mode === 'both') {
+    const totalTokens = getTotalTokens(ctx.stdin);
+    const size = ctx.stdin.context_window?.context_window_size ?? 0;
+    if (size > 0) {
+      return `${percent}% (${formatTokens(totalTokens)}/${formatTokens(size)})`;
+    }
+    return `${percent}% (${formatTokens(totalTokens)})`;
   }
 
   return `${percent}%`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,13 @@ export interface UsageWindow {
   resetAt: Date | null;
 }
 
+export interface RateLimits {
+  requests_limit?: number;
+  requests_remaining?: number;
+  tokens_limit?: number;
+  tokens_remaining?: number;
+}
+
 export interface UsageData {
   planName: string | null;  // 'Max', 'Pro', or null for API users
   fiveHour: number | null;  // 0-100 percentage, null if unavailable
@@ -60,6 +67,7 @@ export interface UsageData {
   sevenDayResetAt: Date | null;
   apiUnavailable?: boolean; // true if API call failed (user should check DEBUG logs)
   apiError?: string; // short error reason (e.g., 401, timeout)
+  rateLimits?: RateLimits; // rate limit fields from API response
 }
 
 /** Check if usage limit is reached (either window at 100%) */

--- a/src/usage-api.ts
+++ b/src/usage-api.ts
@@ -35,6 +35,12 @@ interface UsageApiResponse {
     utilization?: number;
     resets_at?: string;
   };
+  rate_limits?: {
+    requests_limit?: number;
+    requests_remaining?: number;
+    tokens_limit?: number;
+    tokens_remaining?: number;
+  };
 }
 
 interface UsageApiResult {
@@ -401,10 +407,16 @@ export async function getUsage(overrides: Partial<UsageApiDeps> = {}): Promise<U
     const { accessToken, subscriptionType } = credentials;
 
     // Determine plan name from subscriptionType
-    const planName = getPlanName(subscriptionType);
+    let planName = getPlanName(subscriptionType);
     if (!planName) {
-      // API user, no usage limits to show
-      return null;
+      // subscriptionType may be temporarily null during OAuth refresh — fall back to cached planName
+      const lastGood = readLastGoodData(homeDir);
+      if (lastGood?.planName) {
+        planName = lastGood.planName;
+      } else {
+        // API user or truly unknown, no usage limits to show
+        return null;
+      }
     }
 
     // Fetch usage from API
@@ -458,12 +470,22 @@ export async function getUsage(overrides: Partial<UsageApiDeps> = {}): Promise<U
     const fiveHourResetAt = parseDate(apiResult.data.five_hour?.resets_at);
     const sevenDayResetAt = parseDate(apiResult.data.seven_day?.resets_at);
 
+    const rateLimits = apiResult.data.rate_limits
+      ? {
+          requests_limit: apiResult.data.rate_limits.requests_limit,
+          requests_remaining: apiResult.data.rate_limits.requests_remaining,
+          tokens_limit: apiResult.data.rate_limits.tokens_limit,
+          tokens_remaining: apiResult.data.rate_limits.tokens_remaining,
+        }
+      : undefined;
+
     const result: UsageData = {
       planName,
       fiveHour,
       sevenDay,
       fiveHourResetAt,
       sevenDayResetAt,
+      ...(rateLimits && { rateLimits }),
     };
 
     // Write to file cache — also store as lastGoodData for rate-limit resilience


### PR DESCRIPTION
## Summary

This PR ships 3 bug fixes and 2 features developed collaboratively by a multi-agent team (agent-a, hermes, agent-b, agent-c) working in parallel on the claude-hud codebase.

### Bug Fixes

- **fix #257 (usage-api):** Fall back to cached `planName` when `subscriptionType` is transiently `null` during OAuth token refresh — usage line no longer disappears mid-session
- **fix #255 (setup):** Add `--env-file /dev/null` to Bun invocation to prevent project `.env` files (e.g. `ANTHROPIC_BASE_URL`) from polluting plan detection and hiding the usage line
- **fix #238 (usage):** Free users now always see their weekly usage bar — previously it was hidden below `sevenDayThreshold` even though it's their only usage indicator. Also skips the ghost 5-hour bar (`--`) that was showing instead

### Features

- **feat #260 (usage-api):** Add `rate_limits` field support — parses `requests_limit`, `requests_remaining`, `tokens_limit`, `tokens_remaining` from the API response into `UsageData` via a new `RateLimits` interface in `types.ts`
- **feat #246 (config):** Add `contextValue: 'both'` display mode — renders context as `45% (90k/200k)` showing percent and token count together, in both expanded and compact layouts. Gracefully falls back to `45% (90k)` when window size is unavailable

## Test plan

- [ ] Verify usage line stays visible when OAuth token refreshes (subscriptionType briefly null)
- [ ] Verify HUD works correctly when project has `.env` with `ANTHROPIC_BASE_URL` and runtime is Bun
- [ ] Verify free users see `Usage ███░░░░░░░ 30% (5d 2h)` instead of `Usage ░░░░░░░░░░ --`
- [ ] Set `contextValue: 'both'` in config and confirm `45% (90k/200k)` format in HUD
- [ ] Confirm `rateLimits` field appears in UsageData when API returns rate_limits

🤖 Generated with [Claude Code](https://claude.com/claude-code) by a multi-agent team (agent-a · hermes · agent-b · agent-c)