### PR TITLE
docs: make setup JSON escaping explicit

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -223,6 +223,10 @@ If a write fails with `File has been unexpectedly modified`, re-read the file an
 }
 ```
 
+**JSON safety**: Write `settings.json` with a real JSON serializer or editor API, not manual string concatenation.
+If you must inspect the saved JSON manually, the embedded bash command must preserve escaped backslashes inside the awk fragment.
+For example, the saved JSON should contain `\\$(NF-1)` and `\\$0`, not `\$(NF-1)` and `\$0`.
+
 
 After successfully writing the config, tell the user:
 


### PR DESCRIPTION
## Summary
- document the JSON-escaping requirement for embedded bash awk fragments
- explicitly show the correct escaped form for `$(NF-1)` and `$0`
- steer setup edits toward real JSON serialization instead of string concatenation

## Testing
- not run (docs-only change)

Closes #315
