### PR TITLE
README.md: added the instruction to /reload-plugins after installing claude-hud

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ Then run the install command below in that session. This is a [Claude Code platf
 /plugin install claude-hud
 ```
 
+After that, reload plugins:
+
+```
+/reload-plugins
+```
+
+
 **Step 3: Configure the statusline**
 ```
 /claude-hud:setup


### PR DESCRIPTION
Added a simple /reload-plugins instruction in the README, which is required to have claude-hud available after installing.