### PR TITLE
fix: stabilize CI version cache tests

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -235,10 +235,14 @@ export async function getClaudeCodeVersion(): Promise<string | undefined> {
     }
   }
 
-  const binaryInfo = resolveClaudeBinaryImpl();
-  if (!binaryInfo) {
+  const resolvedBinaryInfo = resolveClaudeBinaryImpl();
+  if (!resolvedBinaryInfo) {
     return undefined;
   }
+
+  // Normalize resolver output to the actual on-disk binary so cache keys and
+  // persisted mtimes stay stable across process boundaries.
+  const binaryInfo = statResolvedBinary(resolvedBinaryInfo.path) ?? resolvedBinaryInfo;
 
   const binaryKey = getBinaryCacheKey(binaryInfo);
   if (hasResolved && cachedBinaryKey === binaryKey) {

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -8,10 +8,12 @@ import path from "node:path";
 import { readFileSync } from "node:fs";
 
 function stripAnsi(text) {
-  return text.replace(
-    /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nq-uy=><]/g,
-    "",
-  );
+  return text
+    .replace(
+      /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nq-uy=><]/g,
+      "",
+    )
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "");
 }
 
 function skipIfSpawnBlocked(result, t) {

--- a/tests/version.test.js
+++ b/tests/version.test.js
@@ -1,7 +1,7 @@
 import { afterEach, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { existsSync, utimesSync } from 'node:fs';
+import { existsSync, realpathSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
@@ -172,6 +172,7 @@ test('getClaudeCodeVersion executes the resolved binary path', async () => {
   utimesSync(binaryPath, binaryMtimeMs / 1000, binaryMtimeMs / 1000);
 
   try {
+    const realBinaryPath = realpathSync(binaryPath);
     _setResolveClaudeBinaryForTests(() => ({ path: binaryPath, mtimeMs: binaryMtimeMs }));
     _setExecFileImplForTests(async (file) => {
       execCalls.push(file);
@@ -180,7 +181,7 @@ test('getClaudeCodeVersion executes the resolved binary path', async () => {
 
     const version = await getClaudeCodeVersion();
     assert.equal(version, '2.1.81');
-    assert.deepEqual(execCalls, [binaryPath]);
+    assert.deepEqual(execCalls, [realBinaryPath]);
   } finally {
     restoreEnvVar('HOME', originalHome);
     restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
@@ -205,6 +206,7 @@ test('getClaudeCodeVersion uses the Windows wrapper invocation for .cmd binaries
   utimesSync(binaryPath, binaryMtimeMs / 1000, binaryMtimeMs / 1000);
 
   try {
+    const realBinaryPath = realpathSync(binaryPath);
     _setVersionInvocationEnvForTests(() => 'win32', () => 'C:\\Windows\\System32\\cmd.exe');
     _setResolveClaudeBinaryForTests(() => ({ path: binaryPath, mtimeMs: binaryMtimeMs }));
     _setExecFileImplForTests(async (file, args) => {
@@ -214,7 +216,7 @@ test('getClaudeCodeVersion uses the Windows wrapper invocation for .cmd binaries
 
     const version = await getClaudeCodeVersion();
     assert.equal(version, '2.1.81');
-    const expectedInvocation = _getClaudeVersionInvocation(binaryPath, 'win32', 'C:\\Windows\\System32\\cmd.exe');
+    const expectedInvocation = _getClaudeVersionInvocation(realBinaryPath, 'win32', 'C:\\Windows\\System32\\cmd.exe');
     assert.deepEqual(execCalls, [{
       file: expectedInvocation.file,
       args: expectedInvocation.args,


### PR DESCRIPTION
## Summary
- canonicalize the resolved Claude binary path and mtime before using it for version cache keys
- update version tests to assert the real on-disk binary path instead of the pre-realpath temp path
- strip OSC hyperlink sequences in the CLI integration test so it stays stable across terminal environments

## Verification
- npm run test:coverage
