### PR TITLE
fix(render): skip line wrapping when terminal width is unreliable

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -15,7 +15,6 @@ import {
   renderSessionTokensLine,
 } from './lines/index.js';
 import { dim, RESET } from './colors.js';
-import { UNKNOWN_TERMINAL_WIDTH } from '../utils/terminal.js';
 
 // eslint-disable-next-line no-control-regex
 const ANSI_ESCAPE_PATTERN = /^(?:\x1b\[[0-9;]*m|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\))/;
@@ -25,11 +24,7 @@ const GRAPHEME_SEGMENTER = typeof Intl.Segmenter === 'function'
   ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
   : null;
 
-function stripAnsi(str: string): string {
-  return str.replace(ANSI_ESCAPE_GLOBAL, '');
-}
-
-function getTerminalWidth(): number {
+function getTerminalWidth(): number | null {
   const stdoutColumns = process.stdout?.columns;
   if (typeof stdoutColumns === 'number' && Number.isFinite(stdoutColumns) && stdoutColumns > 0) {
     return Math.floor(stdoutColumns);
@@ -47,7 +42,10 @@ function getTerminalWidth(): number {
     return envColumns;
   }
 
-  return UNKNOWN_TERMINAL_WIDTH;
+  // No reliable width source available (e.g. piped statusline subprocess).
+  // Return null so callers can skip width-dependent wrapping rather than
+  // using a wrong fallback that causes incorrect line breaks.
+  return null;
 }
 
 function splitAnsiTokens(str: string): Array<{ type: 'ansi' | 'text'; value: string }> {
@@ -143,6 +141,10 @@ function visualLength(str: string): number {
     }
   }
   return width;
+}
+
+function stripAnsi(str: string): string {
+  return str.replace(ANSI_ESCAPE_GLOBAL, '');
 }
 
 function sliceVisible(str: string, maxVisible: number): string {
@@ -397,7 +399,7 @@ function renderExpanded(ctx: RenderContext, terminalWidth: number | null = null)
 
       if (firstLine && secondLine) {
         const combinedLine = `${firstLine} │ ${secondLine}`;
-        const canCombine = !terminalWidth || visualLength(combinedLine) <= terminalWidth;
+        const canCombine = terminalWidth !== null && visualLength(combinedLine) <= terminalWidth;
 
         if (canCombine) {
           lines.push({ line: combinedLine, isActivity: false });
@@ -485,10 +487,15 @@ export function render(ctx: RenderContext): void {
   }
 
   const physicalLines = lines.flatMap(line => line.split('\n'));
-  const visibleLines = physicalLines.flatMap(line => wrapLineToWidth(line, terminalWidth));
+  // Only wrap when we have a reliable terminal width from stdout/stderr/COLUMNS.
+  // When running as a piped statusline subprocess with no width source, let the
+  // parent (Claude Code's Ink layer) handle truncation instead of wrapping at a
+  // wrong fallback value.
+  const visibleLines = terminalWidth
+    ? physicalLines.flatMap(line => wrapLineToWidth(line, terminalWidth))
+    : physicalLines;
 
   for (const line of visibleLines) {
-    const outputLine = `${RESET}${line}`;
-    console.log(outputLine);
+    console.log(`${RESET}${line}`);
   }
 }

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -259,7 +259,7 @@ test('render ignores BEL-terminated OSC 8 hyperlink sequences when measuring lin
   assert.ok(displayWidth(lines[0]) <= 47, 'visible width should respect terminal width');
 });
 
-test('render falls back to a safe default width when no terminal size is available', () => {
+test('render skips wrapping when no reliable terminal size is available', () => {
   const ctx = baseContext();
   ctx.stdin.model = { display_name: 'Sonnet 4.6' };
   ctx.stdin.cwd = '/tmp/very-long-project-name-for-ghostty-fallback-check';
@@ -296,8 +296,10 @@ test('render falls back to a safe default width when no terminal size is availab
     });
   });
 
-  assert.ok(lines.length > 1, 'should wrap output instead of emitting one oversized line');
-  assert.ok(lines.every(line => displayWidth(line) <= 80), 'all lines should fit the safe fallback width');
+  // With no reliable width source, lines should NOT be wrapped/truncated.
+  // The parent process (Claude Code) handles truncation via Ink.
+  assert.ok(lines.length >= 1, 'should still render output');
+  assert.ok(lines.some(line => displayWidth(line) > 40), 'long lines should pass through without truncation at fallback width');
 });
 
 test('render does not strand a bare 5h continuation line in compact mode', () => {


### PR DESCRIPTION
## Summary

- **`getTerminalWidth()` now returns `null`** instead of falling back to `UNKNOWN_TERMINAL_WIDTH` (40) when no reliable width source is available (`stdout.columns`, `stderr.columns`, `COLUMNS` env var all undefined)
- **Wrapping is skipped when width is `null`** — the parent process (Claude Code's Ink layer with `wrap=truncate`) handles truncation instead of the HUD doing it with a wrong value
- **`renderExpanded()` no longer combines Context/Usage lines** when width is unknown, keeping them on separate lines as the safe default

## Problem

When running as a statusline subprocess, stdout and stderr are piped — `process.stdout.columns`, `process.stderr.columns`, and `process.env.COLUMNS` are all `undefined`. The previous code fell back to `UNKNOWN_TERMINAL_WIDTH = 40`, causing `wrapLineToWidth()` to split compact session lines at `|` separators even when the actual terminal was 120+ columns wide.

This is a known Claude Code limitation: [anthropics/claude-code#22115](https://github.com/anthropics/claude-code/issues/22115) — the statusline subprocess has no way to detect terminal width since Claude Code doesn't pass `COLUMNS` to child processes.

### Before (compact mode, 120-col terminal)

```
[Opus 4.6 (1M context)] ████░░░░░░ 4%
Github | keep it simple
▶▶ auto mode on (shift+tab to cycle)
```

The session line wraps at 40 chars, pushing `Github | keep it simple` to a second line.

### After

```
[Opus 4.6 (1M context)] ████░░░░░░ 4% | Github | keep it simple
▶▶ auto mode on (shift+tab to cycle)
```

Single line as intended. Claude Code's Ink layer truncates if it actually exceeds terminal width.

## Approach

Rather than trying to detect width via `tput cols` or other workarounds (which fail on Windows, add subprocess overhead, or return stale values), the fix follows the principle: **if you don't know the width, don't wrap**. The caller (Claude Code) owns the terminal and is the right place to handle truncation.

When a reliable width source IS available (e.g. `stderr.columns` in terminals where stderr is still a TTY, or `COLUMNS` set by the parent), wrapping works exactly as before.

## Changes

| File | Change |
|---|---|
| `src/render/index.ts` | `getTerminalWidth()` returns `null` instead of `UNKNOWN_TERMINAL_WIDTH`; wrap pass conditioned on `terminalWidth !== null`; `canCombine` logic updated to not merge lines when width is unknown |
| `tests/render-width.test.js` | Updated fallback test to verify lines are NOT truncated when width is unavailable |

## Test plan

- [x] `npm run build` compiles cleanly
- [x] All 13 render-width tests pass
- [x] Wrapping still works when `stdout.columns` is set (mocked in tests)
- [x] Wrapping still works when `stderr.columns` is set
- [x] Wrapping still works when `COLUMNS` env var is set
- [x] No wrapping occurs when all width sources are unavailable
- [x] Context/Usage lines stay separate in expanded mode when width is unknown
- [x] Manual verification in Claude Code with compact layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)