### PR TITLE
release: cut v0.0.12

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-    "version": "0.0.11"
+    "version": "0.0.12"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hud",
   "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,26 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+## [0.0.12] - 2026-04-04
+
+### Added
+- Chinese (`zh`) HUD labels as an explicit opt-in, while keeping English as the default.
+- Guided language selection in `/claude-hud:configure` so users can choose English or Chinese without hand-editing JSON.
+- Offline estimated session cost display via `display.showCost` for known Anthropic model families, derived from local transcript token usage only.
+- Session token totals, output-style display, git push count threshold coloring, configurable model badge formatting, and a custom model override.
+- Git file diff rendering with per-file and total line deltas, plus clickable OSC 8 file links where supported.
+
 ### Changed
-- Simplify usage display to rely only on Claude Code's official stdin `rate_limits` fields.
-- Remove the background OAuth usage API fallback, related cache/lock behavior, and credential-derived subscriber plan labels from the HUD.
+- Usage display now relies only on Claude Code's official stdin `rate_limits` fields. Background OAuth usage polling, related cache/lock behavior, and credential-derived subscriber plan labels were removed.
+- Setup and configure flows now better support simple onboarding: Windows setup prefers Node.js guidance, the GitHub star prompt includes `gh` compatibility guidance, and configure now exposes language as a first-class guided choice.
+- Plugin detection, config caching, and transcript-derived activity/session metadata are more robust and better covered by tests.
+
+### Fixed
+- Stabilize Claude Code version cache behavior across resolved binary paths and mtimes, fixing Node 20 CI failures.
+- Stop guessing auth mode from environment variables alone.
+- Preserve task IDs across `TodoWrite`, detect transcript agents recorded as `Agent`, and improve narrow-terminal wrapping including OSC hyperlink width handling.
+- Improve macOS memory reporting, config cache invalidation, and fallback rendering when terminal width is unavailable.
+- Clarify official usage-data behavior and keep Bedrock/unknown pricing cases hidden rather than showing misleading estimates.
 
 ## [0.0.10] - 2026-03-23
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hud",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Real-time statusline HUD for Claude Code",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump the plugin version to `0.0.12`
- update changelog notes for the current main-branch release contents
- prepare the repo for the `v0.0.12` tag and GitHub release workflow

## Verification
- `npm test`
- `npm run test:coverage`
