### PR TITLE
feat: add showAccount display option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- New `display.showAccount` option to display the currently logged-in account (email or display name with organization) in the project/session line. Disabled by default; customizable via `colors.account`.
+
 ### Changed
 - Simplify usage display to rely only on Claude Code's official stdin `rate_limits` fields.
 - Remove the background OAuth usage API fallback, related cache/lock behavior, and credential-derived subscriber plan labels from the HUD.

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import { getClaudeConfigJsonPath } from './claude-config-dir.js';
+import { createDebug } from './debug.js';
+
+const debug = createDebug('account');
+
+export interface AccountInfo {
+  email: string;
+  displayName?: string;
+  orgName?: string;
+}
+
+type AccountReader = (configPath: string) => AccountInfo | null;
+
+let cachedMtimeMs: number | undefined;
+let cachedAccountInfo: AccountInfo | null = null;
+
+function defaultReadAccount(configPath: string): AccountInfo | null {
+  const content = fs.readFileSync(configPath, 'utf-8');
+  const config = JSON.parse(content);
+  const oauth = config.oauthAccount;
+
+  if (!oauth || typeof oauth.emailAddress !== 'string') {
+    debug('No oauthAccount or emailAddress in config');
+    return null;
+  }
+
+  return {
+    email: oauth.emailAddress,
+    displayName: typeof oauth.displayName === 'string' ? oauth.displayName : undefined,
+    orgName: typeof oauth.organizationName === 'string' ? oauth.organizationName : undefined,
+  };
+}
+
+let readAccount: AccountReader = defaultReadAccount;
+
+export async function getAccountInfo(): Promise<AccountInfo | null> {
+  // getClaudeConfigJsonPath appends ".json" to the config directory,
+  // producing e.g. ~/.claude.json (a sibling of ~/.claude/).
+  const configPath = getClaudeConfigJsonPath(os.homedir());
+
+  try {
+    const stat = fs.statSync(configPath);
+    if (stat.mtimeMs === cachedMtimeMs) {
+      return cachedAccountInfo;
+    }
+
+    cachedMtimeMs = stat.mtimeMs;
+    cachedAccountInfo = readAccount(configPath);
+    return cachedAccountInfo;
+  } catch (error) {
+    debug('Failed to read account info:', error);
+    return null;
+  }
+}
+
+export function formatAccountLabel(info: AccountInfo): string {
+  const { email, displayName, orgName } = info;
+
+  // If org name is distinct from the email (i.e. not a personal org), show it
+  const emailPrefix = email.split('@')[0];
+  const hasDistinctOrg = orgName
+    && !orgName.includes(emailPrefix)
+    && orgName !== email;
+
+  if (displayName && hasDistinctOrg) {
+    return `${displayName} @ ${orgName}`;
+  }
+
+  if (hasDistinctOrg) {
+    return `${emailPrefix} @ ${orgName}`;
+  }
+
+  return email;
+}
+
+export function _resetAccountCache(): void {
+  cachedMtimeMs = undefined;
+  cachedAccountInfo = null;
+}
+
+export function _setAccountReaderForTests(reader: AccountReader | null): void {
+  readAccount = reader ?? defaultReadAccount;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ export interface HudColorOverrides {
   gitBranch: HudColorValue;
   label: HudColorValue;
   custom: HudColorValue;
+  account: HudColorValue;
 }
 
 export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
@@ -76,6 +77,7 @@ export interface HudConfig {
     showSessionName: boolean;
     showClaudeCodeVersion: boolean;
     showMemoryUsage: boolean;
+    showAccount: boolean;
     autocompactBuffer: AutocompactBufferMode;
     usageThreshold: number;
     sevenDayThreshold: number;
@@ -113,6 +115,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showSessionName: false,
     showClaudeCodeVersion: false,
     showMemoryUsage: false,
+    showAccount: false,
     autocompactBuffer: 'enabled',
     usageThreshold: 0,
     sevenDayThreshold: 80,
@@ -131,6 +134,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     gitBranch: 'cyan',
     label: 'dim',
     custom: 208,
+    account: 'dim',
   },
 };
 
@@ -316,6 +320,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showMemoryUsage: typeof migrated.display?.showMemoryUsage === 'boolean'
       ? migrated.display.showMemoryUsage
       : DEFAULT_CONFIG.display.showMemoryUsage,
+    showAccount: typeof migrated.display?.showAccount === 'boolean'
+      ? migrated.display.showAccount
+      : DEFAULT_CONFIG.display.showAccount,
     autocompactBuffer: validateAutocompactBuffer(migrated.display?.autocompactBuffer)
       ? migrated.display.autocompactBuffer
       : DEFAULT_CONFIG.display.autocompactBuffer,
@@ -361,6 +368,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     custom: validateColorValue(migrated.colors?.custom)
       ? migrated.colors.custom
       : DEFAULT_CONFIG.colors.custom,
+    account: validateColorValue(migrated.colors?.account)
+      ? migrated.colors.account
+      : DEFAULT_CONFIG.colors.account,
   };
 
   return { lineLayout, showSeparators, pathLevels, elementOrder, gitStatus, display, colors };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { loadConfig } from './config.js';
 import { parseExtraCmdArg, runExtraCmd } from './extra-cmd.js';
 import { getClaudeCodeVersion } from './version.js';
 import { getMemoryUsage } from './memory.js';
+import { getAccountInfo } from './account.js';
 import type { RenderContext } from './types.js';
 import { fileURLToPath } from 'node:url';
 import { realpathSync } from 'node:fs';
@@ -22,6 +23,7 @@ export type MainDeps = {
   runExtraCmd: typeof runExtraCmd;
   getClaudeCodeVersion: typeof getClaudeCodeVersion;
   getMemoryUsage: typeof getMemoryUsage;
+  getAccountInfo: typeof getAccountInfo;
   render: typeof render;
   now: () => number;
   log: (...args: unknown[]) => void;
@@ -39,6 +41,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     runExtraCmd,
     getClaudeCodeVersion,
     getMemoryUsage,
+    getAccountInfo,
     render,
     now: () => Date.now(),
     log: console.log,
@@ -84,6 +87,9 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     const memoryUsage = config.display.showMemoryUsage && config.lineLayout === 'expanded'
       ? await deps.getMemoryUsage()
       : null;
+    const accountInfo = config.display.showAccount
+      ? await deps.getAccountInfo()
+      : null;
 
     const ctx: RenderContext = {
       stdin,
@@ -99,6 +105,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       config,
       extraLabel,
       claudeCodeVersion,
+      accountInfo,
     };
 
     deps.render(ctx);

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -108,6 +108,10 @@ export function custom(text: string, colors?: Partial<HudColorOverrides>): strin
   return withOverride(text, colors?.custom, CLAUDE_ORANGE);
 }
 
+export function account(text: string, colors?: Partial<HudColorOverrides>): string {
+  return withOverride(text, colors?.account, DIM);
+}
+
 export function warning(text: string, colors?: Partial<HudColorOverrides>): string {
   return colorize(text, resolveAnsi(colors?.warning, YELLOW));
 }

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -1,7 +1,8 @@
 import type { RenderContext } from '../../types.js';
 import { getModelName, getProviderLabel } from '../../stdin.js';
 import { getOutputSpeed } from '../../speed-tracker.js';
-import { git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, red, custom as customColor } from '../colors.js';
+import { git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, red, custom as customColor, account as accountColor } from '../colors.js';
+import { formatAccountLabel } from '../../account.js';
 
 export function renderProjectLine(ctx: RenderContext): string | null {
   const display = ctx.config?.display;
@@ -75,6 +76,10 @@ export function renderProjectLine(ctx: RenderContext): string | null {
 
   if (display?.showClaudeCodeVersion && ctx.claudeCodeVersion) {
     parts.push(label(`CC v${ctx.claudeCodeVersion}`, colors));
+  }
+
+  if (display?.showAccount && ctx.accountInfo) {
+    parts.push(accountColor(formatAccountLabel(ctx.accountInfo), colors));
   }
 
   if (ctx.extraLabel) {

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -2,7 +2,8 @@ import type { RenderContext } from '../types.js';
 import { isLimitReached } from '../types.js';
 import { getContextPercent, getBufferedPercent, getModelName, getProviderLabel, getTotalTokens } from '../stdin.js';
 import { getOutputSpeed } from '../speed-tracker.js';
-import { coloredBar, critical, git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, red, getContextColor, getQuotaColor, quotaBar, custom as customColor, RESET } from './colors.js';
+import { coloredBar, critical, git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, red, getContextColor, getQuotaColor, quotaBar, custom as customColor, account as accountColor, RESET } from './colors.js';
+import { formatAccountLabel } from '../account.js';
 import { getAdaptiveBarWidth } from '../utils/terminal.js';
 
 const DEBUG = process.env.DEBUG?.includes('claude-hud') || process.env.DEBUG === '*';
@@ -115,6 +116,11 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   if (display?.showClaudeCodeVersion && ctx.claudeCodeVersion) {
     parts.push(label(`CC v${ctx.claudeCodeVersion}`, colors));
+  }
+
+  // Account info
+  if (display?.showAccount && ctx.accountInfo) {
+    parts.push(accountColor(formatAccountLabel(ctx.accountInfo), colors));
   }
 
   // Config counts (respects environmentThreshold)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { HudConfig } from './config.js';
 import type { GitStatus } from './git.js';
+import type { AccountInfo } from './account.js';
 
 export interface StdinData {
   transcript_path?: string;
@@ -97,4 +98,5 @@ export interface RenderContext {
   config: HudConfig;
   extraLabel: string | null;
   claudeCodeVersion?: string;
+  accountInfo: AccountInfo | null;
 }

--- a/tests/account.test.js
+++ b/tests/account.test.js
@@ -1,0 +1,314 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { getAccountInfo, formatAccountLabel, _resetAccountCache, _setAccountReaderForTests } from '../dist/account.js';
+import { renderSessionLine } from '../dist/render/session-line.js';
+import { renderProjectLine } from '../dist/render/lines/project.js';
+import { main } from '../dist/index.js';
+import { DEFAULT_CONFIG } from '../dist/config.js';
+
+function stripAnsi(str) {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+function baseContext(overrides = {}) {
+  return {
+    stdin: {
+      model: { display_name: 'Opus' },
+      context_window: {
+        context_window_size: 200000,
+        current_usage: { input_tokens: 10000 },
+      },
+    },
+    transcript: { tools: [], agents: [], todos: [] },
+    claudeMdCount: 0,
+    rulesCount: 0,
+    mcpCount: 0,
+    hooksCount: 0,
+    sessionDuration: '',
+    gitStatus: null,
+    usageData: null,
+    memoryUsage: null,
+    config: {
+      ...DEFAULT_CONFIG,
+      lineLayout: 'compact',
+      display: { ...DEFAULT_CONFIG.display, showAccount: true },
+    },
+    extraLabel: null,
+    accountInfo: null,
+    ...overrides,
+  };
+}
+
+// --- formatAccountLabel ---
+
+test('formatAccountLabel returns email for personal org', () => {
+  const result = formatAccountLabel({
+    email: 'alice@example.com',
+    displayName: 'Alice',
+    orgName: "alice@example.com's Organization",
+  });
+  assert.equal(result, 'alice@example.com');
+});
+
+test('formatAccountLabel shows displayName @ orgName for distinct org', () => {
+  const result = formatAccountLabel({
+    email: 'alice@company.com',
+    displayName: 'Alice',
+    orgName: 'Acme Corp',
+  });
+  assert.equal(result, 'Alice @ Acme Corp');
+});
+
+test('formatAccountLabel uses email prefix when no displayName and distinct org', () => {
+  const result = formatAccountLabel({
+    email: 'alice@company.com',
+    orgName: 'Acme Corp',
+  });
+  assert.equal(result, 'alice @ Acme Corp');
+});
+
+test('formatAccountLabel returns just email when no org', () => {
+  const result = formatAccountLabel({ email: 'alice@example.com' });
+  assert.equal(result, 'alice@example.com');
+});
+
+test('formatAccountLabel returns email when orgName is empty string', () => {
+  const result = formatAccountLabel({ email: 'alice@example.com', orgName: '' });
+  assert.equal(result, 'alice@example.com');
+});
+
+// --- getAccountInfo with test seam ---
+
+test('getAccountInfo reads account via reader', async () => {
+  _resetAccountCache();
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-account-'));
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+  try {
+    process.env.CLAUDE_CONFIG_DIR = tempDir;
+    // getClaudeConfigJsonPath produces ${tempDir}.json (sibling of the directory)
+    await writeFile(`${tempDir}.json`, JSON.stringify({
+      oauthAccount: {
+        emailAddress: 'test@example.com',
+        displayName: 'Test User',
+        organizationName: 'Test Org',
+      },
+    }));
+
+    const info = await getAccountInfo();
+    assert.deepEqual(info, {
+      email: 'test@example.com',
+      displayName: 'Test User',
+      orgName: 'Test Org',
+    });
+  } finally {
+    _resetAccountCache();
+    process.env.CLAUDE_CONFIG_DIR = originalConfigDir ?? '';
+    await rm(tempDir, { recursive: true });
+    await rm(`${tempDir}.json`, { force: true });
+  }
+});
+
+test('getAccountInfo returns null when config file does not exist', async () => {
+  _resetAccountCache();
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-account-'));
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+  try {
+    process.env.CLAUDE_CONFIG_DIR = tempDir;
+    // No .json file created — statSync will throw ENOENT
+    const info = await getAccountInfo();
+    assert.equal(info, null);
+  } finally {
+    _resetAccountCache();
+    process.env.CLAUDE_CONFIG_DIR = originalConfigDir ?? '';
+    await rm(tempDir, { recursive: true });
+  }
+});
+
+test('getAccountInfo returns null when oauthAccount is missing', async () => {
+  _resetAccountCache();
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-account-'));
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+  try {
+    process.env.CLAUDE_CONFIG_DIR = tempDir;
+    await writeFile(`${tempDir}.json`, JSON.stringify({ userID: 'abc' }));
+
+    const info = await getAccountInfo();
+    assert.equal(info, null);
+  } finally {
+    _resetAccountCache();
+    process.env.CLAUDE_CONFIG_DIR = originalConfigDir ?? '';
+    await rm(tempDir, { recursive: true });
+    await rm(`${tempDir}.json`, { force: true });
+  }
+});
+
+test('getAccountInfo returns null for malformed JSON', async () => {
+  _resetAccountCache();
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-account-'));
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+  try {
+    process.env.CLAUDE_CONFIG_DIR = tempDir;
+    await writeFile(`${tempDir}.json`, '{ not valid json!!!');
+
+    const info = await getAccountInfo();
+    assert.equal(info, null);
+  } finally {
+    _resetAccountCache();
+    process.env.CLAUDE_CONFIG_DIR = originalConfigDir ?? '';
+    await rm(tempDir, { recursive: true });
+    await rm(`${tempDir}.json`, { force: true });
+  }
+});
+
+test('getAccountInfo returns null when emailAddress is not a string', async () => {
+  _resetAccountCache();
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-account-'));
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+  try {
+    process.env.CLAUDE_CONFIG_DIR = tempDir;
+    await writeFile(`${tempDir}.json`, JSON.stringify({
+      oauthAccount: { emailAddress: 42, displayName: 'Alice' },
+    }));
+
+    const info = await getAccountInfo();
+    assert.equal(info, null);
+  } finally {
+    _resetAccountCache();
+    process.env.CLAUDE_CONFIG_DIR = originalConfigDir ?? '';
+    await rm(tempDir, { recursive: true });
+    await rm(`${tempDir}.json`, { force: true });
+  }
+});
+
+test('getAccountInfo uses mtime cache on repeated calls', async () => {
+  _resetAccountCache();
+  let readCalls = 0;
+  _setAccountReaderForTests((configPath) => {
+    readCalls += 1;
+    return { email: 'cached@test.com' };
+  });
+
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-account-'));
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+  try {
+    process.env.CLAUDE_CONFIG_DIR = tempDir;
+    await writeFile(`${tempDir}.json`, '{}');
+
+    await getAccountInfo();
+    await getAccountInfo();
+    await getAccountInfo();
+
+    assert.equal(readCalls, 1, 'should only read file once when mtime unchanged');
+  } finally {
+    _resetAccountCache();
+    _setAccountReaderForTests(null);
+    process.env.CLAUDE_CONFIG_DIR = originalConfigDir ?? '';
+    await rm(tempDir, { recursive: true });
+    await rm(`${tempDir}.json`, { force: true });
+  }
+});
+
+// --- renderSessionLine with account ---
+
+test('renderSessionLine shows account when enabled and accountInfo present', () => {
+  const ctx = baseContext({
+    accountInfo: { email: 'alice@company.com', displayName: 'Alice', orgName: 'Acme Corp' },
+  });
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('Alice @ Acme Corp'), `Expected account in: ${line}`);
+});
+
+test('renderSessionLine omits account when showAccount is false', () => {
+  const ctx = baseContext({
+    config: {
+      ...DEFAULT_CONFIG,
+      lineLayout: 'compact',
+      display: { ...DEFAULT_CONFIG.display, showAccount: false },
+    },
+    accountInfo: { email: 'alice@company.com', displayName: 'Alice', orgName: 'Acme Corp' },
+  });
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(!line.includes('Alice'), `Should not contain account in: ${line}`);
+});
+
+test('renderSessionLine omits account when accountInfo is null', () => {
+  const ctx = baseContext({ accountInfo: null });
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(!line.includes('@'), `Should not contain account in: ${line}`);
+});
+
+// --- renderProjectLine (expanded) with account ---
+
+test('renderProjectLine shows account in expanded mode', () => {
+  const ctx = baseContext({
+    accountInfo: { email: 'bob@work.com', displayName: 'Bob', orgName: 'WorkCo' },
+  });
+  ctx.config.lineLayout = 'expanded';
+  const line = stripAnsi(renderProjectLine(ctx));
+  assert.ok(line.includes('Bob @ WorkCo'), `Expected account in: ${line}`);
+});
+
+// --- main integration ---
+
+test('main includes accountInfo in render context when showAccount is enabled', async () => {
+  _resetAccountCache();
+  let renderedContext;
+  let lookupCalls = 0;
+
+  await main({
+    readStdin: async () => ({
+      model: { display_name: 'Opus' },
+      context_window: { context_window_size: 100, current_usage: { input_tokens: 10 } },
+    }),
+    parseTranscript: async () => ({ tools: [], agents: [], todos: [] }),
+    countConfigs: async () => ({ claudeMdCount: 0, rulesCount: 0, mcpCount: 0, hooksCount: 0 }),
+    getGitStatus: async () => null,
+    loadConfig: async () => ({
+      ...DEFAULT_CONFIG,
+      display: { ...DEFAULT_CONFIG.display, showAccount: true },
+    }),
+    getAccountInfo: async () => {
+      lookupCalls += 1;
+      return { email: 'int@test.com', displayName: 'IntTest', orgName: 'IntOrg' };
+    },
+    render: (ctx) => { renderedContext = ctx; },
+  });
+
+  assert.equal(lookupCalls, 1);
+  assert.deepEqual(renderedContext?.accountInfo, {
+    email: 'int@test.com',
+    displayName: 'IntTest',
+    orgName: 'IntOrg',
+  });
+});
+
+test('main skips getAccountInfo when showAccount is disabled', async () => {
+  let lookupCalls = 0;
+
+  await main({
+    readStdin: async () => ({
+      model: { display_name: 'Opus' },
+      context_window: { context_window_size: 100, current_usage: { input_tokens: 10 } },
+    }),
+    parseTranscript: async () => ({ tools: [], agents: [], todos: [] }),
+    countConfigs: async () => ({ claudeMdCount: 0, rulesCount: 0, mcpCount: 0, hooksCount: 0 }),
+    getGitStatus: async () => null,
+    getAccountInfo: async () => {
+      lookupCalls += 1;
+      return { email: 'skip@test.com' };
+    },
+    render: () => {},
+  });
+
+  assert.equal(lookupCalls, 0, 'should not call getAccountInfo when showAccount is false');
+});


### PR DESCRIPTION
## Summary

- Adds a `display.showAccount` config option that shows the currently logged-in account (email, display name, and/or organization) in the project/session line
- Disabled by default — users opt in via `config.json`
- Works in both compact and expanded layouts
- Color customizable via `colors.account` (defaults to dim)
- Reads `oauthAccount` from `~/.claude.json` with mtime-based caching to avoid re-parsing on every 300ms tick

## How it looks

With `{ "display": { "showAccount": true } }` in config:

- **Distinct org:** `[Opus] │ Alice @ Acme Corp`
- **Personal org:** `[Opus] │ user@example.com`

## Test plan

- [x] `npm test` — 17 new tests, all 281 existing tests pass
- [x] `npm run test:coverage`
- [x] Tested manually in both compact and expanded layouts
- [x] Verified mtime caching works (file only re-read when changed)
- [x] No `dist/` changes included