### PR TITLE
fix: restore null fallback for unknown terminal width

### DIFF
--- a/dist/render/index.js
+++ b/dist/render/index.js
@@ -154,7 +154,7 @@ function sliceVisible(str, maxVisible) {
     return result;
 }
 function truncateToWidth(str, maxWidth) {
-    if (maxWidth <= 0 || visualLength(str) <= maxWidth) {
+    if (maxWidth == null || maxWidth <= 0 || visualLength(str) <= maxWidth) {
         return str;
     }
     const suffix = maxWidth >= 3 ? '...' : '.'.repeat(maxWidth);
@@ -227,7 +227,7 @@ function splitWrapParts(line) {
     return parts;
 }
 function wrapLineToWidth(line, maxWidth) {
-    if (maxWidth <= 0 || visualLength(line) <= maxWidth) {
+    if (maxWidth == null || maxWidth <= 0 || visualLength(line) <= maxWidth) {
         return [line];
     }
     const parts = splitWrapParts(line);

--- a/dist/utils/terminal.js
+++ b/dist/utils/terminal.js
@@ -1,4 +1,4 @@
-export const UNKNOWN_TERMINAL_WIDTH = 40;
+export const UNKNOWN_TERMINAL_WIDTH = null;
 // Returns a progress bar width scaled to the current terminal width.
 // Wide (>=100): 10, Medium (60-99): 6, Narrow (<60): 4.
 export function getAdaptiveBarWidth() {

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -29,7 +29,7 @@ function stripAnsi(str: string): string {
   return str.replace(ANSI_ESCAPE_GLOBAL, '');
 }
 
-function getTerminalWidth(): number {
+function getTerminalWidth(): number | null {
   const stdoutColumns = process.stdout?.columns;
   if (typeof stdoutColumns === 'number' && Number.isFinite(stdoutColumns) && stdoutColumns > 0) {
     return Math.floor(stdoutColumns);
@@ -189,8 +189,8 @@ function sliceVisible(str: string, maxVisible: number): string {
   return result;
 }
 
-function truncateToWidth(str: string, maxWidth: number): string {
-  if (maxWidth <= 0 || visualLength(str) <= maxWidth) {
+function truncateToWidth(str: string, maxWidth: number | null): string {
+  if (maxWidth == null || maxWidth <= 0 || visualLength(str) <= maxWidth) {
     return str;
   }
 
@@ -274,8 +274,8 @@ function splitWrapParts(line: string): Array<{ separator: string; segment: strin
   return parts;
 }
 
-function wrapLineToWidth(line: string, maxWidth: number): string[] {
-  if (maxWidth <= 0 || visualLength(line) <= maxWidth) {
+function wrapLineToWidth(line: string, maxWidth: number | null): string[] {
+  if (maxWidth == null || maxWidth <= 0 || visualLength(line) <= maxWidth) {
     return [line];
   }
 

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -1,4 +1,4 @@
-export const UNKNOWN_TERMINAL_WIDTH = 40;
+export const UNKNOWN_TERMINAL_WIDTH: number | null = null;
 
 // Returns a progress bar width scaled to the current terminal width.
 // Wide (>=100): 10, Medium (60-99): 6, Narrow (<60): 4.


### PR DESCRIPTION
## Summary

- `UNKNOWN_TERMINAL_WIDTH` was changed from `null` (v0.0.11) to `40` in v0.0.12, causing HUD output to be aggressively wrapped/truncated to 40 columns when running as a statusline subprocess (where `stdout.columns` and `stderr.columns` are unavailable)
- Restore `null` fallback and add `null` guards in `truncateToWidth` and `wrapLineToWidth` so wrapping is skipped when the real terminal width cannot be detected

## Test plan

- [x] Verified HUD renders full-width output after the fix (macOS, Claude Code statusline)
- [ ] Confirm no regression on terminals where width _is_ available (wrapping should still work normally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)