### PR TITLE
feat: add MiniMax (China) subscription usage tracking

### DIFF
--- a/commands/configure.md
+++ b/commands/configure.md
@@ -23,10 +23,10 @@ Advanced settings such as `colors.*`, `pathLevels`, `display.usageThreshold`, an
 ## Two Flows Based on Config State
 
 ### Flow A: New User (no config)
-Questions: **Layout → Preset → Language → Turn Off → Turn On → Custom Line**
+Questions: **Layout → Preset → Language → Turn Off → Turn On → MiniMax Usage → Custom Line**
 
 ### Flow B: Update Config (config exists)
-Questions: **Turn Off → Turn On → Git Style → Layout/Reset → Language → Custom Line** (6 questions max)
+Questions: **Turn Off → Turn On → MiniMax Usage → Git Style → Layout/Reset → Language → Custom Line** (7 questions max)
 
 ---
 
@@ -64,7 +64,7 @@ Save as `language: "en"` or `language: "zh"`.
 - header: "Turn Off"
 - question: "Disable any of these? (enabled by your preset)"
 - multiSelect: true
-- options: **ONLY items that are ON in the chosen preset** (max 4)
+- options: **ONLY items that are ON in the chosen preset** (max 6)
   - "Tools activity" - ◐ Edit: file.ts | ✓ Read ×3
   - "Agents status" - ◐ explore [haiku]: Finding code
   - "Todo progress" - ▸ Fix bug (2/5 tasks)
@@ -88,7 +88,20 @@ Save as `language: "en"` or `language: "zh"`.
 **Note:** If preset has all items ON (Full), Q5 shows "Nothing to enable - Full preset has everything!"
 If preset has all items OFF (Minimal), Q4 shows "Nothing to disable - Minimal preset is already minimal!"
 
-### Q6: Custom Line (optional)
+### Q6: MiniMax Usage (optional)
+- header: "MiniMax Usage"
+- question: "Enable MiniMax (China) subscription usage tracking? (Requires MiniMax model)"
+- multiSelect: false
+- options:
+  - "Skip" - Do not enable (Recommended)
+  - "China (minimaxi.com)" - Enable with default API endpoint
+  - "Custom URL" - Enter your own API URL
+
+If user chooses "Skip", do not modify `miniMaxUsageApi`.
+If user chooses "China", save `miniMaxUsageApi: { enabled: true, apiUrl: "https://www.minimaxi.com/v1/api/openplatform/coding_plan/remains" }`.
+If user chooses "Custom URL", use AskUserQuestion to get the URL, then save with the custom URL.
+
+### Q7: Custom Line (optional)
 - header: "Custom Line"
 - question: "Add a custom phrase to display in the HUD? (e.g. a motto, max 80 chars)"
 - multiSelect: false
@@ -100,13 +113,13 @@ If user chooses "Enter custom text", use AskUserQuestion to get their text. Save
 
 ---
 
-## Flow B: Update Config (6 Questions)
+## Flow B: Update Config (7 Questions)
 
 ### Q1: Turn Off
 - header: "Turn Off"
 - question: "What do you want to DISABLE? (currently enabled)"
 - multiSelect: true
-- options: **ONLY items currently ON** (max 4, prioritize Activity first)
+- options: **ONLY items currently ON** (max 6, prioritize Activity first)
   - "Tools activity" - ◐ Edit: file.ts | ✓ Read ×3
   - "Agents status" - ◐ explore [haiku]: Finding code
   - "Todo progress" - ▸ Fix bug (2/5 tasks)
@@ -116,14 +129,14 @@ If user chooses "Enter custom text", use AskUserQuestion to get their text. Save
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
   - "Usage bar style" - ██░░ 25% visual bar (only if usageBarEnabled is true)
 
-If more than 4 items ON, show Activity items (Tools, Agents, Todos, Project, Git) first.
-Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset to Minimal" in Q4.
+If more than 6 items ON, show Activity items (Tools, Agents, Todos, Project, Git) first.
+Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset to Minimal" in Q5.
 
 ### Q2: Turn On
 - header: "Turn On"
 - question: "What do you want to ENABLE? (currently disabled)"
 - multiSelect: true
-- options: **ONLY items currently OFF** (max 4)
+- options: **ONLY items currently OFF** (max 6)
   - "Config counts" - 2 CLAUDE.md | 4 rules
   - "Token breakdown" - (in: 45k, cache: 12k)
   - "Output speed" - out: 42.1 tok/s
@@ -133,7 +146,22 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
   - "Session duration" - ⏱️ 5m
 
-### Q3: Git Style (only if Git is currently enabled)
+### Q3: MiniMax Usage (optional)
+- header: "MiniMax Usage"
+- question: "Enable MiniMax (China) subscription usage tracking? (Requires MiniMax model)"
+- multiSelect: false
+- options:
+  - "Skip" - Do not modify MiniMax settings
+  - "Enable" - Enable with default API endpoint
+  - "Disable" - Turn off MiniMax usage tracking
+  - "Custom URL" - Set a custom API endpoint
+
+If user chooses "Skip", do not modify `miniMaxUsageApi`.
+If user chooses "Enable", save `miniMaxUsageApi: { enabled: true, apiUrl: "https://www.minimaxi.com/v1/api/openplatform/coding_plan/remains" }`.
+If user chooses "Disable", save `miniMaxUsageApi: { enabled: false }`.
+If user chooses "Custom URL", use AskUserQuestion to get the URL, then save with enabled: true and custom URL.
+
+### Q4: Git Style (only if Git is currently enabled)
 - header: "Git Style"
 - question: "How much git info to show?"
 - multiSelect: false
@@ -143,9 +171,9 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
   - "Full details" - git:(main* ↑2 ↓1) includes ahead/behind
   - "File stats" - git:(main* !2 +1 ?3) Starship-compatible format
 
-**Skip Q3 if Git is OFF** - proceed to Q4.
+**Skip Q4 if Git is OFF** - proceed to Q6.
 
-### Q4: Layout/Reset
+### Q5: Layout/Reset
 - header: "Layout/Reset"
 - question: "Change layout or reset to preset?"
 - multiSelect: false
@@ -156,7 +184,7 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
   - "Reset to Full" - Enable everything
   - "Reset to Essential" - Activity + git only
 
-### Q5: Language
+### Q6: Language
 - header: "Language"
 - question: "Update HUD label language? (current: '{English or 中文}')"
 - multiSelect: false
@@ -169,7 +197,7 @@ If user chooses "Keep current", leave `language` unchanged.
 If user chooses "English (Recommended)", save `language: "en"`.
 If user chooses "中文", save `language: "zh"`.
 
-### Q6: Custom Line (optional)
+### Q7: Custom Line (optional)
 - header: "Custom Line"
 - question: "Update your custom phrase? (currently: '{current customLine or none}')"
 - multiSelect: false
@@ -232,6 +260,20 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 
 ---
 
+## MiniMax Usage Mapping
+
+| Option | Config |
+|--------|--------|
+| Skip | No change to `miniMaxUsageApi` |
+| China (minimaxi.com) | `miniMaxUsageApi: { enabled: true, apiUrl: "https://www.minimaxi.com/v1/api/openplatform/coding_plan/remains" }` |
+| Enable | `miniMaxUsageApi: { enabled: true, apiUrl: "https://www.minimaxi.com/v1/api/openplatform/coding_plan/remains" }` |
+| Disable | `miniMaxUsageApi: { enabled: false }` |
+| Custom URL | `miniMaxUsageApi: { enabled: true, apiUrl: "<user-provided URL>" }` |
+
+**Note**: `apiKey` is NOT configured via the guided flow. The HUD falls back to the `ANTHROPIC_AUTH_TOKEN` environment variable automatically.
+
+---
+
 ## Element Mapping
 
 | Element | Config Key |
@@ -275,16 +317,18 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 2. Apply chosen language
 3. Apply Turn Off selections (set those items to OFF)
 4. Apply Turn On selections (set those items to ON)
-5. Apply chosen layout
+5. Apply MiniMax Usage selection (Enable, Disable, Skip, or Custom URL)
+6. Apply chosen layout
 
 ### For Returning Users (Flow B):
 1. Start from current config
 2. Apply Turn Off selections (set to OFF, including usageBarEnabled if selected)
 3. Apply Turn On selections (set to ON, including usageBarEnabled if selected)
-4. Apply Git Style selection (if shown)
-5. If "Reset to [preset]" selected, override with preset values
-6. If layout change selected, apply it
-7. If language change selected, apply it
+4. Apply MiniMax Usage selection (Enable, Disable, or Custom URL)
+5. Apply Git Style selection (if shown)
+6. If "Reset to [preset]" selected, override with preset values
+7. If layout change selected, apply it
+8. If language change selected, apply it
 
 ---
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { getHudPluginDir } from './claude-config-dir.js';
+import { DEFAULT_MINIMAX_API_URL } from './minimax-usage.js';
 import type { Language } from './i18n/types.js';
 
 export type LineLayoutType = 'compact' | 'expanded';
@@ -58,6 +59,12 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
 
 const KNOWN_ELEMENTS = new Set<HudElement>(DEFAULT_ELEMENT_ORDER);
 
+export interface MiniMaxUsageApiConfig {
+  enabled: boolean;
+  apiKey?: string;
+  apiUrl?: string;
+}
+
 export interface HudConfig {
   language: Language;
   lineLayout: LineLayoutType;
@@ -72,6 +79,7 @@ export interface HudConfig {
     pushWarningThreshold: number;
     pushCriticalThreshold: number;
   };
+  miniMaxUsageApi: MiniMaxUsageApiConfig;
   display: {
     showModel: boolean;
     showProject: boolean;
@@ -109,6 +117,10 @@ export const DEFAULT_CONFIG: HudConfig = {
   showSeparators: false,
   pathLevels: 1,
   elementOrder: [...DEFAULT_ELEMENT_ORDER],
+  miniMaxUsageApi: {
+    enabled: false,
+    apiUrl: DEFAULT_MINIMAX_API_URL,
+  },
   gitStatus: {
     enabled: true,
     showDirty: true,
@@ -313,6 +325,18 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     pushCriticalThreshold: validateCountThreshold(migrated.gitStatus?.pushCriticalThreshold),
   };
 
+  const miniMaxUsageApi = {
+    enabled: typeof migrated.miniMaxUsageApi?.enabled === 'boolean'
+      ? migrated.miniMaxUsageApi.enabled
+      : DEFAULT_CONFIG.miniMaxUsageApi.enabled,
+    apiKey: typeof migrated.miniMaxUsageApi?.apiKey === 'string'
+      ? migrated.miniMaxUsageApi.apiKey
+      : DEFAULT_CONFIG.miniMaxUsageApi.apiKey,
+    apiUrl: typeof migrated.miniMaxUsageApi?.apiUrl === 'string'
+      ? migrated.miniMaxUsageApi.apiUrl
+      : DEFAULT_CONFIG.miniMaxUsageApi.apiUrl,
+  };
+
   const display = {
     showModel: typeof migrated.display?.showModel === 'boolean'
       ? migrated.display.showModel
@@ -424,7 +448,7 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
       : DEFAULT_CONFIG.colors.custom,
   };
 
-  return { language, lineLayout, showSeparators, pathLevels, elementOrder, gitStatus, display, colors };
+  return { language, lineLayout, showSeparators, pathLevels, elementOrder, gitStatus, miniMaxUsageApi, display, colors };
 }
 
 export async function loadConfig(): Promise<HudConfig> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { readStdin, getUsageFromStdin } from "./stdin.js";
+import { readStdin, getUsageFromStdin, isMiniMaxModelId } from "./stdin.js";
 import { parseTranscript } from "./transcript.js";
 import { render } from "./render/index.js";
 import { countConfigs } from "./config-reader.js";
@@ -8,6 +8,7 @@ import { parseExtraCmdArg, runExtraCmd } from "./extra-cmd.js";
 import { getClaudeCodeVersion } from "./version.js";
 import { getMemoryUsage } from "./memory.js";
 import { setLanguage, t } from "./i18n/index.js";
+import { fetchMiniMaxUsage } from "./minimax-usage.js";
 import type { RenderContext } from "./types.js";
 import { fileURLToPath } from "node:url";
 import { realpathSync } from "node:fs";
@@ -24,6 +25,7 @@ export type MainDeps = {
   getClaudeCodeVersion: typeof getClaudeCodeVersion;
   getMemoryUsage: typeof getMemoryUsage;
   render: typeof render;
+  fetchMiniMaxUsage: typeof fetchMiniMaxUsage;
   now: () => number;
   log: (...args: unknown[]) => void;
 };
@@ -41,6 +43,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     getClaudeCodeVersion,
     getMemoryUsage,
     render,
+    fetchMiniMaxUsage,
     now: () => Date.now(),
     log: console.log,
     ...overrides,
@@ -73,10 +76,24 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       ? await deps.getGitStatus(stdin.cwd)
       : null;
 
-    // Usage comes only from Claude Code's official stdin rate_limits fields.
+    // Usage comes from Claude Code's stdin rate_limits fields, or MiniMax API if configured.
+    // For MiniMax models, prefer the dedicated MiniMax API over stdin rate_limits since
+    // the stdin rate_limits may not reflect the actual MiniMax subscription usage.
     let usageData: RenderContext["usageData"] = null;
     if (config.display.showUsage !== false) {
-      usageData = deps.getUsageFromStdin(stdin);
+      const isMiniMax = isMiniMaxModelId(stdin.model?.id);
+
+      if (isMiniMax && config.miniMaxUsageApi.enabled) {
+        // MiniMax model with API enabled: use MiniMax API directly (ignore stdin rate_limits)
+        const apiKey = config.miniMaxUsageApi.apiKey ?? process.env.ANTHROPIC_AUTH_TOKEN ?? '';
+        const apiUrl = config.miniMaxUsageApi.apiUrl;
+        if (apiKey) {
+          usageData = await deps.fetchMiniMaxUsage(apiKey, apiUrl);
+        }
+      } else {
+        // Default: use stdin rate_limits
+        usageData = deps.getUsageFromStdin(stdin);
+      }
     }
 
     const extraCmd = deps.parseExtraCmdArg();

--- a/src/minimax-usage.ts
+++ b/src/minimax-usage.ts
@@ -1,0 +1,172 @@
+import type { UsageData } from './types.js';
+
+/**
+ * Default API endpoint for MiniMax (China) subscription usage.
+ * Users can override this via config.miniMaxUsageApi.apiUrl.
+ */
+export const DEFAULT_MINIMAX_API_URL = 'https://www.minimaxi.com/v1/api/openplatform/coding_plan/remains';
+
+/** Default request timeout in milliseconds. */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+interface MiniMaxModelRemain {
+  model_name: string;
+  current_interval_total_count: number;
+  current_interval_usage_count: number;
+  remains_time: number;
+  start_time: number;
+  end_time: number;
+  current_weekly_total_count: number;
+  current_weekly_usage_count: number;
+  weekly_remains_time: number;
+  weekly_start_time: number;
+  weekly_end_time: number;
+}
+
+interface MiniMaxApiResponse {
+  model_remains: MiniMaxModelRemain[];
+  base_resp: MiniMaxApiStatus;
+}
+
+interface MiniMaxApiStatus {
+  status_code: number;
+  status_msg: string;
+}
+
+// Target model patterns to look for (in order of preference)
+const TARGET_MODEL_PATTERNS = [
+  /^minimax-m\s*\*/i,
+  /^minimax-m2/i,
+  /^minimax/i,
+];
+
+// Cache
+let cachedData: UsageData | null = null;
+let cacheTimestamp: number = 0;
+const CACHE_TTL_MS = 60_000; // 60 seconds
+
+/**
+ * Checks if a model name matches MiniMax (China) subscription models.
+ * Matches patterns like "MiniMax-M*", "MiniMax-M2", etc.
+ */
+function matchModel(modelName: string): boolean {
+  const lower = modelName.toLowerCase();
+  return TARGET_MODEL_PATTERNS.some(pattern => pattern.test(lower));
+}
+
+/**
+ * Parses the MiniMax API response into UsageData format.
+ *
+ * Note: The API returns remaining quota (not used), so we compute:
+ *   used = total - remaining
+ *
+ * @param data - The parsed API response
+ * @param nowMs - Current timestamp in milliseconds (for reset time calculation)
+ * @returns UsageData or null if parsing fails or no matching model found
+ */
+function parseApiResponse(data: MiniMaxApiResponse, nowMs: number): UsageData | null {
+  if (data.base_resp.status_code !== 0) {
+    return null;
+  }
+
+  // Find the best matching model
+  const modelEntry = data.model_remains.find(entry => matchModel(entry.model_name));
+  if (!modelEntry) {
+    return null;
+  }
+
+  const { current_interval_total_count, current_interval_usage_count, end_time, remains_time } = modelEntry;
+
+  // Calculate percentage: usage_count is REMAINING, so used = total - remaining
+  let fiveHour: number | null = null;
+  if (current_interval_total_count > 0) {
+    const used = current_interval_total_count - current_interval_usage_count;
+    fiveHour = Math.round((used / current_interval_total_count) * 100);
+    fiveHour = Math.min(100, Math.max(0, fiveHour));
+  }
+
+  // Weekly: usage_count is REMAINING
+  let sevenDay: number | null = null;
+  if (modelEntry.current_weekly_total_count > 0) {
+    const weeklyUsed = modelEntry.current_weekly_total_count - modelEntry.current_weekly_usage_count;
+    sevenDay = Math.round((weeklyUsed / modelEntry.current_weekly_total_count) * 100);
+    sevenDay = Math.min(100, Math.max(0, sevenDay));
+  }
+
+  // Reset time: use end_time if available, otherwise estimate from remains_time
+  let fiveHourResetAt: Date | null = null;
+  if (end_time > 0) {
+    fiveHourResetAt = new Date(end_time);
+  } else if (remains_time > 0) {
+    fiveHourResetAt = new Date(nowMs + remains_time);
+  }
+
+  return {
+    fiveHour,
+    sevenDay,
+    fiveHourResetAt,
+    sevenDayResetAt: null,
+  };
+}
+
+/**
+ * Fetches subscription usage data from the MiniMax (China) API.
+ *
+ * Uses a 60-second cache to avoid excessive API calls. Returns cached
+ * data on network errors to prevent stale UI updates.
+ *
+ * @param apiKey - Bearer token for authentication
+ * @param apiUrl - Optional custom API URL (defaults to DEFAULT_MINIMAX_API_URL)
+ * @param timeoutMs - Request timeout in milliseconds (default: 10000)
+ * @returns UsageData or null if the request fails or no matching model is found
+ */
+export async function fetchMiniMaxUsage(
+  apiKey: string,
+  apiUrl?: string,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<UsageData | null> {
+  const nowMs = Date.now();
+
+  // Return cached data if still valid
+  if (cachedData && (nowMs - cacheTimestamp) < CACHE_TTL_MS) {
+    return cachedData;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    const response = await fetch(apiUrl ?? DEFAULT_MINIMAX_API_URL, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      return cachedData; // Return stale cache on error
+    }
+
+    const data = await response.json() as MiniMaxApiResponse;
+    const parsed = parseApiResponse(data, nowMs);
+
+    if (parsed) {
+      cachedData = parsed;
+      cacheTimestamp = nowMs;
+    }
+
+    return parsed;
+  } catch {
+    return cachedData; // Return stale cache on error
+  }
+}
+
+/** Clears the cached MiniMax usage data. Useful for testing. */
+export function clearMiniMaxCache(): void {
+  cachedData = null;
+  cacheTimestamp = 0;
+}

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -17,7 +17,9 @@ export function renderUsageLine(ctx: RenderContext): string | null {
     return null;
   }
 
-  if (getProviderLabel(ctx.stdin)) {
+  // Only hide usage for Bedrock; MiniMax usage is fetched separately
+  const provider = getProviderLabel(ctx.stdin);
+  if (provider === 'Bedrock') {
     return null;
   }
 

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -142,7 +142,9 @@ export function renderSessionLine(ctx: RenderContext): string {
   }
 
   // Usage limits display (shown when enabled in config, respects usageThreshold)
-  if (display?.showUsage !== false && ctx.usageData && !providerLabel) {
+  // Only hide usage for Bedrock (which uses stdin rate_limits); MiniMax usage is fetched
+  // via API and should always display when available.
+  if (display?.showUsage !== false && ctx.usageData && providerLabel !== 'Bedrock') {
     if (isLimitReached(ctx.usageData)) {
       const resetTime = ctx.usageData.fiveHour === 100
         ? formatResetTime(ctx.usageData.fiveHourResetAt)

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -219,9 +219,20 @@ export function isBedrockModelId(modelId?: string): boolean {
   return normalized.includes('anthropic.claude-');
 }
 
+export function isMiniMaxModelId(modelId?: string): boolean {
+  if (!modelId) {
+    return false;
+  }
+  const normalized = modelId.toLowerCase();
+  return normalized.includes('minimax');
+}
+
 export function getProviderLabel(stdin: StdinData): string | null {
   if (isBedrockModelId(stdin.model?.id)) {
     return 'Bedrock';
+  }
+  if (isMiniMaxModelId(stdin.model?.id)) {
+    return 'MiniMax';
   }
   return null;
 }


### PR DESCRIPTION
Add MiniMax coding plan usage tracking via the /claude-hud:configure guided setup flow.

- Insert MiniMax Usage question in Flow A (Q6) and Flow B (Q3)
- Increase max items per multi-select from 4 to 6
- Fix skip reference after inserting new question
- Add miniMaxUsageApi config field with default API URL

## Summary

  Add MiniMax (China) subscription usage tracking via the `/claude-hud:configure` guided setup flow. When enabled and a MiniMax model is detected, the HUD fetches usage data from the MiniMax API and
  displays it alongside regular Claude usage.

  - Insert MiniMax Usage question in Flow A (Q6 after Turn On) and Flow B (Q3)
  - Increase max items per multi-select from 4 to 6 to reduce prompt grouping
  - Fix skip reference (Q3→Q4) after inserting new question
  - Add `miniMaxUsageApi` config field with default API URL and Bearer token auth

  ## Testing

  - `npm test` — 26 pre-existing `countConfigs` tests fail on Windows (Linux CI passes)
  - `npm run test:coverage` — same Windows-specific failures

  **Note:** The 26 failing tests use `process.env.HOME` for isolation, which does not affect `os.homedir()` on Windows (`USERPROFILE`). This is a pre-existing cross-platform test design issue, not
  related to this change.

  ## Checklist

  - [x] Tests updated or not needed (test failures are pre-existing Windows environment issue)
  - [x] Docs updated (configure.md flow questions updated)
