### PR TITLE
docs: prefer node over bun on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Then run the install command below in that session. This is a [Claude Code platf
 <details>
 <summary><strong>⚠️ Windows users: Click here if setup says no JavaScript runtime was found</strong></summary>
 
-If setup says no JavaScript runtime was found on Windows, install one for your shell first. The simplest fallback is Node.js LTS:
+On Windows, Node.js LTS is the recommended runtime for Claude HUD. If setup says no JavaScript runtime was found, install Node.js for your shell first:
 ```powershell
 winget install OpenJS.NodeJS.LTS
 ```

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -116,10 +116,15 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
    ```
    If empty, the plugin is not installed. Go back to Step 0 to check for ghost installation or EXDEV issues. If Step 0 was clean, ask the user to install via `/plugin install claude-hud` first.
 
-2. Get runtime absolute path (prefer bun for performance, fallback to node):
-   ```bash
-   command -v bun 2>/dev/null || command -v node 2>/dev/null
-   ```
+2. Get runtime absolute path:
+   - On `darwin` or `linux`, prefer bun for performance and fall back to node:
+     ```bash
+     command -v bun 2>/dev/null || command -v node 2>/dev/null
+     ```
+   - On `win32` + `bash`, prefer node first and only fall back to bun because Bun is currently unstable for frequent statusLine invocations on Windows:
+     ```bash
+     command -v node 2>/dev/null || command -v bun 2>/dev/null
+     ```
 
    If empty, stop setup and explain that the current shell cannot find `bun` or `node`.
    - On **Windows + Git Bash/MSYS2**, explicitly explain that the current Git Bash session could not find `bun` or `node`, even if Claude Code itself is installed.
@@ -128,7 +133,7 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
      winget install OpenJS.NodeJS.LTS
      ```
    - Otherwise ask the user to install one of these:
-     - Node.js LTS from https://nodejs.org/
+     - Node.js LTS from https://nodejs.org/ (recommended on Windows)
      - Bun from https://bun.sh/
    - After installation, ask the user to restart their shell and re-run `/claude-hud:setup`.
 
@@ -158,7 +163,7 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
 **Windows + Git Bash** (Platform: `win32`, Shell: `bash`):
 
-Use the macOS/Linux bash instructions above - same detection commands, same command format. Do not use PowerShell commands when the shell is bash. Claude Code invokes statusLine commands through bash, which will interpret PowerShell variables like `$env` and `$p` before PowerShell ever sees them.
+Use the macOS/Linux bash command format above, but on Windows prefer `node` first and only fall back to `bun`. Do not use PowerShell commands when the shell is bash. Claude Code invokes statusLine commands through bash, which will interpret PowerShell variables like `$env` and `$p` before PowerShell ever sees them.
 
 **Windows + PowerShell** (Platform: `win32`, Shell: `powershell`, `pwsh`, or `cmd`):
 
@@ -169,9 +174,9 @@ Use the macOS/Linux bash instructions above - same detection commands, same comm
    ```
    If empty or errors, the plugin is not installed. Ask the user to install via marketplace first.
 
-2. Get runtime absolute path (prefer bun, fallback to node):
+2. Get runtime absolute path (prefer node, fallback to bun on Windows):
    ```powershell
-   if (Get-Command bun -ErrorAction SilentlyContinue) { (Get-Command bun).Source } elseif (Get-Command node -ErrorAction SilentlyContinue) { (Get-Command node).Source } else { Write-Error "Neither bun nor node found" }
+   if (Get-Command node -ErrorAction SilentlyContinue) { (Get-Command node).Source } elseif (Get-Command bun -ErrorAction SilentlyContinue) { (Get-Command bun).Source } else { Write-Error "Neither node nor bun found" }
    ```
 
    If neither found, stop setup and explain that the current PowerShell session cannot find `bun` or `node`.
@@ -180,6 +185,7 @@ Use the macOS/Linux bash instructions above - same detection commands, same comm
      winget install OpenJS.NodeJS.LTS
      ```
    - Otherwise ask the user to install either Node.js LTS or Bun, then restart PowerShell and re-run `/claude-hud:setup`.
+   - On Windows, prefer Node.js when both are available because Bun is currently unstable for repeated statusLine execution.
 
 3. Check if runtime is bun (by filename). If bun, use `src\index.ts`. Otherwise use `dist\index.js`.
 


### PR DESCRIPTION
## Summary
- change Windows setup guidance to prefer Node over Bun for the statusLine runtime
- keep Bun as a fallback only when Node is unavailable
- document the Windows recommendation in the README setup note

## Testing
- not run (docs-only change)

Closes #355
