### PR TITLE
feat: add claude server status indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Claude HUD gives you better insights into what's happening in your Claude Code s
 | **Tool activity** | Watch Claude read, edit, and search files as it happens |
 | **Agent tracking** | See which subagents are running and what they're doing |
 | **Todo progress** | Track task completion in real-time |
+| **Service status** | See Claude Code service health at a glance — know if an outage is you or them |
 
 ## What You See
 
@@ -166,6 +167,7 @@ Edit `~/.claude/plugins/claude-hud/config.json` directly for advanced settings s
 | `display.showSessionName` | boolean | false | Show session slug or custom title from `/rename` |
 | `display.showClaudeCodeVersion` | boolean | false | Show the installed Claude Code version, e.g. `CC v2.1.81` |
 | `display.showMemoryUsage` | boolean | false | Show an approximate system RAM usage line in expanded layout |
+| `display.showStatus` | boolean | false | Show Claude Code service status from status.claude.com (`●` when operational, expands with incident details on issues) |
 | `colors.context` | color value | `green` | Base color for the context bar and context percentage |
 | `colors.usage` | color value | `brightBlue` | Base color for usage bars and percentages below warning thresholds |
 | `colors.warning` | color value | `yellow` | Warning color for context thresholds and usage warning text |
@@ -260,6 +262,10 @@ To disable, set `display.showUsage` to `false`.
 **With file stats:** `[Opus] │ my-project git:(main* !3 +1 ?2)`
 - `!` = modified files, `+` = added/staged, `✘` = deleted, `?` = untracked
 - Counts of 0 are omitted for cleaner display
+
+**With service status:** `[Opus] │ my-project git:(main*) │ ●`
+
+**During an outage:** `[Opus] │ my-project git:(main*) │ ✖ Elevated errors on Opus 4.6`
 
 ### Troubleshooting
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,22 +1,30 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as os from 'node:os';
-import { getHudPluginDir } from './claude-config-dir.js';
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { getHudPluginDir } from "./claude-config-dir.js";
 
-export type LineLayoutType = 'compact' | 'expanded';
+export type LineLayoutType = "compact" | "expanded";
 
-export type AutocompactBufferMode = 'enabled' | 'disabled';
-export type ContextValueMode = 'percent' | 'tokens' | 'remaining' | 'both';
-export type HudElement = 'project' | 'context' | 'usage' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos';
+export type AutocompactBufferMode = "enabled" | "disabled";
+export type ContextValueMode = "percent" | "tokens" | "remaining" | "both";
+export type HudElement =
+  | "project"
+  | "context"
+  | "usage"
+  | "memory"
+  | "environment"
+  | "tools"
+  | "agents"
+  | "todos";
 export type HudColorName =
-  | 'dim'
-  | 'red'
-  | 'green'
-  | 'yellow'
-  | 'magenta'
-  | 'cyan'
-  | 'brightBlue'
-  | 'brightMagenta';
+  | "dim"
+  | "red"
+  | "green"
+  | "yellow"
+  | "magenta"
+  | "cyan"
+  | "brightBlue"
+  | "brightMagenta";
 
 /** A color value: named preset, 256-color index (0-255), or hex string (#rrggbb). */
 export type HudColorValue = HudColorName | number | string;
@@ -36,14 +44,14 @@ export interface HudColorOverrides {
 }
 
 export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
-  'project',
-  'context',
-  'usage',
-  'memory',
-  'environment',
-  'tools',
-  'agents',
-  'todos',
+  "project",
+  "context",
+  "usage",
+  "memory",
+  "environment",
+  "tools",
+  "agents",
+  "todos",
 ];
 
 const KNOWN_ELEMENTS = new Set<HudElement>(DEFAULT_ELEMENT_ORDER);
@@ -76,6 +84,7 @@ export interface HudConfig {
     showSessionName: boolean;
     showClaudeCodeVersion: boolean;
     showMemoryUsage: boolean;
+    showStatus: boolean;
     autocompactBuffer: AutocompactBufferMode;
     usageThreshold: number;
     sevenDayThreshold: number;
@@ -86,7 +95,7 @@ export interface HudConfig {
 }
 
 export const DEFAULT_CONFIG: HudConfig = {
-  lineLayout: 'expanded',
+  lineLayout: "expanded",
   showSeparators: false,
   pathLevels: 1,
   elementOrder: [...DEFAULT_ELEMENT_ORDER],
@@ -100,7 +109,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showModel: true,
     showProject: true,
     showContextBar: true,
-    contextValue: 'percent',
+    contextValue: "percent",
     showConfigCounts: false,
     showDuration: false,
     showSpeed: false,
@@ -113,30 +122,31 @@ export const DEFAULT_CONFIG: HudConfig = {
     showSessionName: false,
     showClaudeCodeVersion: false,
     showMemoryUsage: false,
-    autocompactBuffer: 'enabled',
+    showStatus: false,
+    autocompactBuffer: "enabled",
     usageThreshold: 0,
     sevenDayThreshold: 80,
     environmentThreshold: 0,
-    customLine: '',
+    customLine: "",
   },
   colors: {
-    context: 'green',
-    usage: 'brightBlue',
-    warning: 'yellow',
-    usageWarning: 'brightMagenta',
-    critical: 'red',
-    model: 'cyan',
-    project: 'yellow',
-    git: 'magenta',
-    gitBranch: 'cyan',
-    label: 'dim',
+    context: "green",
+    usage: "brightBlue",
+    warning: "yellow",
+    usageWarning: "brightMagenta",
+    critical: "red",
+    model: "cyan",
+    project: "yellow",
+    git: "magenta",
+    gitBranch: "cyan",
+    label: "dim",
     custom: 208,
   },
 };
 
 export function getConfigPath(): string {
   const homeDir = os.homedir();
-  return path.join(getHudPluginDir(homeDir), 'config.json');
+  return path.join(getHudPluginDir(homeDir), "config.json");
 }
 
 function validatePathLevels(value: unknown): value is 1 | 2 | 3 {
@@ -144,34 +154,49 @@ function validatePathLevels(value: unknown): value is 1 | 2 | 3 {
 }
 
 function validateLineLayout(value: unknown): value is LineLayoutType {
-  return value === 'compact' || value === 'expanded';
+  return value === "compact" || value === "expanded";
 }
 
-function validateAutocompactBuffer(value: unknown): value is AutocompactBufferMode {
-  return value === 'enabled' || value === 'disabled';
+function validateAutocompactBuffer(
+  value: unknown,
+): value is AutocompactBufferMode {
+  return value === "enabled" || value === "disabled";
 }
 
 function validateContextValue(value: unknown): value is ContextValueMode {
-  return value === 'percent' || value === 'tokens' || value === 'remaining' || value === 'both';
+  return (
+    value === "percent" ||
+    value === "tokens" ||
+    value === "remaining" ||
+    value === "both"
+  );
 }
 
 function validateColorName(value: unknown): value is HudColorName {
-  return value === 'dim'
-    || value === 'red'
-    || value === 'green'
-    || value === 'yellow'
-    || value === 'magenta'
-    || value === 'cyan'
-    || value === 'brightBlue'
-    || value === 'brightMagenta';
+  return (
+    value === "dim" ||
+    value === "red" ||
+    value === "green" ||
+    value === "yellow" ||
+    value === "magenta" ||
+    value === "cyan" ||
+    value === "brightBlue" ||
+    value === "brightMagenta"
+  );
 }
 
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 
 function validateColorValue(value: unknown): value is HudColorValue {
   if (validateColorName(value)) return true;
-  if (typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 255) return true;
-  if (typeof value === 'string' && HEX_COLOR_PATTERN.test(value)) return true;
+  if (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value <= 255
+  )
+    return true;
+  if (typeof value === "string" && HEX_COLOR_PATTERN.test(value)) return true;
   return false;
 }
 
@@ -184,7 +209,7 @@ function validateElementOrder(value: unknown): HudElement[] {
   const elementOrder: HudElement[] = [];
 
   for (const item of value) {
-    if (typeof item !== 'string' || !KNOWN_ELEMENTS.has(item as HudElement)) {
+    if (typeof item !== "string" || !KNOWN_ELEMENTS.has(item as HudElement)) {
       continue;
     }
 
@@ -201,28 +226,36 @@ function validateElementOrder(value: unknown): HudElement[] {
 }
 
 interface LegacyConfig {
-  layout?: 'default' | 'separators' | Record<string, unknown>;
+  layout?: "default" | "separators" | Record<string, unknown>;
 }
 
-function migrateConfig(userConfig: Partial<HudConfig> & LegacyConfig): Partial<HudConfig> {
+function migrateConfig(
+  userConfig: Partial<HudConfig> & LegacyConfig,
+): Partial<HudConfig> {
   const migrated = { ...userConfig } as Partial<HudConfig> & LegacyConfig;
 
-  if ('layout' in userConfig && !('lineLayout' in userConfig)) {
-    if (typeof userConfig.layout === 'string') {
+  if ("layout" in userConfig && !("lineLayout" in userConfig)) {
+    if (typeof userConfig.layout === "string") {
       // Legacy string migration (v0.0.x → v0.1.x)
-      if (userConfig.layout === 'separators') {
-        migrated.lineLayout = 'compact';
+      if (userConfig.layout === "separators") {
+        migrated.lineLayout = "compact";
         migrated.showSeparators = true;
       } else {
-        migrated.lineLayout = 'compact';
+        migrated.lineLayout = "compact";
         migrated.showSeparators = false;
       }
-    } else if (typeof userConfig.layout === 'object' && userConfig.layout !== null) {
+    } else if (
+      typeof userConfig.layout === "object" &&
+      userConfig.layout !== null
+    ) {
       // Object layout written by third-party tools — extract nested fields
       const obj = userConfig.layout as Record<string, unknown>;
-      if (typeof obj.lineLayout === 'string') migrated.lineLayout = obj.lineLayout as any;
-      if (typeof obj.showSeparators === 'boolean') migrated.showSeparators = obj.showSeparators;
-      if (typeof obj.pathLevels === 'number') migrated.pathLevels = obj.pathLevels as any;
+      if (typeof obj.lineLayout === "string")
+        migrated.lineLayout = obj.lineLayout as any;
+      if (typeof obj.showSeparators === "boolean")
+        migrated.showSeparators = obj.showSeparators;
+      if (typeof obj.pathLevels === "number")
+        migrated.pathLevels = obj.pathLevels as any;
     }
     delete migrated.layout;
   }
@@ -231,7 +264,7 @@ function migrateConfig(userConfig: Partial<HudConfig> & LegacyConfig): Partial<H
 }
 
 function validateThreshold(value: unknown, max = 100): number {
-  if (typeof value !== 'number') return 0;
+  if (typeof value !== "number") return 0;
   return Math.max(0, Math.min(max, value));
 }
 
@@ -242,9 +275,10 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     ? migrated.lineLayout
     : DEFAULT_CONFIG.lineLayout;
 
-  const showSeparators = typeof migrated.showSeparators === 'boolean'
-    ? migrated.showSeparators
-    : DEFAULT_CONFIG.showSeparators;
+  const showSeparators =
+    typeof migrated.showSeparators === "boolean"
+      ? migrated.showSeparators
+      : DEFAULT_CONFIG.showSeparators;
 
   const pathLevels = validatePathLevels(migrated.pathLevels)
     ? migrated.pathLevels
@@ -253,78 +287,110 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
   const elementOrder = validateElementOrder(migrated.elementOrder);
 
   const gitStatus = {
-    enabled: typeof migrated.gitStatus?.enabled === 'boolean'
-      ? migrated.gitStatus.enabled
-      : DEFAULT_CONFIG.gitStatus.enabled,
-    showDirty: typeof migrated.gitStatus?.showDirty === 'boolean'
-      ? migrated.gitStatus.showDirty
-      : DEFAULT_CONFIG.gitStatus.showDirty,
-    showAheadBehind: typeof migrated.gitStatus?.showAheadBehind === 'boolean'
-      ? migrated.gitStatus.showAheadBehind
-      : DEFAULT_CONFIG.gitStatus.showAheadBehind,
-    showFileStats: typeof migrated.gitStatus?.showFileStats === 'boolean'
-      ? migrated.gitStatus.showFileStats
-      : DEFAULT_CONFIG.gitStatus.showFileStats,
+    enabled:
+      typeof migrated.gitStatus?.enabled === "boolean"
+        ? migrated.gitStatus.enabled
+        : DEFAULT_CONFIG.gitStatus.enabled,
+    showDirty:
+      typeof migrated.gitStatus?.showDirty === "boolean"
+        ? migrated.gitStatus.showDirty
+        : DEFAULT_CONFIG.gitStatus.showDirty,
+    showAheadBehind:
+      typeof migrated.gitStatus?.showAheadBehind === "boolean"
+        ? migrated.gitStatus.showAheadBehind
+        : DEFAULT_CONFIG.gitStatus.showAheadBehind,
+    showFileStats:
+      typeof migrated.gitStatus?.showFileStats === "boolean"
+        ? migrated.gitStatus.showFileStats
+        : DEFAULT_CONFIG.gitStatus.showFileStats,
   };
 
   const display = {
-    showModel: typeof migrated.display?.showModel === 'boolean'
-      ? migrated.display.showModel
-      : DEFAULT_CONFIG.display.showModel,
-    showProject: typeof migrated.display?.showProject === 'boolean'
-      ? migrated.display.showProject
-      : DEFAULT_CONFIG.display.showProject,
-    showContextBar: typeof migrated.display?.showContextBar === 'boolean'
-      ? migrated.display.showContextBar
-      : DEFAULT_CONFIG.display.showContextBar,
+    showModel:
+      typeof migrated.display?.showModel === "boolean"
+        ? migrated.display.showModel
+        : DEFAULT_CONFIG.display.showModel,
+    showProject:
+      typeof migrated.display?.showProject === "boolean"
+        ? migrated.display.showProject
+        : DEFAULT_CONFIG.display.showProject,
+    showContextBar:
+      typeof migrated.display?.showContextBar === "boolean"
+        ? migrated.display.showContextBar
+        : DEFAULT_CONFIG.display.showContextBar,
     contextValue: validateContextValue(migrated.display?.contextValue)
       ? migrated.display.contextValue
       : DEFAULT_CONFIG.display.contextValue,
-    showConfigCounts: typeof migrated.display?.showConfigCounts === 'boolean'
-      ? migrated.display.showConfigCounts
-      : DEFAULT_CONFIG.display.showConfigCounts,
-    showDuration: typeof migrated.display?.showDuration === 'boolean'
-      ? migrated.display.showDuration
-      : DEFAULT_CONFIG.display.showDuration,
-    showSpeed: typeof migrated.display?.showSpeed === 'boolean'
-      ? migrated.display.showSpeed
-      : DEFAULT_CONFIG.display.showSpeed,
-    showTokenBreakdown: typeof migrated.display?.showTokenBreakdown === 'boolean'
-      ? migrated.display.showTokenBreakdown
-      : DEFAULT_CONFIG.display.showTokenBreakdown,
-    showUsage: typeof migrated.display?.showUsage === 'boolean'
-      ? migrated.display.showUsage
-      : DEFAULT_CONFIG.display.showUsage,
-    usageBarEnabled: typeof migrated.display?.usageBarEnabled === 'boolean'
-      ? migrated.display.usageBarEnabled
-      : DEFAULT_CONFIG.display.usageBarEnabled,
-    showTools: typeof migrated.display?.showTools === 'boolean'
-      ? migrated.display.showTools
-      : DEFAULT_CONFIG.display.showTools,
-    showAgents: typeof migrated.display?.showAgents === 'boolean'
-      ? migrated.display.showAgents
-      : DEFAULT_CONFIG.display.showAgents,
-    showTodos: typeof migrated.display?.showTodos === 'boolean'
-      ? migrated.display.showTodos
-      : DEFAULT_CONFIG.display.showTodos,
-    showSessionName: typeof migrated.display?.showSessionName === 'boolean'
-      ? migrated.display.showSessionName
-      : DEFAULT_CONFIG.display.showSessionName,
-    showClaudeCodeVersion: typeof migrated.display?.showClaudeCodeVersion === 'boolean'
-      ? migrated.display.showClaudeCodeVersion
-      : DEFAULT_CONFIG.display.showClaudeCodeVersion,
-    showMemoryUsage: typeof migrated.display?.showMemoryUsage === 'boolean'
-      ? migrated.display.showMemoryUsage
-      : DEFAULT_CONFIG.display.showMemoryUsage,
-    autocompactBuffer: validateAutocompactBuffer(migrated.display?.autocompactBuffer)
+    showConfigCounts:
+      typeof migrated.display?.showConfigCounts === "boolean"
+        ? migrated.display.showConfigCounts
+        : DEFAULT_CONFIG.display.showConfigCounts,
+    showDuration:
+      typeof migrated.display?.showDuration === "boolean"
+        ? migrated.display.showDuration
+        : DEFAULT_CONFIG.display.showDuration,
+    showSpeed:
+      typeof migrated.display?.showSpeed === "boolean"
+        ? migrated.display.showSpeed
+        : DEFAULT_CONFIG.display.showSpeed,
+    showTokenBreakdown:
+      typeof migrated.display?.showTokenBreakdown === "boolean"
+        ? migrated.display.showTokenBreakdown
+        : DEFAULT_CONFIG.display.showTokenBreakdown,
+    showUsage:
+      typeof migrated.display?.showUsage === "boolean"
+        ? migrated.display.showUsage
+        : DEFAULT_CONFIG.display.showUsage,
+    usageBarEnabled:
+      typeof migrated.display?.usageBarEnabled === "boolean"
+        ? migrated.display.usageBarEnabled
+        : DEFAULT_CONFIG.display.usageBarEnabled,
+    showTools:
+      typeof migrated.display?.showTools === "boolean"
+        ? migrated.display.showTools
+        : DEFAULT_CONFIG.display.showTools,
+    showAgents:
+      typeof migrated.display?.showAgents === "boolean"
+        ? migrated.display.showAgents
+        : DEFAULT_CONFIG.display.showAgents,
+    showTodos:
+      typeof migrated.display?.showTodos === "boolean"
+        ? migrated.display.showTodos
+        : DEFAULT_CONFIG.display.showTodos,
+    showSessionName:
+      typeof migrated.display?.showSessionName === "boolean"
+        ? migrated.display.showSessionName
+        : DEFAULT_CONFIG.display.showSessionName,
+    showClaudeCodeVersion:
+      typeof migrated.display?.showClaudeCodeVersion === "boolean"
+        ? migrated.display.showClaudeCodeVersion
+        : DEFAULT_CONFIG.display.showClaudeCodeVersion,
+    showMemoryUsage:
+      typeof migrated.display?.showMemoryUsage === "boolean"
+        ? migrated.display.showMemoryUsage
+        : DEFAULT_CONFIG.display.showMemoryUsage,
+    showStatus:
+      typeof migrated.display?.showStatus === "boolean"
+        ? migrated.display.showStatus
+        : DEFAULT_CONFIG.display.showStatus,
+    autocompactBuffer: validateAutocompactBuffer(
+      migrated.display?.autocompactBuffer,
+    )
       ? migrated.display.autocompactBuffer
       : DEFAULT_CONFIG.display.autocompactBuffer,
     usageThreshold: validateThreshold(migrated.display?.usageThreshold, 100),
-    sevenDayThreshold: validateThreshold(migrated.display?.sevenDayThreshold, 100),
-    environmentThreshold: validateThreshold(migrated.display?.environmentThreshold, 100),
-    customLine: typeof migrated.display?.customLine === 'string'
-      ? migrated.display.customLine.slice(0, 80)
-      : DEFAULT_CONFIG.display.customLine,
+    sevenDayThreshold: validateThreshold(
+      migrated.display?.sevenDayThreshold,
+      100,
+    ),
+    environmentThreshold: validateThreshold(
+      migrated.display?.environmentThreshold,
+      100,
+    ),
+    customLine:
+      typeof migrated.display?.customLine === "string"
+        ? migrated.display.customLine.slice(0, 80)
+        : DEFAULT_CONFIG.display.customLine,
   };
 
   const colors = {
@@ -363,7 +429,15 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
       : DEFAULT_CONFIG.colors.custom,
   };
 
-  return { lineLayout, showSeparators, pathLevels, elementOrder, gitStatus, display, colors };
+  return {
+    lineLayout,
+    showSeparators,
+    pathLevels,
+    elementOrder,
+    gitStatus,
+    display,
+    colors,
+  };
 }
 
 export async function loadConfig(): Promise<HudConfig> {
@@ -374,7 +448,7 @@ export async function loadConfig(): Promise<HudConfig> {
       return DEFAULT_CONFIG;
     }
 
-    const content = fs.readFileSync(configPath, 'utf-8');
+    const content = fs.readFileSync(configPath, "utf-8");
     const userConfig = JSON.parse(content) as Partial<HudConfig>;
     return mergeConfig(userConfig);
   } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,16 @@
-import { readStdin, getUsageFromStdin } from './stdin.js';
-import { parseTranscript } from './transcript.js';
-import { render } from './render/index.js';
-import { countConfigs } from './config-reader.js';
-import { getGitStatus } from './git.js';
-import { loadConfig } from './config.js';
-import { parseExtraCmdArg, runExtraCmd } from './extra-cmd.js';
-import { getClaudeCodeVersion } from './version.js';
-import { getMemoryUsage } from './memory.js';
-import type { RenderContext } from './types.js';
-import { fileURLToPath } from 'node:url';
-import { realpathSync } from 'node:fs';
+import { readStdin, getUsageFromStdin } from "./stdin.js";
+import { parseTranscript } from "./transcript.js";
+import { render } from "./render/index.js";
+import { countConfigs } from "./config-reader.js";
+import { getGitStatus } from "./git.js";
+import { loadConfig } from "./config.js";
+import { parseExtraCmdArg, runExtraCmd } from "./extra-cmd.js";
+import { getClaudeCodeVersion } from "./version.js";
+import { getMemoryUsage } from "./memory.js";
+import { getServiceStatus } from "./status.js";
+import type { RenderContext } from "./types.js";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 export type MainDeps = {
   readStdin: typeof readStdin;
@@ -22,6 +23,7 @@ export type MainDeps = {
   runExtraCmd: typeof runExtraCmd;
   getClaudeCodeVersion: typeof getClaudeCodeVersion;
   getMemoryUsage: typeof getMemoryUsage;
+  getServiceStatus: typeof getServiceStatus;
   render: typeof render;
   now: () => number;
   log: (...args: unknown[]) => void;
@@ -39,6 +41,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     runExtraCmd,
     getClaudeCodeVersion,
     getMemoryUsage,
+    getServiceStatus,
     render,
     now: () => Date.now(),
     log: console.log,
@@ -50,18 +53,21 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
 
     if (!stdin) {
       // Running without stdin - this happens during setup verification
-      const isMacOS = process.platform === 'darwin';
-      deps.log('[claude-hud] Initializing...');
+      const isMacOS = process.platform === "darwin";
+      deps.log("[claude-hud] Initializing...");
       if (isMacOS) {
-        deps.log('[claude-hud] Note: On macOS, you may need to restart Claude Code for the HUD to appear.');
+        deps.log(
+          "[claude-hud] Note: On macOS, you may need to restart Claude Code for the HUD to appear.",
+        );
       }
       return;
     }
 
-    const transcriptPath = stdin.transcript_path ?? '';
+    const transcriptPath = stdin.transcript_path ?? "";
     const transcript = await deps.parseTranscript(transcriptPath);
 
-    const { claudeMdCount, rulesCount, mcpCount, hooksCount } = await deps.countConfigs(stdin.cwd);
+    const { claudeMdCount, rulesCount, mcpCount, hooksCount } =
+      await deps.countConfigs(stdin.cwd);
 
     const config = await deps.loadConfig();
     const gitStatus = config.gitStatus.enabled
@@ -69,7 +75,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       : null;
 
     // Usage comes only from Claude Code's official stdin rate_limits fields.
-    let usageData: RenderContext['usageData'] = null;
+    let usageData: RenderContext["usageData"] = null;
     if (config.display.showUsage !== false) {
       usageData = deps.getUsageFromStdin(stdin);
     }
@@ -77,12 +83,19 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     const extraCmd = deps.parseExtraCmdArg();
     const extraLabel = extraCmd ? await deps.runExtraCmd(extraCmd) : null;
 
-    const sessionDuration = formatSessionDuration(transcript.sessionStart, deps.now);
+    const sessionDuration = formatSessionDuration(
+      transcript.sessionStart,
+      deps.now,
+    );
     const claudeCodeVersion = config.display.showClaudeCodeVersion
       ? await deps.getClaudeCodeVersion()
       : undefined;
-    const memoryUsage = config.display.showMemoryUsage && config.lineLayout === 'expanded'
-      ? await deps.getMemoryUsage()
+    const memoryUsage =
+      config.display.showMemoryUsage && config.lineLayout === "expanded"
+        ? await deps.getMemoryUsage()
+        : null;
+    const statusData = config.display.showStatus
+      ? await deps.getServiceStatus()
       : null;
 
     const ctx: RenderContext = {
@@ -96,6 +109,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       gitStatus,
       usageData,
       memoryUsage,
+      statusData,
       config,
       extraLabel,
       claudeCodeVersion,
@@ -103,19 +117,25 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
 
     deps.render(ctx);
   } catch (error) {
-    deps.log('[claude-hud] Error:', error instanceof Error ? error.message : 'Unknown error');
+    deps.log(
+      "[claude-hud] Error:",
+      error instanceof Error ? error.message : "Unknown error",
+    );
   }
 }
 
-export function formatSessionDuration(sessionStart?: Date, now: () => number = () => Date.now()): string {
+export function formatSessionDuration(
+  sessionStart?: Date,
+  now: () => number = () => Date.now(),
+): string {
   if (!sessionStart) {
-    return '';
+    return "";
   }
 
   const ms = now() - sessionStart.getTime();
   const mins = Math.floor(ms / 60000);
 
-  if (mins < 1) return '<1m';
+  if (mins < 1) return "<1m";
   if (mins < 60) return `${mins}m`;
 
   const hours = Math.floor(mins / 60);

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -1,7 +1,17 @@
-import type { RenderContext } from '../../types.js';
-import { getModelName, getProviderLabel } from '../../stdin.js';
-import { getOutputSpeed } from '../../speed-tracker.js';
-import { git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, red, custom as customColor } from '../colors.js';
+import type { RenderContext, StatusData } from "../../types.js";
+import { getModelName, getProviderLabel } from "../../stdin.js";
+import { getOutputSpeed } from "../../speed-tracker.js";
+import {
+  green,
+  yellow,
+  git as gitColor,
+  gitBranch as gitBranchColor,
+  label,
+  model as modelColor,
+  project as projectColor,
+  red,
+  custom as customColor,
+} from "../colors.js";
 
 export function renderProjectLine(ctx: RenderContext): string | null {
   const display = ctx.config?.display;
@@ -13,8 +23,11 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     const providerLabel = getProviderLabel(ctx.stdin);
     const showUsage = display?.showUsage !== false;
     const hasApiKey = !!process.env.ANTHROPIC_API_KEY;
-    const modelQualifier = providerLabel ?? (showUsage && hasApiKey ? red('API') : undefined);
-    const modelDisplay = modelQualifier ? `${model} | ${modelQualifier}` : model;
+    const modelQualifier =
+      providerLabel ?? (showUsage && hasApiKey ? red("API") : undefined);
+    const modelDisplay = modelQualifier
+      ? `${model} | ${modelQualifier}`
+      : model;
     parts.push(modelColor(`[${modelDisplay}]`, colors));
   }
 
@@ -22,11 +35,12 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   if (display?.showProject !== false && ctx.stdin.cwd) {
     const segments = ctx.stdin.cwd.split(/[/\\]/).filter(Boolean);
     const pathLevels = ctx.config?.pathLevels ?? 1;
-    const projectPath = segments.length > 0 ? segments.slice(-pathLevels).join('/') : '/';
+    const projectPath =
+      segments.length > 0 ? segments.slice(-pathLevels).join("/") : "/";
     projectPart = projectColor(projectPath, colors);
   }
 
-  let gitPart = '';
+  let gitPart = "";
   const gitConfig = ctx.config?.gitStatus;
   const showGit = gitConfig?.enabled ?? true;
 
@@ -34,7 +48,7 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     const gitParts: string[] = [ctx.gitStatus.branch];
 
     if ((gitConfig?.showDirty ?? true) && ctx.gitStatus.isDirty) {
-      gitParts.push('*');
+      gitParts.push("*");
     }
 
     if (gitConfig?.showAheadBehind) {
@@ -54,11 +68,11 @@ export function renderProjectLine(ctx: RenderContext): string | null {
       if (deleted > 0) statParts.push(`✘${deleted}`);
       if (untracked > 0) statParts.push(`?${untracked}`);
       if (statParts.length > 0) {
-        gitParts.push(` ${statParts.join(' ')}`);
+        gitParts.push(` ${statParts.join(" ")}`);
       }
     }
 
-    gitPart = `${gitColor('git:(', colors)}${gitBranchColor(gitParts.join(''), colors)}${gitColor(')', colors)}`;
+    gitPart = `${gitColor("git:(", colors)}${gitBranchColor(gitParts.join(""), colors)}${gitColor(")", colors)}`;
   }
 
   if (projectPart && gitPart) {
@@ -92,6 +106,10 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
   }
 
+  if (display?.showStatus && ctx.statusData) {
+    parts.push(formatStatusSegment(ctx.statusData));
+  }
+
   const customLine = display?.customLine;
   if (customLine) {
     parts.push(customColor(customLine, colors));
@@ -101,5 +119,22 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     return null;
   }
 
-  return parts.join(' \u2502 ');
+  return parts.join(" \u2502 ");
+}
+
+function formatStatusSegment(data: StatusData): string {
+  const { status, activeIncident } = data;
+
+  switch (status) {
+    case "degraded_performance":
+      return yellow(activeIncident ? `◐ ${activeIncident}` : "◐ Degraded");
+    case "partial_outage":
+      return red(activeIncident ? `◑ ${activeIncident}` : "◑ Partial Outage");
+    case "major_outage":
+      return red(activeIncident ? `✖ ${activeIncident}` : "✖ Major Outage");
+    case "under_maintenance":
+      return yellow("⏳ Maintenance");
+    default:
+      return green("●");
+  }
 }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -1,11 +1,34 @@
-import type { RenderContext } from '../types.js';
-import { isLimitReached } from '../types.js';
-import { getContextPercent, getBufferedPercent, getModelName, getProviderLabel, getTotalTokens } from '../stdin.js';
-import { getOutputSpeed } from '../speed-tracker.js';
-import { coloredBar, critical, git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, red, getContextColor, getQuotaColor, quotaBar, custom as customColor, RESET } from './colors.js';
-import { getAdaptiveBarWidth } from '../utils/terminal.js';
+import type { RenderContext, StatusData } from "../types.js";
+import { isLimitReached } from "../types.js";
+import {
+  getContextPercent,
+  getBufferedPercent,
+  getModelName,
+  getProviderLabel,
+  getTotalTokens,
+} from "../stdin.js";
+import { getOutputSpeed } from "../speed-tracker.js";
+import {
+  coloredBar,
+  critical,
+  green,
+  yellow,
+  git as gitColor,
+  gitBranch as gitBranchColor,
+  label,
+  model as modelColor,
+  project as projectColor,
+  red,
+  getContextColor,
+  getQuotaColor,
+  quotaBar,
+  custom as customColor,
+  RESET,
+} from "./colors.js";
+import { getAdaptiveBarWidth } from "../utils/terminal.js";
 
-const DEBUG = process.env.DEBUG?.includes('claude-hud') || process.env.DEBUG === '*';
+const DEBUG =
+  process.env.DEBUG?.includes("claude-hud") || process.env.DEBUG === "*";
 
 /**
  * Renders the full session line (model + context bar + project + git + counts + usage + duration).
@@ -16,11 +39,13 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   const rawPercent = getContextPercent(ctx.stdin);
   const bufferedPercent = getBufferedPercent(ctx.stdin);
-  const autocompactMode = ctx.config?.display?.autocompactBuffer ?? 'enabled';
-  const percent = autocompactMode === 'disabled' ? rawPercent : bufferedPercent;
+  const autocompactMode = ctx.config?.display?.autocompactBuffer ?? "enabled";
+  const percent = autocompactMode === "disabled" ? rawPercent : bufferedPercent;
 
-  if (DEBUG && autocompactMode === 'disabled') {
-    console.error(`[claude-hud:context] autocompactBuffer=disabled, showing raw ${rawPercent}% (buffered would be ${bufferedPercent}%)`);
+  if (DEBUG && autocompactMode === "disabled") {
+    console.error(
+      `[claude-hud:context] autocompactBuffer=disabled, showing raw ${rawPercent}% (buffered would be ${bufferedPercent}%)`,
+    );
   }
 
   const colors = ctx.config?.colors;
@@ -29,7 +54,7 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   const parts: string[] = [];
   const display = ctx.config?.display;
-  const contextValueMode = display?.contextValue ?? 'percent';
+  const contextValueMode = display?.contextValue ?? "percent";
   const contextValue = formatContextValue(ctx, percent, contextValueMode);
   const contextValueDisplay = `${getContextColor(percent, colors)}${contextValue}${RESET}`;
 
@@ -37,13 +62,18 @@ export function renderSessionLine(ctx: RenderContext): string {
   const providerLabel = getProviderLabel(ctx.stdin);
   const showUsage = display?.showUsage !== false;
   const hasApiKey = !!process.env.ANTHROPIC_API_KEY;
-  const modelQualifier = providerLabel ?? (showUsage && hasApiKey ? red('API') : undefined);
+  const modelQualifier =
+    providerLabel ?? (showUsage && hasApiKey ? red("API") : undefined);
   const modelDisplay = modelQualifier ? `${model} | ${modelQualifier}` : model;
 
   if (display?.showModel !== false && display?.showContextBar !== false) {
-    parts.push(`${modelColor(`[${modelDisplay}]`, colors)} ${bar} ${contextValueDisplay}`);
+    parts.push(
+      `${modelColor(`[${modelDisplay}]`, colors)} ${bar} ${contextValueDisplay}`,
+    );
   } else if (display?.showModel !== false) {
-    parts.push(`${modelColor(`[${modelDisplay}]`, colors)} ${contextValueDisplay}`);
+    parts.push(
+      `${modelColor(`[${modelDisplay}]`, colors)} ${contextValueDisplay}`,
+    );
   } else if (display?.showContextBar !== false) {
     parts.push(`${bar} ${contextValueDisplay}`);
   } else {
@@ -58,11 +88,12 @@ export function renderSessionLine(ctx: RenderContext): string {
     const pathLevels = ctx.config?.pathLevels ?? 1;
     // Always join with forward slash for consistent display
     // Handle root path (/) which results in empty segments
-    const projectPath = segments.length > 0 ? segments.slice(-pathLevels).join('/') : '/';
+    const projectPath =
+      segments.length > 0 ? segments.slice(-pathLevels).join("/") : "/";
     projectPart = projectColor(projectPath, colors);
   }
 
-  let gitPart = '';
+  let gitPart = "";
   const gitConfig = ctx.config?.gitStatus;
   const showGit = gitConfig?.enabled ?? true;
 
@@ -71,7 +102,7 @@ export function renderSessionLine(ctx: RenderContext): string {
 
     // Show dirty indicator
     if ((gitConfig?.showDirty ?? true) && ctx.gitStatus.isDirty) {
-      gitParts.push('*');
+      gitParts.push("*");
     }
 
     // Show ahead/behind (with space separator for readability)
@@ -93,11 +124,11 @@ export function renderSessionLine(ctx: RenderContext): string {
       if (deleted > 0) statParts.push(`✘${deleted}`);
       if (untracked > 0) statParts.push(`?${untracked}`);
       if (statParts.length > 0) {
-        gitParts.push(` ${statParts.join(' ')}`);
+        gitParts.push(` ${statParts.join(" ")}`);
       }
     }
 
-    gitPart = `${gitColor('git:(', colors)}${gitBranchColor(gitParts.join(''), colors)}${gitColor(')', colors)}`;
+    gitPart = `${gitColor("git:(", colors)}${gitBranchColor(gitParts.join(""), colors)}${gitColor(")", colors)}`;
   }
 
   if (projectPart && gitPart) {
@@ -119,7 +150,8 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   // Config counts (respects environmentThreshold)
   if (display?.showConfigCounts !== false) {
-    const totalCounts = ctx.claudeMdCount + ctx.rulesCount + ctx.mcpCount + ctx.hooksCount;
+    const totalCounts =
+      ctx.claudeMdCount + ctx.rulesCount + ctx.mcpCount + ctx.hooksCount;
     const envThreshold = display?.environmentThreshold ?? 0;
 
     if (totalCounts > 0 && totalCounts >= envThreshold) {
@@ -144,10 +176,16 @@ export function renderSessionLine(ctx: RenderContext): string {
   // Usage limits display (shown when enabled in config, respects usageThreshold)
   if (display?.showUsage !== false && ctx.usageData && !providerLabel) {
     if (isLimitReached(ctx.usageData)) {
-      const resetTime = ctx.usageData.fiveHour === 100
-        ? formatResetTime(ctx.usageData.fiveHourResetAt)
-        : formatResetTime(ctx.usageData.sevenDayResetAt);
-      parts.push(critical(`⚠ Limit reached${resetTime ? ` (resets ${resetTime})` : ''}`, colors));
+      const resetTime =
+        ctx.usageData.fiveHour === 100
+          ? formatResetTime(ctx.usageData.fiveHourResetAt)
+          : formatResetTime(ctx.usageData.sevenDayResetAt);
+      parts.push(
+        critical(
+          `⚠ Limit reached${resetTime ? ` (resets ${resetTime})` : ""}`,
+          colors,
+        ),
+      );
     } else {
       const usageThreshold = display?.usageThreshold ?? 0;
       const fiveHour = ctx.usageData.fiveHour;
@@ -158,7 +196,7 @@ export function renderSessionLine(ctx: RenderContext): string {
         const usageBarEnabled = display?.usageBarEnabled ?? true;
         if (fiveHour === null && sevenDay !== null) {
           const weeklyOnlyPart = formatUsageWindowPart({
-            label: '7d',
+            label: "7d",
             percent: sevenDay,
             resetAt: ctx.usageData.sevenDayResetAt,
             colors,
@@ -169,7 +207,7 @@ export function renderSessionLine(ctx: RenderContext): string {
           parts.push(weeklyOnlyPart);
         } else {
           const fiveHourPart = formatUsageWindowPart({
-            label: '5h',
+            label: "5h",
             percent: fiveHour,
             resetAt: ctx.usageData.fiveHourResetAt,
             colors,
@@ -180,7 +218,7 @@ export function renderSessionLine(ctx: RenderContext): string {
           const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
           if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
             const sevenDayPart = formatUsageWindowPart({
-              label: '7d',
+              label: "7d",
               percent: sevenDay,
               resetAt: ctx.usageData.sevenDayResetAt,
               colors,
@@ -212,20 +250,27 @@ export function renderSessionLine(ctx: RenderContext): string {
     parts.push(label(ctx.extraLabel, colors));
   }
 
+  if (display?.showStatus && ctx.statusData) {
+    parts.push(formatStatusSegment(ctx.statusData));
+  }
+
   // Custom line (static user-defined text)
   const customLine = display?.customLine;
   if (customLine) {
     parts.push(customColor(customLine, colors));
   }
 
-  let line = parts.join(' | ');
+  let line = parts.join(" | ");
 
   // Token breakdown at high context
   if (display?.showTokenBreakdown !== false && percent >= 85) {
     const usage = ctx.stdin.context_window?.current_usage;
     if (usage) {
       const input = formatTokens(usage.input_tokens ?? 0);
-      const cache = formatTokens((usage.cache_creation_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0));
+      const cache = formatTokens(
+        (usage.cache_creation_input_tokens ?? 0) +
+          (usage.cache_read_input_tokens ?? 0),
+      );
       line += label(` (in: ${input}, cache: ${cache})`, colors);
     }
   }
@@ -243,34 +288,41 @@ function formatTokens(n: number): string {
   return n.toString();
 }
 
-function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent' | 'tokens' | 'remaining' | 'both'): string {
+function formatContextValue(
+  ctx: RenderContext,
+  percent: number,
+  mode: "percent" | "tokens" | "remaining" | "both",
+): string {
   const totalTokens = getTotalTokens(ctx.stdin);
   const size = ctx.stdin.context_window?.context_window_size ?? 0;
 
-  if (mode === 'tokens') {
+  if (mode === "tokens") {
     if (size > 0) {
       return `${formatTokens(totalTokens)}/${formatTokens(size)}`;
     }
     return formatTokens(totalTokens);
   }
 
-  if (mode === 'both') {
+  if (mode === "both") {
     if (size > 0) {
       return `${percent}% (${formatTokens(totalTokens)}/${formatTokens(size)})`;
     }
     return `${percent}%`;
   }
 
-  if (mode === 'remaining') {
+  if (mode === "remaining") {
     return `${Math.max(0, 100 - percent)}%`;
   }
 
   return `${percent}%`;
 }
 
-function formatUsagePercent(percent: number | null, colors?: RenderContext['config']['colors']): string {
+function formatUsagePercent(
+  percent: number | null,
+  colors?: RenderContext["config"]["colors"],
+): string {
   if (percent === null) {
-    return label('--', colors);
+    return label("--", colors);
   }
   const color = getQuotaColor(percent, colors);
   return `${color}${percent}%${RESET}`;
@@ -285,10 +337,10 @@ function formatUsageWindowPart({
   barWidth,
   forceLabel = false,
 }: {
-  label: '5h' | '7d';
+  label: "5h" | "7d";
   percent: number | null;
   resetAt: Date | null;
-  colors?: RenderContext['config']['colors'];
+  colors?: RenderContext["config"]["colors"];
   usageBarEnabled: boolean;
   barWidth: number;
   forceLabel?: boolean;
@@ -309,10 +361,10 @@ function formatUsageWindowPart({
 }
 
 function formatResetTime(resetAt: Date | null): string {
-  if (!resetAt) return '';
+  if (!resetAt) return "";
   const now = new Date();
   const diffMs = resetAt.getTime() - now.getTime();
-  if (diffMs <= 0) return '';
+  if (diffMs <= 0) return "";
 
   const diffMins = Math.ceil(diffMs / 60000);
   if (diffMins < 60) return `${diffMins}m`;
@@ -328,4 +380,21 @@ function formatResetTime(resetAt: Date | null): string {
   }
 
   return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+function formatStatusSegment(data: StatusData): string {
+  const { status, activeIncident } = data;
+
+  switch (status) {
+    case "degraded_performance":
+      return yellow(activeIncident ? `◐ ${activeIncident}` : "◐ Degraded");
+    case "partial_outage":
+      return red(activeIncident ? `◑ ${activeIncident}` : "◑ Partial Outage");
+    case "major_outage":
+      return red(activeIncident ? `✖ ${activeIncident}` : "✖ Major Outage");
+    case "under_maintenance":
+      return yellow("⏳ Maintenance");
+    default:
+      return green("●");
+  }
 }

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,119 @@
+import * as https from "node:https";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getHudPluginDir } from "./claude-config-dir.js";
+import type { StatusData } from "./types.js";
+
+const CACHE_FILENAME = ".claude-status-cache.json";
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 3000;
+const STATUS_API_URL = "https://status.claude.com/api/v2/summary.json";
+const CLAUDE_CODE_COMPONENT_ID = "yyzkbfz2thpt";
+
+let hasResolved = false;
+let cachedResult: StatusData | null = null;
+
+function getCachePath(homeDir: string): string {
+  return path.join(getHudPluginDir(homeDir), CACHE_FILENAME);
+}
+
+function readCache(homeDir: string): StatusData | null {
+  try {
+    const cachePath = getCachePath(homeDir);
+    if (!fs.existsSync(cachePath)) return null;
+    const parsed = JSON.parse(fs.readFileSync(cachePath, "utf8")) as StatusData;
+    if (
+      typeof parsed.status !== "string" ||
+      typeof parsed.fetchedAt !== "number"
+    )
+      return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(homeDir: string, data: StatusData): void {
+  try {
+    const cachePath = getCachePath(homeDir);
+    fs.writeFileSync(cachePath, JSON.stringify(data), "utf8");
+  } catch {
+    // Ignore write failures
+  }
+}
+
+type FetchImpl = () => Promise<StatusData>;
+
+let fetchImpl: FetchImpl = fetchApi;
+
+function fetchApi(): Promise<StatusData> {
+  return new Promise((resolve, reject) => {
+    const req = https.get(
+      STATUS_API_URL,
+      { timeout: FETCH_TIMEOUT_MS },
+      (res) => {
+        let body = "";
+        res.on("data", (chunk: string) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          try {
+            const json = JSON.parse(body);
+            const component = json.components?.find(
+              (c: { id: string }) => c.id === CLAUDE_CODE_COMPONENT_ID,
+            );
+            const incident = json.incidents?.[0];
+            resolve({
+              status: component?.status ?? "operational",
+              activeIncident: incident?.name ?? null,
+              fetchedAt: Date.now(),
+            });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("timeout"));
+    });
+  });
+}
+
+export async function getServiceStatus(): Promise<StatusData | null> {
+  if (hasResolved) return cachedResult;
+
+  const homeDir = os.homedir();
+  const diskCache = readCache(homeDir);
+
+  if (diskCache && Date.now() - diskCache.fetchedAt < CACHE_TTL_MS) {
+    hasResolved = true;
+    cachedResult = diskCache;
+    return cachedResult;
+  }
+
+  try {
+    const fresh = await fetchImpl();
+    writeCache(homeDir, fresh);
+    hasResolved = true;
+    cachedResult = fresh;
+    return cachedResult;
+  } catch {
+    // Fall back to stale cache
+    hasResolved = true;
+    cachedResult = diskCache;
+    return cachedResult;
+  }
+}
+
+export function _resetStatusCache(): void {
+  hasResolved = false;
+  cachedResult = null;
+}
+
+export function _setFetchImplForTests(impl: FetchImpl | null): void {
+  fetchImpl = impl ?? fetchApi;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import type { HudConfig } from './config.js';
-import type { GitStatus } from './git.js';
+import type { HudConfig } from "./config.js";
+import type { GitStatus } from "./git.js";
 
 export interface StdinData {
   transcript_path?: string;
@@ -36,7 +36,7 @@ export interface ToolEntry {
   id: string;
   name: string;
   target?: string;
-  status: 'running' | 'completed' | 'error';
+  status: "running" | "completed" | "error";
   startTime: Date;
   endTime?: Date;
 }
@@ -46,19 +46,19 @@ export interface AgentEntry {
   type: string;
   model?: string;
   description?: string;
-  status: 'running' | 'completed';
+  status: "running" | "completed";
   startTime: Date;
   endTime?: Date;
 }
 
 export interface TodoItem {
   content: string;
-  status: 'pending' | 'in_progress' | 'completed';
+  status: "pending" | "in_progress" | "completed";
 }
 
 export interface UsageData {
-  fiveHour: number | null;  // 0-100 percentage, null if unavailable
-  sevenDay: number | null;  // 0-100 percentage, null if unavailable
+  fiveHour: number | null; // 0-100 percentage, null if unavailable
+  sevenDay: number | null; // 0-100 percentage, null if unavailable
   fiveHourResetAt: Date | null;
   sevenDayResetAt: Date | null;
 }
@@ -68,6 +68,19 @@ export interface MemoryInfo {
   usedBytes: number;
   freeBytes: number;
   usedPercent: number;
+}
+
+export type ServiceStatusValue =
+  | "operational"
+  | "degraded_performance"
+  | "partial_outage"
+  | "major_outage"
+  | "under_maintenance";
+
+export interface StatusData {
+  status: ServiceStatusValue;
+  activeIncident: string | null;
+  fetchedAt: number;
 }
 
 /** Check if usage limit is reached (either window at 100%) */
@@ -94,6 +107,7 @@ export interface RenderContext {
   gitStatus: GitStatus | null;
   usageData: UsageData | null;
   memoryUsage: MemoryInfo | null;
+  statusData: StatusData | null;
   config: HudConfig;
   extraLabel: string | null;
   claudeCodeVersion?: string;


### PR DESCRIPTION
## Summary

Add a real-time Claude Code service status indicator to the HUD's first line.

- Fetches Claude Code component status from the `status.claude.com` API (`/api/v2/summary.json`)
- Displays a green dot (`●`) when operational; expands to show status icon + active incident title on degraded/outage/maintenance states
- Uses inline fetch with file-based caching (5-minute TTL), following the same pattern as `version.ts`
- Opt-in via `"showStatus": true` in config

**Display examples:**
[Opus] │ my-project git:(main*) │ ●                              ← operational
[Opus] │ my-project git:(main*) │ ◐ Elevated errors on Opus 4.6  ← degraded (yellow)
[Opus] │ my-project git:(main*) │ ✖ Claude Code service down     ← major outage (red)

**example1: operational**
<img width="250" height="69" alt="image" src="https://github.com/user-attachments/assets/10f83295-348a-419f-935e-16cea3e6200f" />

**example2: degraded**
<img width="380" height="74" alt="image" src="https://github.com/user-attachments/assets/79f4651e-cdf6-4724-8f02-1221d0317905" />

**example3: outage**
<img width="403" height="71" alt="image" src="https://github.com/user-attachments/assets/63a16c5b-cdfc-456e-b9a0-e41fd775c4ba" />


## Testing

- [ ] `npm test`
- [ ] `npm run test:coverage`
- Manually verified all status states (operational, degraded, partial/major outage, maintenance) by injecting test cache data

## Checklist

- [x] Tests updated or not needed — no tests added; status fetch relies on external API, manual verification done with injected cache data
- [x] Docs updated if behavior changed