### PR TITLE
fix: honor COLUMNS override before stream-based width detection

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -30,21 +30,23 @@ function stripAnsi(str: string): string {
 }
 
 function getTerminalWidth(): number {
+  // Respect an explicit COLUMNS override first. This is useful when stdout/stderr
+  // columns are inaccurate (for example some Windows subprocess scenarios).
+  const envColumns = Number.parseInt(process.env.COLUMNS ?? '', 10);
+  if (Number.isFinite(envColumns) && envColumns > 0) {
+    return envColumns;
+  }
+
   const stdoutColumns = process.stdout?.columns;
   if (typeof stdoutColumns === 'number' && Number.isFinite(stdoutColumns) && stdoutColumns > 0) {
     return Math.floor(stdoutColumns);
   }
 
   // When running as a statusline subprocess, stdout is piped but stderr is
-  // still connected to the real terminal — use it to get the actual width.
+  // still connected to the real terminal — use it as fallback.
   const stderrColumns = process.stderr?.columns;
   if (typeof stderrColumns === 'number' && Number.isFinite(stderrColumns) && stderrColumns > 0) {
     return Math.floor(stderrColumns);
-  }
-
-  const envColumns = Number.parseInt(process.env.COLUMNS ?? '', 10);
-  if (Number.isFinite(envColumns) && envColumns > 0) {
-    return envColumns;
   }
 
   return UNKNOWN_TERMINAL_WIDTH;

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -3,10 +3,13 @@ export const UNKNOWN_TERMINAL_WIDTH = 40;
 // Returns a progress bar width scaled to the current terminal width.
 // Wide (>=100): 10, Medium (60-99): 6, Narrow (<60): 4.
 export function getAdaptiveBarWidth(): number {
+  const envCols = Number.parseInt(process.env.COLUMNS ?? '', 10);
   const stdoutCols = process.stdout?.columns;
-  const cols = (typeof stdoutCols === 'number' && Number.isFinite(stdoutCols) && stdoutCols > 0)
-    ? Math.floor(stdoutCols)
-    : Number.parseInt(process.env.COLUMNS ?? '', 10);
+  const cols = (Number.isFinite(envCols) && envCols > 0)
+    ? envCols
+    : (typeof stdoutCols === 'number' && Number.isFinite(stdoutCols) && stdoutCols > 0)
+      ? Math.floor(stdoutCols)
+      : Number.NaN;
 
   if (Number.isFinite(cols) && cols > 0) {
     if (cols >= 100) return 10;

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -190,7 +190,7 @@ test('render falls back to COLUMNS env when stdout.columns is unavailable', () =
   assert.ok(lines.every(line => displayWidth(line) <= 10), 'all lines should fit COLUMNS width');
 });
 
-test('render falls back to stderr.columns when stdout.columns is unavailable', () => {
+test('render uses COLUMNS override before stderr.columns when stdout.columns is unavailable', () => {
   const ctx = baseContext();
   const originalEnvColumns = process.env.COLUMNS;
 
@@ -211,8 +211,7 @@ test('render falls back to stderr.columns when stdout.columns is unavailable', (
   });
 
   assert.ok(lines.length > 0, 'should still render output lines');
-  assert.ok(lines.every(line => displayWidth(line) <= 12), 'stderr width should be honored');
-  assert.ok(lines.some(line => displayWidth(line) > 10), 'stderr width should override COLUMNS fallback');
+  assert.ok(lines.every(line => displayWidth(line) <= 10), 'COLUMNS override should be honored');
 });
 
 test('render ignores OSC 8 hyperlink sequences when measuring line width', () => {
@@ -326,7 +325,7 @@ test('render does not strand a bare 5h continuation line in compact mode', () =>
   assert.ok(!lines.some(line => line.startsWith('5h ')), `did not expect a bare 5h continuation line: ${lines.join(' | ')}`);
 });
 
-test('render prefers stdout columns over COLUMNS env fallback', () => {
+test('render prefers COLUMNS env override over stdout columns', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = '/tmp/very-long-project-name-for-width-checking';
   const originalEnvColumns = process.env.COLUMNS;
@@ -343,8 +342,7 @@ test('render prefers stdout columns over COLUMNS env fallback', () => {
     process.env.COLUMNS = originalEnvColumns;
   }
 
-  assert.ok(lines.every(line => displayWidth(line) <= 30), 'stdout width should be honored');
-  assert.ok(lines.some(line => displayWidth(line) > 10), 'stdout width should override COLUMNS fallback');
+  assert.ok(lines.every(line => displayWidth(line) <= 10), 'COLUMNS override should be honored');
 });
 
 test('render does not split model/provider separator inside brackets', () => {

--- a/tests/terminal.test.js
+++ b/tests/terminal.test.js
@@ -65,6 +65,12 @@ describe('getAdaptiveBarWidth', () => {
     assert.equal(getAdaptiveBarWidth(), 10);
   });
 
+  test('uses COLUMNS env var as explicit override even when stdout.columns is set', () => {
+    Object.defineProperty(process.stdout, 'columns', { value: 120, configurable: true });
+    process.env.COLUMNS = '70';
+    assert.equal(getAdaptiveBarWidth(), 6);
+  });
+
   test('falls back to COLUMNS env var when stdout.columns unavailable', () => {
     Object.defineProperty(process.stdout, 'columns', { value: undefined, configurable: true });
     process.env.COLUMNS = '70';


### PR DESCRIPTION
## Summary
- prioritize COLUMNS as an explicit terminal width override in width detection
- apply the same precedence to adaptive progress-bar width logic
- update width-related tests to cover the override behavior

## Why
In some Windows subprocess contexts, stdout columns can be incorrect. Respecting COLUMNS first lets users enforce the correct width and avoids truncated HUD output.

## Testing
- npm run build
- node --test tests/terminal.test.js tests/render-width.test.js

Closes #385

Greetings, saschabuehrle