### PR TITLE
fix(transcript): show 'agent' instead of 'unknown' for general-purpose agents

### DIFF
--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -296,7 +296,7 @@ function processEntry(
         const input = block.input as Record<string, unknown>;
         const agentEntry: AgentEntry = {
           id: block.id,
-          type: (input?.subagent_type as string) ?? 'unknown',
+          type: (input?.subagent_type as string) ?? 'agent',
           model: (input?.model as string) ?? undefined,
           description: (input?.description as string) ?? undefined,
           status: 'running',


### PR DESCRIPTION
## Summary

- Changes the fallback agent type label from `'unknown'` to `'agent'` when `subagent_type` is absent in the transcript

## Problem

When the `Agent` tool is invoked without a `subagent_type` (default general-purpose agent), the agents line displays:

```
✓ unknown: Research some topic (4m 22s)
```

The label `unknown` is misleading — the agent ran fine, it just has no named type.

## Fix

One-line change in `src/transcript.ts`:

```diff
- type: (input?.subagent_type as string) ?? 'unknown',
+ type: (input?.subagent_type as string) ?? 'agent',
```

Result:

```
✓ agent: Research some topic (4m 22s)
```

## Testing

- [x] `npm run build` passes with no errors
- [x] Verified locally: general-purpose agents now show `agent` instead of `unknown`

Closes #405