### PR TITLE
fix: bound stdin reads to avoid statusline hangs

### DIFF
--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -2,26 +2,133 @@ import type { StdinData, UsageData } from './types.js';
 import type { ModelFormatMode } from './config.js';
 import { AUTOCOMPACT_BUFFER_PERCENT } from './constants.js';
 
-export async function readStdin(): Promise<StdinData | null> {
-  if (process.stdin.isTTY) {
+type StdinStream = Pick<NodeJS.ReadStream, 'setEncoding' | 'on' | 'off' | 'pause'> & {
+  isTTY?: boolean;
+};
+
+type ReadStdinOptions = {
+  firstByteTimeoutMs?: number;
+  idleTimeoutMs?: number;
+  maxBytes?: number;
+};
+
+const DEFAULT_FIRST_BYTE_TIMEOUT_MS = 250;
+const DEFAULT_IDLE_TIMEOUT_MS = 30;
+const DEFAULT_MAX_STDIN_BYTES = 256 * 1024;
+
+export async function readStdin(
+  stream: StdinStream = process.stdin,
+  options: ReadStdinOptions = {},
+): Promise<StdinData | null> {
+  if (stream.isTTY) {
     return null;
   }
 
-  const chunks: string[] = [];
+  const firstByteTimeoutMs = options.firstByteTimeoutMs ?? DEFAULT_FIRST_BYTE_TIMEOUT_MS;
+  const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_STDIN_BYTES;
 
   try {
-    process.stdin.setEncoding('utf8');
-    for await (const chunk of process.stdin) {
-      chunks.push(chunk as string);
-    }
-    const raw = chunks.join('');
-    if (!raw.trim()) {
-      return null;
-    }
-    return JSON.parse(raw) as StdinData;
+    stream.setEncoding('utf8');
   } catch {
     return null;
   }
+
+  return await new Promise<StdinData | null>((resolve) => {
+    let raw = '';
+    let settled = false;
+    let sawData = false;
+    let firstByteTimer: ReturnType<typeof setTimeout> | undefined;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = (): void => {
+      if (firstByteTimer) {
+        clearTimeout(firstByteTimer);
+        firstByteTimer = undefined;
+      }
+      if (idleTimer) {
+        clearTimeout(idleTimer);
+        idleTimer = undefined;
+      }
+      stream.off('data', onData);
+      stream.off('end', onEnd);
+      stream.off('error', onError);
+      stream.pause();
+    };
+
+    const finish = (value: StdinData | null): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+
+    const tryParse = (): StdinData | null | undefined => {
+      const trimmed = raw.trim();
+      if (!trimmed) {
+        return null;
+      }
+
+      try {
+        return JSON.parse(trimmed) as StdinData;
+      } catch {
+        return undefined;
+      }
+    };
+
+    const scheduleIdleParse = (): void => {
+      if (idleTimer) {
+        clearTimeout(idleTimer);
+      }
+      idleTimer = setTimeout(() => {
+        const parsed = tryParse();
+        finish(parsed ?? null);
+      }, idleTimeoutMs);
+    };
+
+    const onData = (chunk: string | Buffer): void => {
+      sawData = true;
+      if (firstByteTimer) {
+        clearTimeout(firstByteTimer);
+        firstByteTimer = undefined;
+      }
+
+      raw += String(chunk);
+      if (Buffer.byteLength(raw, 'utf8') > maxBytes) {
+        finish(null);
+        return;
+      }
+
+      const parsed = tryParse();
+      if (parsed !== undefined) {
+        finish(parsed);
+        return;
+      }
+
+      scheduleIdleParse();
+    };
+
+    const onEnd = (): void => {
+      const parsed = tryParse();
+      finish(parsed ?? null);
+    };
+
+    const onError = (): void => {
+      finish(null);
+    };
+
+    firstByteTimer = setTimeout(() => {
+      if (!sawData) {
+        finish(null);
+      }
+    }, firstByteTimeoutMs);
+
+    stream.on('data', onData);
+    stream.on('end', onEnd);
+    stream.on('error', onError);
+  });
 }
 
 export function getTotalTokens(stdin: StdinData): number {

--- a/tests/stdin.test.js
+++ b/tests/stdin.test.js
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { PassThrough } from 'node:stream';
 import { readStdin } from '../dist/stdin.js';
 
 test('readStdin returns null for TTY input', async () => {
@@ -29,4 +30,67 @@ test('readStdin returns null on stream errors', async () => {
     process.stdin.setEncoding = originalSetEncoding;
     Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
   }
+});
+
+function createPipe() {
+  const stream = new PassThrough();
+  Object.defineProperty(stream, 'isTTY', { value: false, configurable: true });
+  return stream;
+}
+
+test('readStdin parses valid JSON without waiting for EOF', async () => {
+  const stream = createPipe();
+  const resultPromise = readStdin(stream, { firstByteTimeoutMs: 20, idleTimeoutMs: 10 });
+
+  stream.write('{"cwd":"/tmp/project","model":{"display_name":"Opus"}}');
+
+  const result = await resultPromise;
+  assert.deepEqual(result, {
+    cwd: '/tmp/project',
+    model: { display_name: 'Opus' },
+  });
+});
+
+test('readStdin parses JSON split across multiple chunks', async () => {
+  const stream = createPipe();
+  const resultPromise = readStdin(stream, { firstByteTimeoutMs: 20, idleTimeoutMs: 10 });
+
+  stream.write('{"cwd":"/tmp/project",');
+  stream.write('"model":{"display_name":"Opus"}}');
+
+  const result = await resultPromise;
+  assert.deepEqual(result, {
+    cwd: '/tmp/project',
+    model: { display_name: 'Opus' },
+  });
+});
+
+test('readStdin returns null when a non-TTY stream never produces data', async () => {
+  const stream = createPipe();
+  const result = await readStdin(stream, { firstByteTimeoutMs: 10, idleTimeoutMs: 5 });
+  assert.equal(result, null);
+});
+
+test('readStdin returns null when partial JSON goes idle', async () => {
+  const stream = createPipe();
+  const resultPromise = readStdin(stream, { firstByteTimeoutMs: 20, idleTimeoutMs: 10 });
+
+  stream.write('{"cwd":"/tmp/project"');
+
+  const result = await resultPromise;
+  assert.equal(result, null);
+});
+
+test('readStdin returns null when stdin payload exceeds the safety limit', async () => {
+  const stream = createPipe();
+  const resultPromise = readStdin(stream, {
+    firstByteTimeoutMs: 20,
+    idleTimeoutMs: 10,
+    maxBytes: 16,
+  });
+
+  stream.write('{"cwd":"/tmp/project"}');
+
+  const result = await resultPromise;
+  assert.equal(result, null);
 });


### PR DESCRIPTION
## Summary
- replace EOF-only stdin reads with a bounded event-driven reader
- return as soon as a complete JSON payload is available, even if stdin stays open
- add focused regression coverage for non-closing stdin, split chunks, idle partial payloads, and oversized input

## Root cause
`readStdin()` was reading stdin with `for await (const chunk of process.stdin)` and only parsing after EOF. In Claude Code `statusLine`, stdin can be a non-TTY pipe that delivers the JSON payload but does not close promptly. That left startup blocked in `main()` before the HUD could render.

## Safety notes
- keeps the existing `TTY => null` behavior unchanged
- falls back to `null` on invalid, idle, errored, or oversized input instead of hard-failing startup
- removes stream listeners and pauses stdin on exit so the process is not kept alive by a lingering pipe

## Testing
- `node --test tests/stdin.test.js`
- `npm test`

Closes #375
