### PR TITLE
fix: prevent PowerShell statusline command on win32+bash

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -100,8 +100,8 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 |----------|-------|----------------|
 | `darwin` | any | bash (macOS instructions) |
 | `linux` | any | bash (Linux instructions) |
-| `win32` | `bash` (Git Bash, MSYS2) | bash (use macOS/Linux instructions) |
-| `win32` | `powershell`, `pwsh`, or `cmd` | PowerShell (use Windows instructions) |
+| `win32` | `bash` (Git Bash, MSYS2) | bash — use macOS/Linux instructions. **NEVER use PowerShell commands with bash shell.** |
+| `win32` | `powershell`, `pwsh`, or `cmd` | PowerShell (use Windows + PowerShell instructions) |
 
 ---
 
@@ -137,12 +137,11 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
    bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $0 }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
    ```
 
-**Windows** (Platform: `win32`):
+**Windows + Git Bash** (Platform: `win32`, Shell: `bash`):
 
-Choose instructions by `Shell:` value before running any commands:
-- `Shell: bash` -> use the macOS/Linux section above (same command format).
-- `Shell: powershell`, `pwsh`, or `cmd` -> use the Windows PowerShell section below.
-- Any other shell value -> stop and ask the user which shell launched Claude Code.
+**IMPORTANT**: This is the most common Windows configuration. Use the macOS/Linux bash instructions above — same detection commands, same command format. Do NOT use PowerShell commands when the shell is bash. Claude Code invokes statusline commands through bash, which interprets `$env` and `$p` as empty shell variables before PowerShell ever sees them, breaking the command silently.
+
+**Windows + PowerShell** (Platform: `win32`, Shell: `powershell`, `pwsh`, or `cmd`):
 
 1. Get plugin path:
    ```powershell


### PR DESCRIPTION
## Summary

On Windows with Git Bash (the most common Windows Claude Code config), the setup skill generates a PowerShell statusline command:

```
powershell -Command "& {$p=(Get-ChildItem $env:USERPROFILE\...}"
```

Claude Code invokes statusline commands through bash. Bash interprets `$p` and `$env` as empty shell variables **before** PowerShell sees them, so the command fails silently — node never starts and the HUD shows raw stdin JSON instead of rendered output.

## Changes

- Split the single "Windows" section into explicit **"Windows + Git Bash"** and **"Windows + PowerShell"** subsections
- Added a prominent warning explaining *why* PowerShell commands break under bash
- Bolded the routing table entry for `win32 + bash` to make it impossible to miss

## Root cause

The setup instructions had a routing table saying `win32 + bash → use macOS/Linux instructions`, but it was easy to skip because the PowerShell section was right below under a generic "Windows" header. The AI executing the skill would pick the PowerShell branch for any Windows platform regardless of shell.

## Test plan

- [ ] Run `/claude-hud:setup` on Windows with Git Bash shell — verify bash command is generated (not PowerShell)
- [ ] Run `/claude-hud:setup` on Windows with PowerShell shell — verify PowerShell command is still generated
- [ ] Verify the generated bash command works: `echo '{"model":{"display_name":"Opus"},...}' | node dist/index.js`