### PR TITLE
feat: support stdin rate_limits for usage data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { readStdin } from './stdin.js';
+import { readStdin, parseRateLimits } from './stdin.js';
 import { parseTranscript } from './transcript.js';
 import { render } from './render/index.js';
 import { countConfigs } from './config-reader.js';
@@ -58,9 +58,9 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       ? await deps.getGitStatus(stdin.cwd)
       : null;
 
-    // Only fetch usage if enabled in config (replaces env var requirement)
+    // Prefer stdin rate_limits (Claude Code v2.1.80+), fall back to OAuth API
     const usageData = config.display.showUsage !== false
-      ? await deps.getUsage({
+      ? parseRateLimits(stdin) ?? await deps.getUsage({
           ttls: {
             cacheTtlMs: config.usage.cacheTtlSeconds * 1000,
             failureCacheTtlMs: config.usage.failureCacheTtlSeconds * 1000,

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -1,4 +1,4 @@
-import type { StdinData } from './types.js';
+import type { StdinData, UsageData } from './types.js';
 import { AUTOCOMPACT_BUFFER_PERCENT } from './constants.js';
 
 export async function readStdin(): Promise<StdinData | null> {
@@ -86,6 +86,24 @@ export function getBufferedPercent(stdin: StdinData): number {
   const buffer = size * AUTOCOMPACT_BUFFER_PERCENT * scale;
 
   return Math.min(100, Math.round(((totalTokens + buffer) / size) * 100));
+}
+
+/**
+ * Convert stdin rate_limits to UsageData format.
+ * Returns null if rate_limits is absent or has no windows.
+ */
+export function parseRateLimits(stdin: StdinData): UsageData | null {
+  const rl = stdin.rate_limits;
+  if (!rl) return null;
+  if (!rl.five_hour && !rl.seven_day) return null;
+
+  return {
+    planName: 'Pro',
+    fiveHour: rl.five_hour?.used_percentage ?? null,
+    sevenDay: rl.seven_day?.used_percentage ?? null,
+    fiveHourResetAt: rl.five_hour?.resets_at ? new Date(rl.five_hour.resets_at * 1000) : null,
+    sevenDayResetAt: rl.seven_day?.resets_at ? new Date(rl.seven_day.resets_at * 1000) : null,
+  };
 }
 
 export function getModelName(stdin: StdinData): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,16 @@
 import type { HudConfig } from './config.js';
 import type { GitStatus } from './git.js';
 
+export interface StdinRateLimitWindow {
+  used_percentage: number;
+  resets_at: number; // Unix epoch seconds
+}
+
+export interface StdinRateLimits {
+  five_hour?: StdinRateLimitWindow;
+  seven_day?: StdinRateLimitWindow;
+}
+
 export interface StdinData {
   transcript_path?: string;
   cwd?: string;
@@ -20,6 +30,7 @@ export interface StdinData {
     used_percentage?: number | null;
     remaining_percentage?: number | null;
   };
+  rate_limits?: StdinRateLimits;
 }
 
 export interface ToolEntry {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -167,3 +167,58 @@ test('main includes usageData in render context', async () => {
 
   assert.deepEqual(renderedContext?.usageData, mockUsageData);
 });
+
+test('main uses stdin rate_limits instead of calling getUsage', async () => {
+  let renderedContext;
+  let getUsageCalled = false;
+
+  await main({
+    readStdin: async () => ({
+      model: { display_name: 'Opus' },
+      context_window: { context_window_size: 100, current_usage: { input_tokens: 10 } },
+      rate_limits: {
+        five_hour: { used_percentage: 23.5, resets_at: 1738425600 },
+        seven_day: { used_percentage: 41.2, resets_at: 1738857600 },
+      },
+    }),
+    parseTranscript: async () => ({ tools: [], agents: [], todos: [] }),
+    countConfigs: async () => ({ claudeMdCount: 0, rulesCount: 0, mcpCount: 0, hooksCount: 0 }),
+    getUsage: async () => {
+      getUsageCalled = true;
+      return null;
+    },
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.equal(getUsageCalled, false, 'getUsage should not be called when stdin has rate_limits');
+  assert.equal(renderedContext?.usageData?.planName, 'Pro');
+  assert.equal(renderedContext?.usageData?.fiveHour, 23.5);
+  assert.equal(renderedContext?.usageData?.sevenDay, 41.2);
+});
+
+test('main falls back to getUsage when stdin has no rate_limits', async () => {
+  let renderedContext;
+  let getUsageCalled = false;
+  const mockUsage = { planName: 'Max', fiveHour: 10, sevenDay: 5, fiveHourResetAt: null, sevenDayResetAt: null };
+
+  await main({
+    readStdin: async () => ({
+      model: { display_name: 'Opus' },
+      context_window: { context_window_size: 100, current_usage: { input_tokens: 10 } },
+    }),
+    parseTranscript: async () => ({ tools: [], agents: [], todos: [] }),
+    countConfigs: async () => ({ claudeMdCount: 0, rulesCount: 0, mcpCount: 0, hooksCount: 0 }),
+    getUsage: async () => {
+      getUsageCalled = true;
+      return mockUsage;
+    },
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.equal(getUsageCalled, true, 'getUsage should be called when stdin has no rate_limits');
+  assert.deepEqual(renderedContext?.usageData, mockUsage);
+});

--- a/tests/stdin.test.js
+++ b/tests/stdin.test.js
@@ -1,6 +1,6 @@
-import { test } from 'node:test';
+import { describe, test, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readStdin } from '../dist/stdin.js';
+import { readStdin, parseRateLimits } from '../dist/stdin.js';
 
 test('readStdin returns null for TTY input', async () => {
   const originalIsTTY = process.stdin.isTTY;
@@ -29,4 +29,72 @@ test('readStdin returns null on stream errors', async () => {
     process.stdin.setEncoding = originalSetEncoding;
     Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
   }
+});
+
+describe('parseRateLimits', () => {
+  it('returns null when rate_limits is absent', () => {
+    assert.equal(parseRateLimits({}), null);
+  });
+
+  it('returns null when rate_limits has no windows', () => {
+    assert.equal(parseRateLimits({ rate_limits: {} }), null);
+  });
+
+  it('parses both windows', () => {
+    const result = parseRateLimits({
+      rate_limits: {
+        five_hour: { used_percentage: 23.5, resets_at: 1738425600 },
+        seven_day: { used_percentage: 41.2, resets_at: 1738857600 },
+      },
+    });
+    assert.equal(result.planName, 'Pro');
+    assert.equal(result.fiveHour, 23.5);
+    assert.equal(result.sevenDay, 41.2);
+    assert.ok(result.fiveHourResetAt instanceof Date);
+    assert.equal(result.fiveHourResetAt.getTime(), 1738425600 * 1000);
+    assert.equal(result.sevenDayResetAt.getTime(), 1738857600 * 1000);
+  });
+
+  it('handles five_hour only', () => {
+    const result = parseRateLimits({
+      rate_limits: {
+        five_hour: { used_percentage: 80, resets_at: 1738425600 },
+      },
+    });
+    assert.equal(result.fiveHour, 80);
+    assert.equal(result.sevenDay, null);
+    assert.equal(result.sevenDayResetAt, null);
+  });
+
+  it('handles seven_day only', () => {
+    const result = parseRateLimits({
+      rate_limits: {
+        seven_day: { used_percentage: 50, resets_at: 1738857600 },
+      },
+    });
+    assert.equal(result.fiveHour, null);
+    assert.equal(result.sevenDay, 50);
+  });
+
+  it('handles 100% (limit reached)', () => {
+    const result = parseRateLimits({
+      rate_limits: {
+        five_hour: { used_percentage: 100, resets_at: 1738425600 },
+        seven_day: { used_percentage: 100, resets_at: 1738857600 },
+      },
+    });
+    assert.equal(result.fiveHour, 100);
+    assert.equal(result.sevenDay, 100);
+  });
+
+  it('handles 0% usage', () => {
+    const result = parseRateLimits({
+      rate_limits: {
+        five_hour: { used_percentage: 0, resets_at: 1738425600 },
+        seven_day: { used_percentage: 0, resets_at: 1738857600 },
+      },
+    });
+    assert.equal(result.fiveHour, 0);
+    assert.equal(result.sevenDay, 0);
+  });
 });


### PR DESCRIPTION
## Summary

- Parse `rate_limits` from stdin data (Claude Code v2.1.80+) to get usage info without the OAuth API round-trip
- Fall back to existing `getUsage()` OAuth flow when stdin does not include `rate_limits` (older Claude Code versions)
- No changes to render code -- `UsageData` interface is consumed as-is

## Changes

- **`src/types.ts`**: Add `StdinRateLimitWindow`, `StdinRateLimits` interfaces and `rate_limits` field to `StdinData`
- **`src/stdin.ts`**: Add `parseRateLimits()` function that converts stdin rate_limits to `UsageData`
- **`src/index.ts`**: Prefer `parseRateLimits(stdin)` over `getUsage()`, with OAuth as fallback
- **`tests/stdin.test.js`**: 7 test cases for `parseRateLimits` (null/absent, both windows, single window, edge cases)
- **`tests/index.test.js`**: 2 test cases verifying stdin-first priority and OAuth fallback in `main()`

## stdin rate_limits spec

```json
{
  "rate_limits": {
    "five_hour": { "used_percentage": 23.5, "resets_at": 1738425600 },
    "seven_day": { "used_percentage": 41.2, "resets_at": 1738857600 }
  }
}
```

- `used_percentage`: float (0-100)
- `resets_at`: Unix epoch seconds
- Field is absent for non-subscribers or before first API response
- Each window can independently be absent

## Test plan

- [x] `npm run build` passes
- [x] `node --test` -- 281 passed, 0 failed, 1 skipped (Windows path test)
- [x] Verified `parseRateLimits` returns null when rate_limits absent
- [x] Verified `parseRateLimits` correctly parses both/single windows
- [x] Verified `main()` skips OAuth when stdin has rate_limits
- [x] Verified `main()` falls back to OAuth when stdin lacks rate_limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)