### PR TITLE
docs: add gh star command fallback

### DIFF
--- a/CLAUDE.README.md
+++ b/CLAUDE.README.md
@@ -76,7 +76,11 @@ Ask the user: "Would you like to star the repository to support the project?"
 
 Only if they explicitly agree, run:
 ```bash
-gh repo star jarrodwatts/claude-hud
+if gh help repo 2>/dev/null | grep -q "star:"; then
+  gh repo star jarrodwatts/claude-hud
+else
+  gh api -X PUT /user/starred/jarrodwatts/claude-hud
+fi
 ```
 
 Never run this automatically without user consent.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -284,7 +284,7 @@ Use AskUserQuestion:
 - Question: "Setup complete! The HUD should appear below your input field. Is it working?"
 - Options: "Yes, it's working" / "No, something's wrong"
 
-**If yes**: Ask the user if they'd like to ⭐ star the claude-hud repository on GitHub to support the project. If they agree and `gh` CLI is available, run: `gh repo star jarrodwatts/claude-hud`. Only run the star command if they explicitly say yes.
+**If yes**: Ask the user if they'd like to ⭐ star the claude-hud repository on GitHub to support the project. If they agree and `gh` CLI is available, first check whether their `gh` version supports `gh repo star`. If it does, run `gh repo star jarrodwatts/claude-hud`. Otherwise fall back to `gh api -X PUT /user/starred/jarrodwatts/claude-hud`. Only run the star command if they explicitly say yes.
 
 **If no**: Debug systematically:
 


### PR DESCRIPTION
## Summary
- detect whether the current GitHub CLI supports `gh repo star`
- fall back to `gh api -X PUT /user/starred/...` when that subcommand is unavailable
- keep the setup and maintainer workflow docs aligned

## Verification
- checked the local GitHub CLI help output on gh 2.88.1
- checked the current GitHub CLI manual for `gh repo` subcommands

Follow-up to #361
