### PR TITLE
fix(setup): use $(0) instead of $0 in awk to prevent shell variable expansion

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -109,7 +109,7 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
 1. Get plugin path (sorted by dotted numeric version, not modification time):
    ```bash
-   ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '{ print $(NF-1) "\t" $0 }' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-
+   ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '{ print $(NF-1) "\t" $(0) }' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-
    ```
    If empty, the plugin is not installed. Go back to Step 0 to check for ghost installation or EXDEV issues. If Step 0 was clean, tell user to install via `/plugin install claude-hud` first.
 
@@ -134,7 +134,7 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
 5. Generate command (quotes around runtime path handle spaces):
    ```
-   bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $0 }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
+   bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
    ```
 
 **Windows** (Platform: `win32`):


### PR DESCRIPTION
## Summary

- Replace `$0` with `$(0)` in awk commands within `commands/setup.md` to prevent Claude Code's prompt processing from expanding `$0` as a shell variable

## Problem

When Claude Code loads `setup.md` as a skill prompt, bare `$0` in awk expressions gets silently expanded to an empty string by the prompt processing pipeline. This causes the **plugin path detection command** (Step 1.1) to return an empty path.

As a result, `node` resolves the entry point against CWD instead of the plugin cache directory, producing errors like:

```
Error: Cannot find module 'C:\Users\<user>\dist\index.js'
```

**Note**: The generated command in Step 1.5 uses complex quoting (`'"'"'...$0...'"'"'`) which happens to survive the expansion in some cases, but the Step 1.1 detection command (used to verify the plugin path during setup) consistently fails.

## Root Cause

Claude Code's prompt/skill loading pipeline appears to expand simple `$<digit>` patterns (like `$0`) as shell variables. More complex patterns like `$(NF-1)` (parenthesized expressions) survive because they use the `$(...)` syntax.

## Fix

Replace `$0` → `$(0)` in the two awk commands. In awk, `$0` and `$(0)` are semantically identical — both reference the full input record. But `$(0)` uses the parenthesized expression syntax that survives prompt processing, consistent with how `$(NF-1)` already works in the same command.

### Before
```bash
awk -F/ '{ print $(NF-1) "\t" $0 }'
```

### After
```bash
awk -F/ '{ print $(NF-1) "\t" $(0) }'
```

## Testing

Verified on Windows 11 + Git Bash (win32 + bash):

```bash
# $(0) produces identical output to $0
$ echo "/a/b/0.0.10/" | awk -F/ '{ print $(NF-1) "\t" $(0) }'
0.0.10  /a/b/0.0.10/

# Full path detection works correctly
$ ls -d ~/.claude/plugins/cache/claude-hud/claude-hud/*/ | awk -F/ '{ print $(NF-1) "\t" $(0) }' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-
/c/Users/xiybh/.claude/plugins/cache/claude-hud/claude-hud/0.0.10//
```

## Affected Lines

- Line 112: Step 1.1 — path detection command (macOS/Linux/Git Bash)
- Line 137: Step 1.5 — generated `statusLine` command template