### PR TITLE
fix: add JSON escaping guidance to prevent invalid \$ in settings.json (#315)

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -214,6 +214,49 @@ Read the settings file and merge in the statusLine config, preserving all existi
 If the file doesn't exist, create it. If it contains invalid JSON, report the error and do not overwrite.
 If a write fails with `File has been unexpectedly modified`, re-read the file and retry the merge once.
 
+### ⚠️ CRITICAL: JSON Escaping Rules
+
+When writing the command string to JSON, **dollar signs (`$`) must appear literally** — they do NOT need escaping in JSON strings.
+
+**DO NOT escape `$` as `\$`** because `\$` is not a valid JSON escape sequence and will cause Claude Code to crash on startup with "Unexpected token" or "Invalid escape sequence" errors.
+
+Only these escape sequences are valid in JSON strings:
+- `\"` (double quote)
+- `\\` (backslash)
+- `\/` (forward slash, optional)
+- `\n` (newline)
+- `\t` (tab)
+- `\r` (carriage return)
+- `\b` (backspace)
+- `\f` (form feed)
+- `\uXXXX` (unicode escape)
+
+The generated commands contain shell variables like `$(NF-1)`, `$HOME`, `$env:CLAUDE_CONFIG_DIR`, and `$p`. All of these dollar signs should appear literally in the JSON string value.
+
+**Example of CORRECT JSON** (bash command with dollar signs literal):
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash -c 'plugin_dir=$(ls -d \"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '\"'\"'{ print $(NF-1) \"\\t\" $(0) }'\"'\"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec \"/usr/bin/node\" \"${plugin_dir}dist/index.js\"'"
+  }
+}
+```
+
+**Example of CORRECT JSON** (PowerShell command with dollar signs literal):
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "powershell -Command \"& {$claudeDir=if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME '.claude' }; $p=(Get-ChildItem (Join-Path $claudeDir 'plugins\\cache\\claude-hud\\claude-hud') -Directory | Where-Object { $_.Name -match '^\\d+(\\.\\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName; & 'C:\\Program Files\\nodejs\\node.exe' (Join-Path $p 'dist\\index.js')}\""
+  }
+}
+```
+
+Note that in the PowerShell example, backslashes in Windows paths are escaped as `\\` (which is correct), but dollar signs remain as `$` (not `\\$`).
+
+### Configuration Schema
+
 ```json
 {
   "statusLine": {


### PR DESCRIPTION
## Summary

Fixes #315 — Claude Code crashes with "Invalid or malformed JSON" when the setup command writes statusLine config to `settings.json`.

## Root Cause

The generated bash command contains shell variables (`$(NF-1)`, `$HOME`, `$0`, etc). When Claude Code writes this command into a JSON string, it sometimes incorrectly escapes `$` as `\$`. Since `\$` is not a valid JSON escape sequence, the entire settings.json becomes unparseable.

## Fix

Added a prominent **"JSON Escaping Rules"** section to `commands/setup.md` Step 3, right before the JSON config template:

- **Clear rule**: Dollar signs must appear literally in JSON strings — do NOT escape as `\$`
- **Valid escapes list**: All 8 valid JSON escape sequences for reference
- **Correct examples**: Full JSON snippets showing proper formatting for both bash and PowerShell commands
- **PowerShell note**: Backslashes in Windows paths need `\\` escaping, but dollar signs remain literal

## Why this approach

The bug is in Claude Code's behavior when executing the setup command, not in claude-hud's source code. The fix is to make the setup instructions explicit enough that Claude Code won't misapply escaping rules. The existing command templates are correct bash — the issue is only in how they get serialized to JSON.