### PR TITLE
fix: prevent invalid JSON escape in statusLine command

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -214,6 +214,12 @@ Read the settings file and merge in the statusLine config, preserving all existi
 If the file doesn't exist, create it. If it contains invalid JSON, report the error and do not overwrite.
 If a write fails with `File has been unexpectedly modified`, re-read the file and retry the merge once.
 
+**CRITICAL - JSON escaping**: The generated command contains `$` characters (from bash variables and awk expressions like `$(NF-1)` and `$0`). When writing to JSON:
+- Do NOT manually escape `$` as `\$` - this is NOT a valid JSON escape sequence and will break `settings.json` parsing entirely (#315).
+- Instead, use the Read tool to load the existing settings, construct the merged object in your working memory, and use the Edit or Write tool to produce valid JSON. The `$` character is valid as-is inside JSON strings and does not need any escaping.
+- Only these characters require escaping in JSON strings: `"` (as `\"`), `\` (as `\\`), and control characters (`\n`, `\t`, etc.).
+- After writing, verify the output is valid JSON by reading it back.
+
 ```json
 {
   "statusLine": {


### PR DESCRIPTION
## Problem

When running `/claude-hud:setup`, the setup step that writes the command into `settings.json` sometimes produces invalid JSON because `$` characters from the awk expression (like `$(NF-1)` and `$0`) get escaped as `\$`. But `\$` is not valid JSON escape sequence, so the whole `settings.json` file becomes unparseable and Claude Code shows the "Invalid or malformed JSON" error on startup.

I was getting this exact error after fresh setup and it took me some time to figure out what happened. The settings file was corrupted by the escaped dollar signs.

## What I changed

Added explicit guidance in `commands/setup.md` Step 3 about JSON escaping rules. The key points:
- Dollar sign `$` does not need escaping in JSON strings, it is valid as-is
- Manually escaping as `\$` breaks the file because only `\"`, `\\`, and control characters are valid JSON escapes
- After writing should verify the output is valid JSON

This is a prompt-level fix since `setup.md` is the instruction file that guides Claude during the setup process. The root cause is Claude sometimes "helpfully" escaping `$` when it shouldn't.

## How to test

1. Run `/claude-hud:setup` on fresh install
2. Check `~/.claude/settings.json` - the `statusLine.command` value should contain raw `$` characters, not `\$`
3. Claude Code should start normally without JSON error

Closes #315