### PR TITLE
fix: keep context and usage visible on narrow terminals

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -396,7 +396,15 @@ function renderExpanded(ctx: RenderContext, terminalWidth: number | null = null)
       const secondLine = renderElementLine(ctx, nextElement);
 
       if (firstLine && secondLine) {
-        lines.push({ line: `${firstLine} │ ${secondLine}`, isActivity: false });
+        const combinedLine = `${firstLine} │ ${secondLine}`;
+        const canCombine = !terminalWidth || visualLength(combinedLine) <= terminalWidth;
+
+        if (canCombine) {
+          lines.push({ line: combinedLine, isActivity: false });
+        } else {
+          lines.push({ line: firstLine, isActivity: false });
+          lines.push({ line: secondLine, isActivity: false });
+        }
       } else if (firstLine) {
         lines.push({ line: firstLine, isActivity: false });
       } else if (secondLine) {

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -376,6 +376,28 @@ test('render truncation respects Unicode display width', () => {
   assert.ok(lines.every(line => displayWidth(line) <= 10), 'all lines should respect terminal cell width');
 });
 
+test('render keeps context and usage as separate lines when a narrow terminal cannot fit both', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.config.display.usageBarEnabled = true;
+  ctx.stdin.context_window.current_usage.input_tokens = 120000;
+  ctx.usageData = {
+    fiveHour: 62,
+    sevenDay: null,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+  };
+
+  let lines = [];
+  withTerminal(24, () => {
+    lines = captureRender(ctx);
+  });
+
+  assert.ok(lines.some(line => line.includes('Context')), 'context line should remain visible');
+  assert.ok(lines.some(line => line.includes('Usage')), 'usage line should remain visible');
+  assert.ok(lines.every(line => displayWidth(line) <= 24), 'all lines should still fit terminal width');
+});
+
 test('render respects terminal width with Chinese labels enabled', () => {
   const ctx = baseContext();
   ctx.config.lineLayout = 'expanded';


### PR DESCRIPTION
## Summary
- stop combining context and usage onto one expanded-layout line when the terminal cannot fit both
- keep both lines visible on narrow terminals instead of truncating one away
- add a regression test covering narrow-width expanded rendering

## Testing
- npm run build
- node --test tests/render-width.test.js tests/render.test.js