### PR TITLE
feat: add offline estimated cost display

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showContextBar` | boolean | true | Show visual context bar `████░░░░░░` |
 | `display.contextValue` | `percent` \| `tokens` \| `remaining` \| `both` | `percent` | Context display format (`45%`, `45k/200k`, `55%` remaining, or `45% (45k/200k)`) |
 | `display.showConfigCounts` | boolean | false | Show CLAUDE.md, rules, MCPs, hooks counts |
+| `display.showCost` | boolean | false | Show an offline estimated session cost from transcript token usage for known Anthropic model families |
 | `display.showOutputStyle` | boolean | false | Show the active Claude Code `outputStyle` from settings files as `style: <name>` |
 | `display.showDuration` | boolean | false | Show session duration `⏱️ 5m` |
 | `display.showSpeed` | boolean | false | Show output token speed `out: 42.1 tok/s` |
@@ -194,6 +195,8 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 Supported color names: `dim`, `red`, `green`, `yellow`, `magenta`, `cyan`, `brightBlue`, `brightMagenta`. You can also use a 256-color number (`0-255`) or hex (`#rrggbb`).
 
 `display.showMemoryUsage` is fully opt-in and only renders in `expanded` layout. It reports approximate system RAM usage from the local machine, not precise memory pressure inside Claude Code or a specific process. The number may overstate actual pressure because reclaimable OS cache and buffers can still be counted as used memory.
+
+`display.showCost` is fully opt-in. It uses built-in Anthropic family pricing to estimate session cost from transcript token usage and stays hidden when pricing cannot be matched confidently, such as Bedrock-routed sessions or unknown model names. The value is intentionally labeled as an estimate and may lag future pricing changes.
 
 ### Usage Limits
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,6 +78,7 @@ export interface HudConfig {
     showContextBar: boolean;
     contextValue: ContextValueMode;
     showConfigCounts: boolean;
+    showCost: boolean;
     showDuration: boolean;
     showSpeed: boolean;
     showTokenBreakdown: boolean;
@@ -122,6 +123,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showContextBar: true,
     contextValue: 'percent',
     showConfigCounts: false,
+    showCost: false,
     showDuration: false,
     showSpeed: false,
     showTokenBreakdown: true,
@@ -327,6 +329,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showConfigCounts: typeof migrated.display?.showConfigCounts === 'boolean'
       ? migrated.display.showConfigCounts
       : DEFAULT_CONFIG.display.showConfigCounts,
+    showCost: typeof migrated.display?.showCost === 'boolean'
+      ? migrated.display.showCost
+      : DEFAULT_CONFIG.display.showCost,
     showDuration: typeof migrated.display?.showDuration === 'boolean'
       ? migrated.display.showDuration
       : DEFAULT_CONFIG.display.showDuration,

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -1,0 +1,120 @@
+import type { SessionTokenUsage, StdinData } from './types.js';
+import { getProviderLabel } from './stdin.js';
+
+type ModelPricing = {
+  inputUsdPerMillion: number;
+  outputUsdPerMillion: number;
+};
+
+export interface SessionCostEstimate {
+  totalUsd: number;
+  inputUsd: number;
+  cacheCreationUsd: number;
+  cacheReadUsd: number;
+  outputUsd: number;
+}
+
+const TOKENS_PER_MILLION = 1_000_000;
+const CACHE_WRITE_MULTIPLIER = 1.25;
+const CACHE_READ_MULTIPLIER = 0.1;
+
+const ANTHROPIC_MODEL_PRICING: Array<{ pattern: RegExp; pricing: ModelPricing }> = [
+  { pattern: /\bopus 4(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 15, outputUsdPerMillion: 75 } },
+  { pattern: /\bsonnet 4(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
+  { pattern: /\bsonnet 3 7\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
+  { pattern: /\bsonnet 3 5\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
+  { pattern: /\bhaiku 3 5\b/i, pricing: { inputUsdPerMillion: 0.8, outputUsdPerMillion: 4 } },
+];
+
+function normalizeModelName(modelName: string): string {
+  return modelName
+    .toLowerCase()
+    .replace(/^claude\s+/, '')
+    .replace(/\([^)]*\)/g, ' ')
+    .replace(/[._-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function matchAnthropicPricing(modelName: string): ModelPricing | null {
+  const normalized = normalizeModelName(modelName);
+  for (const entry of ANTHROPIC_MODEL_PRICING) {
+    if (entry.pattern.test(normalized)) {
+      return entry.pricing;
+    }
+  }
+  return null;
+}
+
+function calculateUsd(tokens: number, usdPerMillion: number): number {
+  return (tokens * usdPerMillion) / TOKENS_PER_MILLION;
+}
+
+function getAnthropicPricing(stdin: StdinData): ModelPricing | null {
+  const candidates = [
+    stdin.model?.display_name?.trim(),
+    stdin.model?.id?.trim(),
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+
+    const pricing = matchAnthropicPricing(candidate);
+    if (pricing) {
+      return pricing;
+    }
+  }
+
+  return null;
+}
+
+export function estimateSessionCost(
+  stdin: StdinData,
+  sessionTokens: SessionTokenUsage | undefined,
+): SessionCostEstimate | null {
+  if (!sessionTokens) {
+    return null;
+  }
+
+  if (getProviderLabel(stdin)) {
+    return null;
+  }
+
+  const pricing = getAnthropicPricing(stdin);
+  if (!pricing) {
+    return null;
+  }
+
+  const totalTokens = sessionTokens.inputTokens
+    + sessionTokens.cacheCreationTokens
+    + sessionTokens.cacheReadTokens
+    + sessionTokens.outputTokens;
+  if (totalTokens === 0) {
+    return null;
+  }
+
+  const inputUsd = calculateUsd(sessionTokens.inputTokens, pricing.inputUsdPerMillion);
+  const cacheCreationUsd = calculateUsd(sessionTokens.cacheCreationTokens, pricing.inputUsdPerMillion * CACHE_WRITE_MULTIPLIER);
+  const cacheReadUsd = calculateUsd(sessionTokens.cacheReadTokens, pricing.inputUsdPerMillion * CACHE_READ_MULTIPLIER);
+  const outputUsd = calculateUsd(sessionTokens.outputTokens, pricing.outputUsdPerMillion);
+
+  return {
+    totalUsd: inputUsd + cacheCreationUsd + cacheReadUsd + outputUsd,
+    inputUsd,
+    cacheCreationUsd,
+    cacheReadUsd,
+    outputUsd,
+  };
+}
+
+export function formatUsd(amount: number): string {
+  if (amount >= 1) {
+    return `$${amount.toFixed(2)}`;
+  }
+  if (amount >= 0.1) {
+    return `$${amount.toFixed(3)}`;
+  }
+  return `$${amount.toFixed(4)}`;
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -8,6 +8,7 @@ export const en: Messages = {
   "label.approxRam": "Approx RAM",
   "label.rules": "rules",
   "label.hooks": "hooks",
+  "label.estimatedCost": "Est.",
 
   // Status
   "status.limitReached": "Limit reached",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -6,6 +6,7 @@ export type MessageKey =
   | "label.approxRam"
   | "label.rules"
   | "label.hooks"
+  | "label.estimatedCost"
   // Status
   | "status.limitReached"
   | "status.allTodosComplete"

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -8,6 +8,7 @@ export const zh: Messages = {
   "label.approxRam": "内存",
   "label.rules": "规则",
   "label.hooks": "钩子",
+  "label.estimatedCost": "估算",
 
   // Status
   "status.limitReached": "已达上限",

--- a/src/render/lines/cost.ts
+++ b/src/render/lines/cost.ts
@@ -1,0 +1,17 @@
+import type { RenderContext } from '../../types.js';
+import { estimateSessionCost, formatUsd } from '../../cost.js';
+import { t } from '../../i18n/index.js';
+import { label } from '../colors.js';
+
+export function renderCostEstimate(ctx: RenderContext): string | null {
+  if (ctx.config?.display?.showCost !== true) {
+    return null;
+  }
+
+  const estimate = estimateSessionCost(ctx.stdin, ctx.transcript.sessionTokens);
+  if (!estimate) {
+    return null;
+  }
+
+  return label(`${t('label.estimatedCost')} ${formatUsd(estimate.totalUsd)}`, ctx.config?.colors);
+}

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -5,6 +5,7 @@ import { getModelName, formatModelName, getProviderLabel } from '../../stdin.js'
 import { getOutputSpeed } from '../../speed-tracker.js';
 import { git as gitColor, gitBranch as gitBranchColor, warning as warningColor, critical as criticalColor, label, model as modelColor, project as projectColor, red, green, yellow, dim, custom as customColor } from '../colors.js';
 import { t } from '../../i18n/index.js';
+import { renderCostEstimate } from './cost.js';
 
 function hyperlink(uri: string, text: string): string {
   const esc = '\x1b';
@@ -93,6 +94,11 @@ export function renderProjectLine(ctx: RenderContext): string | null {
 
   if (display?.showDuration !== false && ctx.sessionDuration) {
     parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
+  }
+
+  const costEstimate = renderCostEstimate(ctx);
+  if (costEstimate) {
+    parts.push(costEstimate);
   }
 
   const customLine = display?.customLine;

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -4,6 +4,7 @@ import { getContextPercent, getBufferedPercent, getModelName, formatModelName, g
 import { getOutputSpeed } from '../speed-tracker.js';
 import { coloredBar, critical, git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, getContextColor, getQuotaColor, quotaBar, custom as customColor, RESET } from './colors.js';
 import { getAdaptiveBarWidth } from '../utils/terminal.js';
+import { renderCostEstimate } from './lines/cost.js';
 import { t } from '../i18n/index.js';
 
 const DEBUG = process.env.DEBUG?.includes('claude-hud') || process.env.DEBUG === '*';
@@ -215,6 +216,11 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   if (display?.showDuration !== false && ctx.sessionDuration) {
     parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
+  }
+
+  const costEstimate = renderCostEstimate(ctx);
+  if (costEstimate) {
+    parts.push(costEstimate);
   }
 
   if (ctx.extraLabel) {

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -60,6 +60,7 @@ test('loadConfig returns valid config structure', async () => {
   assert.equal(typeof config.display.showSessionName, 'boolean');
   assert.equal(typeof config.display.showClaudeCodeVersion, 'boolean');
   assert.equal(typeof config.display.showMemoryUsage, 'boolean');
+  assert.equal(typeof config.display.showCost, 'boolean');
   assert.equal(typeof config.display.showOutputStyle, 'boolean');
   assert.ok(['full', 'compact', 'short'].includes(config.display.modelFormat), 'modelFormat should be valid');
   assert.equal(typeof config.display.modelOverride, 'string', 'modelOverride should be string');
@@ -114,6 +115,17 @@ test('mergeConfig defaults showMemoryUsage to false', () => {
 test('mergeConfig preserves explicit showMemoryUsage=true', () => {
   const config = mergeConfig({ display: { showMemoryUsage: true } });
   assert.equal(config.display.showMemoryUsage, true);
+});
+
+test('mergeConfig defaults showCost to false', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.showCost, false);
+  assert.equal(DEFAULT_CONFIG.display.showCost, false);
+});
+
+test('mergeConfig preserves explicit showCost=true', () => {
+  const config = mergeConfig({ display: { showCost: true } });
+  assert.equal(config.display.showCost, true);
 });
 
 test('mergeConfig defaults git push thresholds to disabled', () => {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { _setCreateReadStreamForTests, parseTranscript } from '../dist/transcript.js';
 import { countConfigs } from '../dist/config-reader.js';
 import { getContextPercent, getBufferedPercent, getModelName, getProviderLabel, getUsageFromStdin, isBedrockModelId, stripContextSuffix, formatModelName } from '../dist/stdin.js';
+import { estimateSessionCost, formatUsd } from '../dist/cost.js';
 import * as fs from 'node:fs';
 
 function restoreEnvVar(name, value) {
@@ -336,6 +337,59 @@ test('bedrock model detection recognizes bedrock ids', () => {
   assert.equal(isBedrockModelId('claude-3-5-sonnet-20241022'), false);
   assert.equal(getProviderLabel({ model: { id: 'anthropic.claude-3-5-sonnet-20240620-v1:0' } }), 'Bedrock');
   assert.equal(getProviderLabel({ model: { id: 'claude-3-5-sonnet-20241022' } }), null);
+});
+
+test('estimateSessionCost calculates offline Anthropic pricing from session tokens', () => {
+  const estimate = estimateSessionCost(
+    { model: { display_name: 'Claude Sonnet 4.5' } },
+    {
+      inputTokens: 100000,
+      cacheCreationTokens: 10000,
+      cacheReadTokens: 20000,
+      outputTokens: 50000,
+    },
+  );
+
+  assert.ok(estimate, 'expected a cost estimate');
+  assert.equal(formatUsd(estimate.totalUsd), '$1.09');
+});
+
+test('estimateSessionCost hides cost for Bedrock and unknown model pricing', () => {
+  assert.equal(
+    estimateSessionCost(
+      { model: { id: 'anthropic.claude-sonnet-4-20250514-v1:0' } },
+      { inputTokens: 1, cacheCreationTokens: 0, cacheReadTokens: 0, outputTokens: 1 },
+    ),
+    null,
+  );
+
+  assert.equal(
+    estimateSessionCost(
+      { model: { display_name: 'Custom Router Model' } },
+      { inputTokens: 1, cacheCreationTokens: 0, cacheReadTokens: 0, outputTokens: 1 },
+    ),
+    null,
+  );
+});
+
+test('estimateSessionCost uses model id when display name is shorthand', () => {
+  const estimate = estimateSessionCost(
+    {
+      model: {
+        display_name: 'Opus',
+        id: 'claude-opus-4-20250514',
+      },
+    },
+    {
+      inputTokens: 100000,
+      cacheCreationTokens: 10000,
+      cacheReadTokens: 20000,
+      outputTokens: 50000,
+    },
+  );
+
+  assert.ok(estimate, 'expected a cost estimate from the model id');
+  assert.equal(formatUsd(estimate.totalUsd), '$5.47');
 });
 
 test('parseTranscript aggregates tools, agents, and todos', async () => {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -50,7 +50,7 @@ function baseContext() {
       pathLevels: 1,
       elementOrder: ['project', 'context', 'usage', 'memory', 'environment', 'tools', 'agents', 'todos'],
       gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, pushWarningThreshold: 0, pushCriticalThreshold: 0 },
-      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showOutputStyle: false, autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
+      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showOutputStyle: false, autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
       colors: {
         context: 'green',
         usage: 'brightBlue',
@@ -589,6 +589,58 @@ test('renderProjectLine includes duration when showDuration is true', () => {
   ctx.sessionDuration = '12m 34s';
   const line = renderProjectLine(ctx);
   assert.ok(line?.includes('12m 34s'), 'should include session duration');
+});
+
+test('renderSessionLine shows estimated cost when enabled and pricing is known', () => {
+  const ctx = baseContext();
+  ctx.stdin.model.id = 'claude-opus-4-20250514';
+  ctx.config.display.showCost = true;
+  ctx.transcript.sessionTokens = {
+    inputTokens: 100000,
+    cacheCreationTokens: 10000,
+    cacheReadTokens: 20000,
+    outputTokens: 50000,
+  };
+
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('Est. $5.47'));
+});
+
+test('renderProjectLine hides estimated cost for Bedrock pricing', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.config.display.showCost = true;
+  ctx.stdin.model = { id: 'anthropic.claude-sonnet-4-20250514-v1:0' };
+  ctx.transcript.sessionTokens = {
+    inputTokens: 100000,
+    cacheCreationTokens: 10000,
+    cacheReadTokens: 20000,
+    outputTokens: 50000,
+  };
+
+  const line = stripAnsi(renderProjectLine(ctx));
+  assert.ok(!line.includes('Est.'), 'Bedrock cost estimate should stay hidden');
+});
+
+test('renderProjectLine translates estimated cost label when Chinese is enabled', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.stdin.model.id = 'claude-opus-4-20250514';
+  ctx.config.display.showCost = true;
+  ctx.transcript.sessionTokens = {
+    inputTokens: 100000,
+    cacheCreationTokens: 10000,
+    cacheReadTokens: 20000,
+    outputTokens: 50000,
+  };
+
+  setLanguage('zh');
+  try {
+    const line = stripAnsi(renderProjectLine(ctx));
+    assert.ok(line.includes('估算 $5.47'));
+  } finally {
+    setLanguage('en');
+  }
 });
 
 test('renderProjectLine omits duration when showDuration is false', () => {


### PR DESCRIPTION
## Summary
- add an opt-in `display.showCost` toggle for offline session cost estimates
- estimate from local transcript token usage only for known Anthropic model families
- hide the estimate for Bedrock and unknown model/pricing cases, and add English/Chinese labels

## Why
Closes #305 without adding network lookups or undocumented API dependencies. The value is intentionally labeled as an estimate and stays hidden when pricing cannot be matched confidently.

## Verification
- `npm run test:coverage`
