### PR TITLE
fix(render): strip OSC 8 sequences from visual length calculation

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -15,8 +15,9 @@ import {
 import { dim, RESET } from './colors.js';
 
 // eslint-disable-next-line no-control-regex
-const ANSI_ESCAPE_PATTERN = /^\x1b\[[0-9;]*m/;
-const ANSI_ESCAPE_GLOBAL = /\x1b\[[0-9;]*m/g;
+const ANSI_ESCAPE_PATTERN = /^(?:\x1b\[[0-9;]*m|\x1b\][^\x1b]*\x1b\\)/;
+// eslint-disable-next-line no-control-regex
+const ANSI_ESCAPE_GLOBAL = /(?:\x1b\[[0-9;]*m|\x1b\][^\x1b]*\x1b\\)/g;
 const GRAPHEME_SEGMENTER = typeof Intl.Segmenter === 'function'
   ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
   : null;


### PR DESCRIPTION
## Problem

The ANSI escape patterns only matched SGR color sequences (`\x1b[...m`), leaving OSC 8 hyperlink sequences (`\x1b]8;;URL\x1b\\ ... \x1b]8;;\x1b\\`) counted as **visible characters** in `visualLength()` and `sliceVisible()`.

This causes HUD elements to be measured as wider than they actually appear, so line-wrapping kicks in too early — pushing elements like the context bar, session duration, and model badge off-screen on any terminal that renders OSC 8 hyperlinks (Ghostty, iTerm2, WezTerm, Kitty).

## Fix

Extend both `ANSI_ESCAPE_PATTERN` and `ANSI_ESCAPE_GLOBAL` to also match `\x1b][^\x1b]*\x1b\\` (OSC sequences terminated by String Terminator), which covers OSC 8 and any other OSC sequences.

```diff
-const ANSI_ESCAPE_PATTERN = /^\x1b\[[0-9;]*m/;
-const ANSI_ESCAPE_GLOBAL = /\x1b\[[0-9;]*m/g;
+// eslint-disable-next-line no-control-regex
+const ANSI_ESCAPE_PATTERN = /^(?:\x1b\[[0-9;]*m|\x1b\][^\x1b]*\x1b\\)/;
+// eslint-disable-next-line no-control-regex
+const ANSI_ESCAPE_GLOBAL = /(?:\x1b\[[0-9;]*m|\x1b\][^\x1b]*\x1b\\)/g;
```

## Test plan

- [ ] Open Claude Code in a terminal with OSC 8 support (Ghostty, iTerm2, WezTerm)
- [ ] Add any hyperlink to a HUD line (e.g. enable `showProject` with a `file://` link)
- [ ] Confirm all other HUD elements (context bar, duration, model badge) still appear correctly on the same line without being pushed off-screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)