### PR TITLE
fix: keep compact usage windows labeled on wrap

### DIFF
--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -188,9 +188,10 @@ export function renderSessionLine(ctx: RenderContext): string {
               barWidth,
               forceLabel: true,
             });
-            parts.push(`${fiveHourPart} | ${sevenDayPart}`);
+            parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
+            parts.push(sevenDayPart);
           } else {
-            parts.push(fiveHourPart);
+            parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
           }
         }
       }

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -297,7 +297,33 @@ test('render falls back to a safe default width when no terminal size is availab
   });
 
   assert.ok(lines.length > 1, 'should wrap output instead of emitting one oversized line');
-  assert.ok(lines.every(line => displayWidth(line) <= 40), 'all lines should fit the safe fallback width');
+  assert.ok(lines.every(line => displayWidth(line) <= 80), 'all lines should fit the safe fallback width');
+});
+
+test('render does not strand a bare 5h continuation line in compact mode', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'compact';
+  ctx.config.display.usageBarEnabled = false;
+  ctx.config.display.showConfigCounts = false;
+  ctx.stdin.cwd = '/tmp/project';
+  ctx.usageData = {
+    planName: 'Pro',
+    fiveHour: 30,
+    sevenDay: 85,
+    fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+    sevenDayResetAt: new Date(Date.now() + 28 * 60 * 60 * 1000),
+  };
+
+  let lines = [];
+  withColumns(process.stdout, undefined, () => {
+    withColumns(process.stderr, 40, () => {
+      lines = captureRender(ctx);
+    });
+  });
+
+  assert.ok(lines.some(line => line.includes('Usage 5h 30%')), `expected usage window to keep its label: ${lines.join(' | ')}`);
+  assert.ok(lines.some(line => line.includes('Weekly 85%')), `expected weekly usage window to render: ${lines.join(' | ')}`);
+  assert.ok(!lines.some(line => line.startsWith('5h ')), `did not expect a bare 5h continuation line: ${lines.join(' | ')}`);
 });
 
 test('render prefers stdout columns over COLUMNS env fallback', () => {


### PR DESCRIPTION
## Summary
- keep the compact usage label attached to the 5h window instead of nesting `5h | Weekly` inside a single part
- add a regression test for the macOS compact-layout case from #379
- keep the wider safe fallback-width expectation covered in render-width tests

## Root cause
Compact mode was building the dual-window usage section as one nested string (`5h ... | Weekly ...`). The generic line wrapper then treated that nested separator like a top-level split point, which could strand a bare `5h ...` continuation line on narrower macOS renders.

Fixes #379
