### PR TITLE
feat: add output style display toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showContextBar` | boolean | true | Show visual context bar `████░░░░░░` |
 | `display.contextValue` | `percent` \| `tokens` \| `remaining` \| `both` | `percent` | Context display format (`45%`, `45k/200k`, `55%` remaining, or `45% (45k/200k)`) |
 | `display.showConfigCounts` | boolean | false | Show CLAUDE.md, rules, MCPs, hooks counts |
+| `display.showOutputStyle` | boolean | false | Show the active Claude Code `outputStyle` from settings files as `style: <name>` |
 | `display.showDuration` | boolean | false | Show session duration `⏱️ 5m` |
 | `display.showSpeed` | boolean | false | Show output token speed `out: 42.1 tok/s` |
 | `display.showUsage` | boolean | true | Show Claude subscriber usage limits when available |

--- a/src/config-reader.ts
+++ b/src/config-reader.ts
@@ -12,6 +12,7 @@ export interface ConfigCounts {
   rulesCount: number;
   mcpCount: number;
   hooksCount: number;
+  outputStyle?: string;
 }
 
 interface SentinelState {
@@ -90,6 +91,21 @@ function countHooksInFile(filePath: string): number {
   return 0;
 }
 
+function readStringSetting(filePath: string, key: string): string | undefined {
+  if (!fs.existsSync(filePath)) return undefined;
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const config = JSON.parse(content);
+    if (typeof config[key] === 'string') {
+      const value = config[key].trim();
+      return value.length > 0 ? value : undefined;
+    }
+  } catch (error) {
+    debug(`Failed to read ${key} from ${filePath}:`, error);
+  }
+  return undefined;
+}
+
 function countRulesInDir(rulesDir: string): number {
   if (!fs.existsSync(rulesDir)) return 0;
   let count = 0;
@@ -159,6 +175,7 @@ function buildSentinelPaths(claudeDir: string, claudeConfigJsonPath: string, cwd
     path.join(claudeDir, 'CLAUDE.md'),
     path.join(claudeDir, 'rules'),
     path.join(claudeDir, 'settings.json'),
+    path.join(claudeDir, 'settings.local.json'),
     claudeConfigJsonPath,
   ];
 
@@ -237,6 +254,7 @@ function isConfigCounts(value: unknown): value is ConfigCounts {
     && typeof counts.hooksCount === 'number'
     && Number.isFinite(counts.hooksCount)
     && counts.hooksCount >= 0
+    && (counts.outputStyle === undefined || typeof counts.outputStyle === 'string')
   );
 }
 
@@ -272,6 +290,7 @@ function computeConfigCountsFresh(cwd?: string): ConfigCounts {
   let claudeMdCount = 0;
   let rulesCount = 0;
   let hooksCount = 0;
+  let outputStyle: string | undefined;
 
   const homeDir = os.homedir();
   const claudeDir = getClaudeConfigDir(homeDir);
@@ -296,6 +315,10 @@ function computeConfigCountsFresh(cwd?: string): ConfigCounts {
     userMcpServers.add(name);
   }
   hooksCount += countHooksInFile(userSettings);
+  outputStyle = readStringSetting(userSettings, 'outputStyle');
+
+  const userLocalSettings = path.join(claudeDir, 'settings.local.json');
+  outputStyle = readStringSetting(userLocalSettings, 'outputStyle') ?? outputStyle;
 
   // {CLAUDE_CONFIG_DIR}.json (additional user-scope MCPs)
   const userClaudeJson = getClaudeConfigJsonPath(homeDir);
@@ -355,6 +378,7 @@ function computeConfigCountsFresh(cwd?: string): ConfigCounts {
         projectMcpServers.add(name);
       }
       hooksCount += countHooksInFile(projectSettings);
+      outputStyle = readStringSetting(projectSettings, 'outputStyle') ?? outputStyle;
     }
 
     // {cwd}/.claude/settings.local.json (local project settings)
@@ -363,6 +387,7 @@ function computeConfigCountsFresh(cwd?: string): ConfigCounts {
       projectMcpServers.add(name);
     }
     hooksCount += countHooksInFile(localSettings);
+    outputStyle = readStringSetting(localSettings, 'outputStyle') ?? outputStyle;
 
     // Get disabled .mcp.json servers from settings.local.json
     const disabledMcpJsonServers = getDisabledMcpServers(localSettings, 'disabledMcpjsonServers');
@@ -381,7 +406,7 @@ function computeConfigCountsFresh(cwd?: string): ConfigCounts {
   // A server with the same name in both user and project scope counts as 2 (separate configs).
   const mcpCount = userMcpServers.size + projectMcpServers.size;
 
-  return { claudeMdCount, rulesCount, mcpCount, hooksCount };
+  return { claudeMdCount, rulesCount, mcpCount, hooksCount, outputStyle };
 }
 
 export async function countConfigs(cwd?: string): Promise<ConfigCounts> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -88,6 +88,7 @@ export interface HudConfig {
     showClaudeCodeVersion: boolean;
     showMemoryUsage: boolean;
     showSessionTokens: boolean;
+    showOutputStyle: boolean;
     autocompactBuffer: AutocompactBufferMode;
     usageThreshold: number;
     sevenDayThreshold: number;
@@ -129,6 +130,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showClaudeCodeVersion: false,
     showMemoryUsage: false,
     showSessionTokens: false,
+    showOutputStyle: false,
     autocompactBuffer: 'enabled',
     usageThreshold: 0,
     sevenDayThreshold: 80,
@@ -348,6 +350,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showSessionTokens: typeof migrated.display?.showSessionTokens === 'boolean'
       ? migrated.display.showSessionTokens
       : DEFAULT_CONFIG.display.showSessionTokens,
+    showOutputStyle: typeof migrated.display?.showOutputStyle === 'boolean'
+      ? migrated.display.showOutputStyle
+      : DEFAULT_CONFIG.display.showOutputStyle,
     autocompactBuffer: validateAutocompactBuffer(migrated.display?.autocompactBuffer)
       ? migrated.display.autocompactBuffer
       : DEFAULT_CONFIG.display.autocompactBuffer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     const transcriptPath = stdin.transcript_path ?? "";
     const transcript = await deps.parseTranscript(transcriptPath);
 
-    const { claudeMdCount, rulesCount, mcpCount, hooksCount } =
+    const { claudeMdCount, rulesCount, mcpCount, hooksCount, outputStyle } =
       await deps.countConfigs(stdin.cwd);
 
     const config = await deps.loadConfig();
@@ -107,6 +107,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       memoryUsage,
       config,
       extraLabel,
+      outputStyle,
       claudeCodeVersion,
     };
 

--- a/src/render/lines/environment.ts
+++ b/src/render/lines/environment.ts
@@ -4,35 +4,33 @@ import { t } from "../../i18n/index.js";
 
 export function renderEnvironmentLine(ctx: RenderContext): string | null {
   const display = ctx.config?.display;
-
-  if (display?.showConfigCounts === false) {
-    return null;
-  }
-
   const totalCounts =
     ctx.claudeMdCount + ctx.rulesCount + ctx.mcpCount + ctx.hooksCount;
   const threshold = display?.environmentThreshold ?? 0;
-
-  if (totalCounts === 0 || totalCounts < threshold) {
-    return null;
-  }
-
+  const showCounts = display?.showConfigCounts !== false;
+  const showOutputStyle = display?.showOutputStyle === true;
   const parts: string[] = [];
 
-  if (ctx.claudeMdCount > 0) {
-    parts.push(`${ctx.claudeMdCount} CLAUDE.md`);
+  if (showCounts && totalCounts >= threshold && totalCounts > 0) {
+    if (ctx.claudeMdCount > 0) {
+      parts.push(`${ctx.claudeMdCount} CLAUDE.md`);
+    }
+
+    if (ctx.rulesCount > 0) {
+      parts.push(`${ctx.rulesCount} ${t("label.rules")}`);
+    }
+
+    if (ctx.mcpCount > 0) {
+      parts.push(`${ctx.mcpCount} MCPs`);
+    }
+
+    if (ctx.hooksCount > 0) {
+      parts.push(`${ctx.hooksCount} ${t("label.hooks")}`);
+    }
   }
 
-  if (ctx.rulesCount > 0) {
-    parts.push(`${ctx.rulesCount} ${t("label.rules")}`);
-  }
-
-  if (ctx.mcpCount > 0) {
-    parts.push(`${ctx.mcpCount} MCPs`);
-  }
-
-  if (ctx.hooksCount > 0) {
-    parts.push(`${ctx.hooksCount} ${t("label.hooks")}`);
+  if (showOutputStyle && ctx.outputStyle) {
+    parts.push(`style: ${ctx.outputStyle}`);
   }
 
   if (parts.length === 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,5 +104,6 @@ export interface RenderContext {
   memoryUsage: MemoryInfo | null;
   config: HudConfig;
   extraLabel: string | null;
+  outputStyle?: string;
   claudeCodeVersion?: string;
 }

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -58,6 +58,7 @@ test('loadConfig returns valid config structure', async () => {
   assert.equal(typeof config.display.showSessionName, 'boolean');
   assert.equal(typeof config.display.showClaudeCodeVersion, 'boolean');
   assert.equal(typeof config.display.showMemoryUsage, 'boolean');
+  assert.equal(typeof config.display.showOutputStyle, 'boolean');
   assert.ok(['full', 'compact', 'short'].includes(config.display.modelFormat), 'modelFormat should be valid');
   assert.equal(typeof config.display.modelOverride, 'string', 'modelOverride should be string');
   assert.equal(typeof config.colors, 'object');
@@ -111,6 +112,17 @@ test('mergeConfig defaults showMemoryUsage to false', () => {
 test('mergeConfig preserves explicit showMemoryUsage=true', () => {
   const config = mergeConfig({ display: { showMemoryUsage: true } });
   assert.equal(config.display.showMemoryUsage, true);
+});
+
+test('mergeConfig defaults showOutputStyle to false', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.showOutputStyle, false);
+  assert.equal(DEFAULT_CONFIG.display.showOutputStyle, false);
+});
+
+test('mergeConfig preserves explicit showOutputStyle=true', () => {
+  const config = mergeConfig({ display: { showOutputStyle: true } });
+  assert.equal(config.display.showOutputStyle, true);
 });
 
 test('mergeConfig preserves customLine and truncates long values', () => {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -893,6 +893,41 @@ test('countConfigs honors project and global config locations', async () => {
   }
 });
 
+test('countConfigs returns outputStyle with project local precedence', async () => {
+  const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
+  const projectDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-project-'));
+  const originalHome = process.env.HOME;
+  process.env.HOME = homeDir;
+
+  try {
+    await mkdir(path.join(homeDir, '.claude'), { recursive: true });
+    await mkdir(path.join(projectDir, '.claude'), { recursive: true });
+
+    await writeFile(
+      path.join(homeDir, '.claude', 'settings.local.json'),
+      JSON.stringify({ outputStyle: 'default-user-style' }),
+      'utf8',
+    );
+    await writeFile(
+      path.join(projectDir, '.claude', 'settings.json'),
+      JSON.stringify({ outputStyle: 'project-base-style' }),
+      'utf8',
+    );
+    await writeFile(
+      path.join(projectDir, '.claude', 'settings.local.json'),
+      JSON.stringify({ outputStyle: 'tech-leader' }),
+      'utf8',
+    );
+
+    const counts = await countConfigs(projectDir);
+    assert.equal(counts.outputStyle, 'tech-leader');
+  } finally {
+    restoreEnvVar('HOME', originalHome);
+    await rm(homeDir, { recursive: true, force: true });
+    await rm(projectDir, { recursive: true, force: true });
+  }
+});
+
 test('countConfigs uses CLAUDE_CONFIG_DIR and matching .json sidecar for user scope', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
   const customConfigDir = path.join(homeDir, '.claude-2');

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -148,6 +148,7 @@ test("main executes the happy path with default dependencies", async () => {
         rulesCount: 0,
         mcpCount: 0,
         hooksCount: 0,
+        outputStyle: "tech-leader",
       }),
       getGitBranch: async () => null,
       getUsage: async () => null,
@@ -160,6 +161,7 @@ test("main executes the happy path with default dependencies", async () => {
   }
 
   assert.equal(renderedContext?.sessionDuration, "1m");
+  assert.equal(renderedContext?.outputStyle, "tech-leader");
 });
 
 test("main includes git status in render context", async () => {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -50,7 +50,7 @@ function baseContext() {
       pathLevels: 1,
       elementOrder: ['project', 'context', 'usage', 'memory', 'environment', 'tools', 'agents', 'todos'],
       gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false },
-      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
+      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showOutputStyle: false, autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
       colors: {
         context: 'green',
         usage: 'brightBlue',
@@ -560,6 +560,26 @@ test('label color overrides apply across shared secondary text surfaces', () => 
   assert.ok(renderToolsLine(ctx)?.includes(`${expected}: src/index.ts\x1b[0m`));
   assert.ok(renderAgentsLine(ctx)?.includes(`${expected}[haiku]\x1b[0m`));
   assert.ok(renderTodosLine(ctx)?.includes(`${expected}(1/2)\x1b[0m`));
+});
+
+test('renderEnvironmentLine shows output style when enabled', () => {
+  const ctx = baseContext();
+  ctx.outputStyle = 'tech-leader';
+  ctx.config.display.showConfigCounts = false;
+  ctx.config.display.showOutputStyle = true;
+
+  assert.ok(renderEnvironmentLine(ctx)?.includes('style: tech-leader'));
+});
+
+test('renderEnvironmentLine appends output style after config counts', () => {
+  const ctx = baseContext();
+  ctx.claudeMdCount = 1;
+  ctx.outputStyle = 'learning';
+  ctx.config.display.showOutputStyle = true;
+
+  const line = renderEnvironmentLine(ctx);
+  assert.ok(line?.includes('1 CLAUDE.md'));
+  assert.ok(line?.includes('style: learning'));
 });
 
 test('renderProjectLine includes duration when showDuration is true', () => {


### PR DESCRIPTION
## Summary
- add an opt-in `display.showOutputStyle` toggle
- read `outputStyle` from Claude Code settings with project-local precedence
- render `style: <name>` on the environment line without opening up arbitrary config-field rendering

## Testing
- npm run build
- node --test tests/config.test.js tests/core.test.js tests/render.test.js tests/index.test.js