### PR TITLE
docs: add language selection to configure flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ Customize your HUD anytime:
 The guided flow handles layout, language, and common display toggles. Advanced overrides such as
 custom colors and thresholds are preserved there, but you set them by editing the config file directly:
 
-- **First time setup**: Choose a preset (Full/Essential/Minimal), then fine-tune individual elements
-- **Customize anytime**: Toggle items on/off, adjust git display style, switch layouts
+- **First time setup**: Choose a preset (Full/Essential/Minimal), pick a label language, then fine-tune individual elements
+- **Customize anytime**: Toggle items on/off, adjust git display style, switch layouts, or change label language
 - **Preview before saving**: See exactly how your HUD will look before committing changes
 
 ### Presets

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -85,8 +85,8 @@ Save as `language: "en"` or `language: "zh"`.
 - options: **ONLY items that are OFF in the chosen preset** (max 4)
   - (same list as above, filtered to OFF items)
 
-**Note:** If preset has all items ON (Full), Q4 shows "Nothing to enable - Full preset has everything!"
-If preset has all items OFF (Minimal), Q3 shows "Nothing to disable - Minimal preset is already minimal!"
+**Note:** If preset has all items ON (Full), Q5 shows "Nothing to enable - Full preset has everything!"
+If preset has all items OFF (Minimal), Q4 shows "Nothing to disable - Minimal preset is already minimal!"
 
 ### Q6: Custom Line (optional)
 - header: "Custom Line"


### PR DESCRIPTION
## Summary
- add explicit language selection to `/claude-hud:configure`
- keep English as the recommended default and Chinese as an explicit opt-in
- update the README so language is described as part of the guided flow, not just manual JSON

## Scope
This is a command-flow/docs change only. It does not add locale auto-detection, new runtime logic, or extra configuration complexity beyond a single explicit language choice.

## Verification
- `git diff --check`
