### PR TITLE
fix: stop guessing auth mode from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Claude HUD gives you better insights into what's happening in your Claude Code s
 [Opus] │ my-project git:(main*)
 Context █████░░░░░ 45% │ Usage ██░░░░░░░░ 25% (1h 30m / 5h)
 ```
-- **Line 1** — Model, provider/auth label when relevant (for example `Bedrock` or `API`), project path, git branch
+- **Line 1** — Model, provider label when positively identified (for example `Bedrock`), project path, git branch
 - **Line 2** — Context bar (green → yellow → red) and usage rate limits
 
 ### Optional lines (enable via `/claude-hud:configure`)

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -1,7 +1,7 @@
 import type { RenderContext } from '../../types.js';
 import { getModelName, formatModelName, getProviderLabel } from '../../stdin.js';
 import { getOutputSpeed } from '../../speed-tracker.js';
-import { git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, red, custom as customColor } from '../colors.js';
+import { git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, custom as customColor } from '../colors.js';
 
 export function renderProjectLine(ctx: RenderContext): string | null {
   const display = ctx.config?.display;
@@ -11,9 +11,7 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   if (display?.showModel !== false) {
     const model = formatModelName(getModelName(ctx.stdin), ctx.config?.display?.modelFormat, ctx.config?.display?.modelOverride);
     const providerLabel = getProviderLabel(ctx.stdin);
-    const showUsage = display?.showUsage !== false;
-    const hasApiKey = !!process.env.ANTHROPIC_API_KEY;
-    const modelQualifier = providerLabel ?? (showUsage && hasApiKey ? red('API') : undefined);
+    const modelQualifier = providerLabel ?? undefined;
     const modelDisplay = modelQualifier ? `${model} | ${modelQualifier}` : model;
     parts.push(modelColor(`[${modelDisplay}]`, colors));
   }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -2,7 +2,7 @@ import type { RenderContext } from '../types.js';
 import { isLimitReached } from '../types.js';
 import { getContextPercent, getBufferedPercent, getModelName, formatModelName, getProviderLabel, getTotalTokens } from '../stdin.js';
 import { getOutputSpeed } from '../speed-tracker.js';
-import { coloredBar, critical, git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, red, getContextColor, getQuotaColor, quotaBar, custom as customColor, RESET } from './colors.js';
+import { coloredBar, critical, git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, getContextColor, getQuotaColor, quotaBar, custom as customColor, RESET } from './colors.js';
 import { getAdaptiveBarWidth } from '../utils/terminal.js';
 
 const DEBUG = process.env.DEBUG?.includes('claude-hud') || process.env.DEBUG === '*';
@@ -35,9 +35,7 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   // Model and context bar (FIRST)
   const providerLabel = getProviderLabel(ctx.stdin);
-  const showUsage = display?.showUsage !== false;
-  const hasApiKey = !!process.env.ANTHROPIC_API_KEY;
-  const modelQualifier = providerLabel ?? (showUsage && hasApiKey ? red('API') : undefined);
+  const modelQualifier = providerLabel ?? undefined;
   const modelDisplay = modelQualifier ? `${model} | ${modelQualifier}` : model;
 
   if (display?.showModel !== false && display?.showContextBar !== false) {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -873,7 +873,7 @@ test('renderSessionLine does not add a synthetic subscriber label from usageData
   assert.ok(!line.includes('Max'), 'should not include plan name derived outside stdin');
 });
 
-test('renderSessionLine shows API label when API key auth is active', () => {
+test('renderSessionLine does not guess API auth from environment variables alone', () => {
   const ctx = baseContext();
   ctx.usageData = {
     planName: 'Max',
@@ -887,7 +887,7 @@ test('renderSessionLine shows API label when API key auth is active', () => {
 
   try {
     const line = renderSessionLine(ctx);
-    assert.ok(line.includes('API'), 'should include API label for API key auth');
+    assert.ok(!line.includes('API'), 'should not guess API auth from ANTHROPIC_API_KEY alone');
     assert.ok(!line.includes('Max'), 'should not include subscriber plan label');
   } finally {
     if (savedApiKey === undefined) {
@@ -898,7 +898,7 @@ test('renderSessionLine shows API label when API key auth is active', () => {
   }
 });
 
-test('renderProjectLine shows API label when API key auth is active', () => {
+test('renderProjectLine does not guess API auth from environment variables alone', () => {
   const ctx = baseContext();
   ctx.usageData = {
     planName: 'Pro',
@@ -912,7 +912,7 @@ test('renderProjectLine shows API label when API key auth is active', () => {
 
   try {
     const line = renderProjectLine(ctx);
-    assert.ok(line?.includes('API'), 'should include API label for API key auth');
+    assert.ok(!line?.includes('API'), 'should not guess API auth from ANTHROPIC_API_KEY alone');
     assert.ok(!line?.includes('Pro'), 'should not include subscriber plan label');
   } finally {
     if (savedApiKey === undefined) {


### PR DESCRIPTION
## Summary
- remove the synthetic `API` label fallback based on `ANTHROPIC_API_KEY`
- only show provider labels when they are positively identified
- update regression tests and README wording to match the safer behavior

## Testing
- npm run build
- node --test tests/render.test.js

Closes #353
