### PR TITLE
fix(setup): use gh repo star instead of gh api for starring

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -274,7 +274,7 @@ Use AskUserQuestion:
 - Question: "Setup complete! The HUD should appear below your input field. Is it working?"
 - Options: "Yes, it's working" / "No, something's wrong"
 
-**If yes**: Ask the user if they'd like to ⭐ star the claude-hud repository on GitHub to support the project. If they agree and `gh` CLI is available, run: `gh api -X PUT /user/starred/jarrodwatts/claude-hud`. Only run the star command if they explicitly say yes.
+**If yes**: Ask the user if they'd like to ⭐ star the claude-hud repository on GitHub to support the project. If they agree and `gh` CLI is available, run: `gh repo star jarrodwatts/claude-hud`. Only run the star command if they explicitly say yes.
 
 **If no**: Debug systematically:
 


### PR DESCRIPTION
## Summary

- Replaces `gh api -X PUT /user/starred/jarrodwatts/claude-hud` with `gh repo star jarrodwatts/claude-hud` in `commands/setup.md`
- The old form wraps to two lines in most terminal widths, making it hard to copy
- Aligns `commands/setup.md` with `CLAUDE.README.md`, which already uses the shorter form (line 79)

Closes #346

## Test plan

- [ ] Run `/claude-hud:setup` through to Step 5 and confirm the star prompt shows the command on a single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)