### PR TITLE
render -- instead of 0% before context is initialized

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ Lines 1-2 always shown. Additional lines are opt-in via config:
 
 | Threshold | Color | Action |
 |-----------|-------|--------|
+| uninitialized | — | Show `--` (no API call yet) |
 | <70% | Green | Normal |
 | 70-85% | Yellow | Warning |
 | >85% | Red | Show token breakdown |

--- a/src/render/lines/identity.ts
+++ b/src/render/lines/identity.ts
@@ -3,6 +3,7 @@ import {
   getContextPercent,
   getBufferedPercent,
   getTotalTokens,
+  isContextInitialized,
 } from "../../stdin.js";
 import { coloredBar, label, getContextColor, RESET } from "../colors.js";
 import { getAdaptiveBarWidth } from "../../utils/terminal.js";
@@ -12,11 +13,21 @@ const DEBUG =
   process.env.DEBUG?.includes("claude-hud") || process.env.DEBUG === "*";
 
 export function renderIdentityLine(ctx: RenderContext): string {
+  const colors = ctx.config?.colors;
+  const display = ctx.config?.display;
+
+  // Before the first API call, Claude Code reports null usage and 0%.
+  // Show "--" to signal "not yet measured" rather than a misleading 0%.
+  if (!isContextInitialized(ctx.stdin)) {
+    return display?.showContextBar !== false
+      ? `${label(t("label.context"), colors)} ${coloredBar(0, getAdaptiveBarWidth(), colors)} --`
+      : `${label(t("label.context"), colors)} --`;
+  }
+
   const rawPercent = getContextPercent(ctx.stdin);
   const bufferedPercent = getBufferedPercent(ctx.stdin);
   const autocompactMode = ctx.config?.display?.autocompactBuffer ?? "enabled";
   const percent = autocompactMode === "disabled" ? rawPercent : bufferedPercent;
-  const colors = ctx.config?.colors;
 
   if (DEBUG && autocompactMode === "disabled") {
     console.error(
@@ -24,7 +35,6 @@ export function renderIdentityLine(ctx: RenderContext): string {
     );
   }
 
-  const display = ctx.config?.display;
   const contextValueMode = display?.contextValue ?? "percent";
   const contextValue = formatContextValue(ctx, percent, contextValueMode);
   const contextValueDisplay = `${getContextColor(percent, colors)}${contextValue}${RESET}`;

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -152,6 +152,28 @@ function getNativePercent(stdin: StdinData): number | null {
   return null;
 }
 
+/**
+ * Returns true once Claude Code has reported real context usage data.
+ * Before the first API call in a session, current_usage is null and
+ * used_percentage is 0 — showing 0% is misleading because the context
+ * window already has overhead (system prompt, tools, memory files, etc.).
+ */
+export function isContextInitialized(stdin: StdinData): boolean {
+  const cw = stdin.context_window;
+  if (!cw) {
+    return false;
+  }
+  // used_percentage is a non-zero number → real data from Claude Code
+  if (typeof cw.used_percentage === 'number' && cw.used_percentage > 0) {
+    return true;
+  }
+  // current_usage is non-null → at least one API call has completed
+  if (cw.current_usage !== null && cw.current_usage !== undefined) {
+    return true;
+  }
+  return false;
+}
+
 export function getContextPercent(stdin: StdinData): number {
   // Prefer native percentage (v2.1.6+) - accurate and matches /context
   const native = getNativePercent(stdin);

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1843,6 +1843,29 @@ test('renderSessionTokensLine renders cumulative session token totals', () => {
   assert.equal(line, 'Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)');
 });
 
+test('renderIdentityLine shows -- on cold start (current_usage null, no used_percentage)', () => {
+  const ctx = baseContext();
+  ctx.stdin.context_window = { context_window_size: 200000, current_usage: null };
+  const line = stripAnsi(renderIdentityLine(ctx));
+  assert.ok(line.includes('--'), `expected "--" in cold-start output, got: ${line}`);
+  assert.ok(!line.includes('0%'), `expected no "0%" in cold-start output, got: ${line}`);
+});
+
+test('renderIdentityLine shows -- when used_percentage is 0 and current_usage is null', () => {
+  const ctx = baseContext();
+  ctx.stdin.context_window = { context_window_size: 200000, current_usage: null, used_percentage: 0 };
+  const line = stripAnsi(renderIdentityLine(ctx));
+  assert.ok(line.includes('--'), `expected "--" in cold-start output, got: ${line}`);
+  assert.ok(!line.includes('0%'), `expected no "0%" in cold-start output, got: ${line}`);
+});
+
+test('renderIdentityLine shows percentage once context is initialized', () => {
+  const ctx = baseContext();
+  const line = stripAnsi(renderIdentityLine(ctx));
+  assert.ok(!line.includes('--'), `expected no "--" after initialization, got: ${line}`);
+  assert.ok(line.includes('%'), `expected "%" in initialized output, got: ${line}`);
+});
+
 test('renderSessionLine includes compact session token summary when enabled', () => {
   const ctx = baseContext();
   ctx.config.display.showSessionTokens = true;

--- a/tests/stdin.test.js
+++ b/tests/stdin.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { PassThrough } from 'node:stream';
-import { readStdin } from '../dist/stdin.js';
+import { readStdin, isContextInitialized } from '../dist/stdin.js';
 
 test('readStdin returns null for TTY input', async () => {
   const originalIsTTY = process.stdin.isTTY;
@@ -93,4 +93,36 @@ test('readStdin returns null when stdin payload exceeds the safety limit', async
 
   const result = await resultPromise;
   assert.equal(result, null);
+});
+
+// isContextInitialized tests
+test('isContextInitialized returns false when context_window is absent', () => {
+  assert.equal(isContextInitialized({}), false);
+});
+
+test('isContextInitialized returns false on cold start (current_usage null, no used_percentage)', () => {
+  assert.equal(isContextInitialized({
+    context_window: { context_window_size: 200000, current_usage: null },
+  }), false);
+});
+
+test('isContextInitialized returns false when used_percentage is 0 and current_usage is null', () => {
+  assert.equal(isContextInitialized({
+    context_window: { context_window_size: 200000, current_usage: null, used_percentage: 0 },
+  }), false);
+});
+
+test('isContextInitialized returns true when used_percentage is non-zero', () => {
+  assert.equal(isContextInitialized({
+    context_window: { context_window_size: 200000, current_usage: null, used_percentage: 5 },
+  }), true);
+});
+
+test('isContextInitialized returns true when current_usage is non-null', () => {
+  assert.equal(isContextInitialized({
+    context_window: {
+      context_window_size: 200000,
+      current_usage: { input_tokens: 10000, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+    },
+  }), true);
 });


### PR DESCRIPTION
## Summary

- Before the first API call, Claude Code reports `null` usage — showing `0%` is misleading since the context window already has overhead (system prompt, tools, memory files, etc.)
- Adds `isContextInitialized()` to detect uninitialized state
- Renders `--` instead of `0%` until real data arrives

Fixes #417

## Test plan

- [ ] Start a new session and verify the context bar shows `--` before the first response
- [ ] Confirm it switches to a real percentage after the first API call
- [ ] Run existing tests: `npm test`