### PR TITLE
feat: make usage reset label configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showUsage` | boolean | true | Show Claude subscriber usage limits when available |
 | `display.usageBarEnabled` | boolean | true | Display usage as visual bar instead of text |
 | `display.timeFormat` | `relative` \| `absolute` \| `both` | `relative` | How reset times are shown in usage windows: countdown only (`resets in 2h 30m`), wall-clock time (`resets at 14:30`), or both (`resets in 2h 30m, at 14:30`) |
+| `display.showResetLabel` | boolean | true | Show the `resets in` prefix before usage countdowns |
+| `display.timeFormat` | `relative` \| `absolute` \| `both` | `relative` | How reset times are shown in usage windows: countdown only (`resets in 2h 30m`), wall-clock time (`resets at 14:30`), or both (`resets in 2h 30m, at 14:30`) |
 | `display.sevenDayThreshold` | 0-100 | 80 | Show 7-day usage when >= threshold (0 = always) |
 | `display.showTokenBreakdown` | boolean | true | Show token details at high context (85%+) |
 | `display.showTools` | boolean | false | Show tools activity line |
@@ -223,6 +225,8 @@ To disable, set `display.showUsage` to `false`.
 Reset times use relative countdowns by default. Set `display.timeFormat` to `absolute` for wall-clock
 times or `both` to show both forms. This setting is manual-only today; `/claude-hud:configure`
 preserves it without editing it.
+
+Set `display.showResetLabel` to `false` if you want shorter usage countdowns such as `(3h 17m)` instead of `(resets in 3h 17m)`.
 
 **Requirements:**
 - Claude Code must include subscriber `rate_limits` data on stdin for the current session

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,6 +86,7 @@ export interface HudConfig {
     showTokenBreakdown: boolean;
     showUsage: boolean;
     usageBarEnabled: boolean;
+    showResetLabel: boolean;
     showTools: boolean;
     showAgents: boolean;
     showTodos: boolean;
@@ -134,6 +135,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showTokenBreakdown: true,
     showUsage: true,
     usageBarEnabled: true,
+    showResetLabel: true,
     showTools: false,
     showAgents: false,
     showTodos: false,
@@ -363,6 +365,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     usageBarEnabled: typeof migrated.display?.usageBarEnabled === 'boolean'
       ? migrated.display.usageBarEnabled
       : DEFAULT_CONFIG.display.usageBarEnabled,
+    showResetLabel: typeof migrated.display?.showResetLabel === 'boolean'
+      ? migrated.display.showResetLabel
+      : DEFAULT_CONFIG.display.showResetLabel,
     showTools: typeof migrated.display?.showTools === 'boolean'
       ? migrated.display.showTools
       : DEFAULT_CONFIG.display.showTools,

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -30,6 +30,7 @@ export function renderUsageLine(
 
   const usageLabel = progressLabel("label.usage", colors, alignLabels);
   const timeFormat: TimeFormatMode = display?.timeFormat ?? 'relative';
+  const showResetLabel = display?.showResetLabel ?? true;
   const resetsKey = timeFormat === 'absolute' ? "format.resets" : "format.resetsIn";
 
   if (isLimitReached(ctx.usageData)) {
@@ -37,7 +38,12 @@ export function renderUsageLine(
       ctx.usageData.fiveHour === 100
         ? formatResetTime(ctx.usageData.fiveHourResetAt, timeFormat)
         : formatResetTime(ctx.usageData.sevenDayResetAt, timeFormat);
-    return `${usageLabel} ${critical(`⚠ ${t("status.limitReached")}${resetTime ? ` (${t(resetsKey)} ${resetTime})` : ""}`, colors)}`;
+    const resetSuffix = resetTime
+      ? showResetLabel
+        ? ` (${t(resetsKey)} ${resetTime})`
+        : ` (${resetTime})`
+      : "";
+    return `${usageLabel} ${critical(`⚠ ${t("status.limitReached")}${resetSuffix}`, colors)}`;
   }
 
   const threshold = display?.usageThreshold ?? 0;
@@ -63,6 +69,7 @@ export function renderUsageLine(
       usageBarEnabled,
       barWidth,
       timeFormat,
+      showResetLabel,
       forceLabel: true,
       alignLabels,
     });
@@ -77,6 +84,7 @@ export function renderUsageLine(
     usageBarEnabled,
     barWidth,
     timeFormat,
+    showResetLabel,
   });
 
   if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
@@ -89,6 +97,7 @@ export function renderUsageLine(
       usageBarEnabled,
       barWidth,
       timeFormat,
+      showResetLabel,
       forceLabel: true,
       alignLabels,
     });
@@ -118,6 +127,7 @@ function formatUsageWindowPart({
   usageBarEnabled,
   barWidth,
   timeFormat = 'relative',
+  showResetLabel,
   forceLabel = false,
   alignLabels = false,
 }: {
@@ -129,6 +139,7 @@ function formatUsageWindowPart({
   usageBarEnabled: boolean;
   barWidth: number;
   timeFormat?: TimeFormatMode;
+  showResetLabel: boolean;
   forceLabel?: boolean;
   alignLabels?: boolean;
 }): string {
@@ -137,17 +148,22 @@ function formatUsageWindowPart({
   const styledLabel = labelKey
     ? progressLabel(labelKey, colors, alignLabels)
     : label(windowLabel, colors);
-  // "resets in X" for relative/both; "resets X" for absolute (avoids "resets in at 14:30")
   const resetsKey = timeFormat === 'absolute' ? "format.resets" : "format.resetsIn";
 
+  const resetSuffix = reset
+    ? showResetLabel
+      ? `(${t(resetsKey)} ${reset})`
+      : `(${reset})`
+    : "";
+
   if (usageBarEnabled) {
-    const body = reset
-      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${t(resetsKey)} ${reset})`
+    const body = resetSuffix
+      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} ${resetSuffix}`
       : `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay}`;
     return forceLabel ? `${styledLabel} ${body}` : body;
   }
 
-  return reset
-    ? `${styledLabel} ${usageDisplay} (${t(resetsKey)} ${reset})`
+  return resetSuffix
+    ? `${styledLabel} ${usageDisplay} ${resetSuffix}`
     : `${styledLabel} ${usageDisplay}`;
 }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -153,10 +153,16 @@ export function renderSessionLine(ctx: RenderContext): string {
   // Usage limits display (shown when enabled in config, respects usageThreshold)
   if (display?.showUsage !== false && ctx.usageData && !providerLabel) {
     if (isLimitReached(ctx.usageData)) {
+      const showResetLabel = display?.showResetLabel ?? true;
       const resetTime = ctx.usageData.fiveHour === 100
         ? formatResetTime(ctx.usageData.fiveHourResetAt, timeFormat)
         : formatResetTime(ctx.usageData.sevenDayResetAt, timeFormat);
-      parts.push(critical(`⚠ ${t('status.limitReached')}${resetTime ? ` (${t(resetsKey)} ${resetTime})` : ''}`, colors));
+      const resetSuffix = resetTime
+        ? showResetLabel
+          ? ` (${t(resetsKey)} ${resetTime})`
+          : ` (${resetTime})`
+        : '';
+      parts.push(critical(`⚠ ${t('status.limitReached')}${resetSuffix}`, colors));
     } else {
       const usageThreshold = display?.usageThreshold ?? 0;
       const fiveHour = ctx.usageData.fiveHour;
@@ -165,6 +171,7 @@ export function renderSessionLine(ctx: RenderContext): string {
 
       if (effectiveUsage >= usageThreshold) {
         const usageBarEnabled = display?.usageBarEnabled ?? true;
+        const showResetLabel = display?.showResetLabel ?? true;
         if (fiveHour === null && sevenDay !== null) {
           const weeklyOnlyPart = formatUsageWindowPart({
             label: t('label.weekly'),
@@ -174,6 +181,7 @@ export function renderSessionLine(ctx: RenderContext): string {
             usageBarEnabled,
             barWidth,
             timeFormat,
+            showResetLabel,
             forceLabel: true,
           });
           parts.push(weeklyOnlyPart);
@@ -186,6 +194,7 @@ export function renderSessionLine(ctx: RenderContext): string {
             usageBarEnabled,
             barWidth,
             timeFormat,
+            showResetLabel,
           });
 
           const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
@@ -198,6 +207,7 @@ export function renderSessionLine(ctx: RenderContext): string {
               usageBarEnabled,
               barWidth,
               timeFormat,
+              showResetLabel,
               forceLabel: true,
             });
             parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
@@ -311,6 +321,7 @@ function formatUsageWindowPart({
   usageBarEnabled,
   barWidth,
   timeFormat = 'relative',
+  showResetLabel,
   forceLabel = false,
 }: {
   label: string;
@@ -320,6 +331,7 @@ function formatUsageWindowPart({
   usageBarEnabled: boolean;
   barWidth: number;
   timeFormat?: TimeFormatMode;
+  showResetLabel: boolean;
   forceLabel?: boolean;
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors);
@@ -333,14 +345,20 @@ function formatUsageWindowPart({
     // Absolute/both modes use the preposition form instead — "(at 14:30 / 5h)" is incoherent.
     const barReset = timeFormat === 'relative'
       ? (reset ? `${reset} / ${windowLabel}` : null)
-      : (reset ? `${t(resetsKey)} ${reset}` : null);
+      : (reset ? (showResetLabel ? `${t(resetsKey)} ${reset}` : reset) : null);
     const body = barReset
       ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${barReset})`
       : `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay}`;
     return forceLabel ? `${styledLabel} ${body}` : body;
   }
 
-  return reset
-    ? `${styledLabel} ${usageDisplay} (${t(resetsKey)} ${reset})`
+  const resetSuffix = reset
+    ? showResetLabel
+      ? `(${t(resetsKey)} ${reset})`
+      : `(${reset})`
+    : '';
+
+  return resetSuffix
+    ? `${styledLabel} ${usageDisplay} ${resetSuffix}`
     : `${styledLabel} ${usageDisplay}`;
 }

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -50,7 +50,7 @@ function baseContext() {
       pathLevels: 1,
       elementOrder: ['project', 'context', 'usage', 'memory', 'environment', 'tools', 'agents', 'todos'],
       gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, pushWarningThreshold: 0, pushCriticalThreshold: 0 },
-      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showOutputStyle: false, autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
+      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showResetLabel: true, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showOutputStyle: false, autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
       colors: {
         context: 'green',
         usage: 'brightBlue',
@@ -1245,6 +1245,25 @@ test('renderUsageLine shows 7d reset countdown in text-only mode', () => {
   assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in text-only mode: ${line}`);
 });
 
+test('renderUsageLine can hide reset label in text-only mode', () => {
+  const ctx = baseContext();
+  const resetTime = new Date(Date.now() + (28 * 60 * 60 * 1000));
+  ctx.config.display.usageBarEnabled = false;
+  ctx.config.display.showResetLabel = false;
+  ctx.config.display.sevenDayThreshold = 80;
+  ctx.usageData = {
+    planName: 'Pro',
+    fiveHour: 45,
+    sevenDay: 85,
+    fiveHourResetAt: null,
+    sevenDayResetAt: resetTime,
+  };
+
+  const line = stripAnsi(renderUsageLine(ctx));
+  assert.ok(line.includes('(1d 4h)'), `should include bare countdown when reset label is hidden: ${line}`);
+  assert.ok(!line.includes('resets in'), `should omit reset label when disabled: ${line}`);
+});
+
 test('renderUsageLine translates weekly label when Chinese is enabled', () => {
   const ctx = baseContext();
   ctx.config.display.sevenDayThreshold = 80;
@@ -1284,6 +1303,25 @@ test('renderUsageLine shows 7d reset countdown in bar mode when above threshold'
   assert.ok(line.includes('85%'), `should include 7d percentage: ${line}`);
   assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in bar mode: ${line}`);
   assert.ok(line.includes('|'), `should render both usage windows above the threshold: ${line}`);
+});
+
+test('renderUsageLine can hide reset label in bar mode', () => {
+  const ctx = baseContext();
+  const resetTime = new Date(Date.now() + (28 * 60 * 60 * 1000));
+  ctx.config.display.usageBarEnabled = true;
+  ctx.config.display.showResetLabel = false;
+  ctx.config.display.sevenDayThreshold = 80;
+  ctx.usageData = {
+    planName: 'Pro',
+    fiveHour: 45,
+    sevenDay: 85,
+    fiveHourResetAt: null,
+    sevenDayResetAt: resetTime,
+  };
+
+  const line = stripAnsi(renderUsageLine(ctx));
+  assert.ok(line.includes('(1d 4h)'), `should include bare countdown in bar mode: ${line}`);
+  assert.ok(!line.includes('resets in'), `should omit reset label in bar mode when disabled: ${line}`);
 });
 
 test('renderUsageLine shows weekly-only usage without a ghost 5h section', () => {


### PR DESCRIPTION
## Summary

Adds a `display.showResetLabel` config option so users can hide the `resets in` prefix from usage countdowns.

Examples:

- Before: `Usage 5h 19% (resets in 3h 17m)`
- After: `Usage 5h 19% (3h 17m)`

This applies to both:
- expanded usage rendering
- compact/session-line rendering

## Why

The reset prefix is a bit redundant, and removing it shortens the HUD line, which helps reduce clutter and wrapping risk.

## Changes

- add `display.showResetLabel` to config, default `true`
- respect it in `src/render/lines/usage.ts`
- respect it in `src/render/session-line.ts`
- document it in `README.md`
- add tests for text and bar modes

## Testing

- [x] `npm test`
- [x] verified real plugin output locally before/after using stdin-driven render

Closes #411
