### PR TITLE
docs: shorten setup star command

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -274,7 +274,7 @@ Use AskUserQuestion:
 - Question: "Setup complete! The HUD should appear below your input field. Is it working?"
 - Options: "Yes, it's working" / "No, something's wrong"
 
-**If yes**: Ask the user if they'd like to ⭐ star the claude-hud repository on GitHub to support the project. If they agree and `gh` CLI is available, run: `gh api -X PUT /user/starred/jarrodwatts/claude-hud`. Only run the star command if they explicitly say yes.
+**If yes**: Ask the user if they'd like to ⭐ star the claude-hud repository on GitHub to support the project. If they agree and `gh` CLI is available, run: `gh repo star jarrodwatts/claude-hud`. Only run the star command if they explicitly say yes.
 
 **If no**: Debug systematically:
 


### PR DESCRIPTION
## Summary
- replace the raw GitHub API star command with the official `gh repo star` subcommand
- keep the setup prompt copy shorter and easier to copy in typical terminal widths
- align the setup instructions with the existing CLAUDE.README example

## Testing
- not run (docs-only change)

Closes #346
