### PR TITLE
fix: use absolute GitHub path for marketplace plugin source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "claude-hud",
-      "source": "./",
+      "source": "jarrodwatts/claude-hud",
       "description": "Real-time statusline showing context usage, active tools, running agents, and todo progress. Always visible below your input, zero config required.",
       "category": "monitoring",
       "tags": ["hud", "statusline", "monitoring", "context", "tools", "agents", "todos"]


### PR DESCRIPTION
## Problem

The marketplace.json uses a relative path `./` for the plugin source, which Claude CLI cannot resolve when loading the marketplace. This causes the plugin installation to fail with 'Plugin not found in any configured marketplace'.

## Solution

Changed the plugin source from `./` to `jarrodwatts/claude-hud` (absolute GitHub path) so Claude CLI can properly locate and load the plugin.

## Testing

After this fix, users should be able to:
```
/plugin marketplace add jarrodwatts/claude-hud
/plugin install claude-hud
```

Without getting the installation error.