### PR TITLE
feat(config): add maxWidth fallback for terminal width detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ After choosing a preset, you can turn individual elements on or off.
 ### Manual Configuration
 
 Edit `~/.claude/plugins/claude-hud/config.json` directly for advanced settings such as `colors.*`,
-`pathLevels`, threshold overrides, and `display.timeFormat`. Running `/claude-hud:configure`
+`pathLevels`, `maxWidth`, threshold overrides, and `display.timeFormat`. Running `/claude-hud:configure`
 preserves those manual settings while still letting you change `language`, layout, and the common
 guided toggles.
 
@@ -159,6 +159,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `language` | `en` \| `zh` | `en` | HUD label language. English is the default; set `zh` to enable Chinese labels. |
 | `lineLayout` | string | `expanded` | Layout: `expanded` (multi-line) or `compact` (single line) |
 | `pathLevels` | 1-3 | 1 | Directory levels to show in project path |
+| `maxWidth` | number \| `null` | `null` | Optional fallback width used only when terminal width detection fails completely |
 | `elementOrder` | string[] | `["project","context","usage","memory","environment","tools","agents","todos"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. |
 | `gitStatus.enabled` | boolean | true | Show git branch in HUD |
 | `gitStatus.showDirty` | boolean | true | Show `*` for uncommitted changes |
@@ -294,7 +295,7 @@ preserves it without editing it.
 
 **Config not applying?**
 - Check for JSON syntax errors: invalid JSON silently falls back to defaults
-- Ensure valid values: `pathLevels` must be 1, 2, or 3; `lineLayout` must be `expanded` or `compact`
+- Ensure valid values: `pathLevels` must be 1, 2, or 3; `lineLayout` must be `expanded` or `compact`; `maxWidth` must be a positive number
 - Delete config and run `/claude-hud:configure` to regenerate
 
 **Git status missing?**

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,6 +64,7 @@ export interface HudConfig {
   lineLayout: LineLayoutType;
   showSeparators: boolean;
   pathLevels: 1 | 2 | 3;
+  maxWidth: number | null;
   elementOrder: HudElement[];
   gitStatus: {
     enabled: boolean;
@@ -111,6 +112,7 @@ export const DEFAULT_CONFIG: HudConfig = {
   lineLayout: 'expanded',
   showSeparators: false,
   pathLevels: 1,
+  maxWidth: null,
   elementOrder: [...DEFAULT_ELEMENT_ORDER],
   gitStatus: {
     enabled: true,
@@ -303,6 +305,11 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     ? migrated.pathLevels
     : DEFAULT_CONFIG.pathLevels;
 
+  const rawMaxWidth = (migrated as Record<string, unknown>).maxWidth;
+  const maxWidth = (typeof rawMaxWidth === 'number' && Number.isFinite(rawMaxWidth) && rawMaxWidth > 0)
+    ? Math.floor(rawMaxWidth)
+    : null;
+
   const elementOrder = validateElementOrder(migrated.elementOrder);
 
   const gitStatus = {
@@ -439,7 +446,7 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
       : DEFAULT_CONFIG.colors.custom,
   };
 
-  return { language, lineLayout, showSeparators, pathLevels, elementOrder, gitStatus, display, colors };
+  return { language, lineLayout, showSeparators, pathLevels, maxWidth, elementOrder, gitStatus, display, colors };
 }
 
 export async function loadConfig(): Promise<HudConfig> {

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -430,8 +430,13 @@ function renderExpanded(ctx: RenderContext, terminalWidth: number | null = null)
 export function render(ctx: RenderContext): void {
   const lineLayout = ctx.config?.lineLayout ?? 'expanded';
   const showSeparators = ctx.config?.showSeparators ?? false;
-  const terminalWidth = getTerminalWidth({ preferEnv: true, fallback: UNKNOWN_TERMINAL_WIDTH })
-    ?? UNKNOWN_TERMINAL_WIDTH;
+  const detectedWidth =
+    getTerminalWidth({ preferEnv: true, fallback: UNKNOWN_TERMINAL_WIDTH }) ??
+    UNKNOWN_TERMINAL_WIDTH;
+  const terminalWidth =
+    detectedWidth === UNKNOWN_TERMINAL_WIDTH && ctx.config?.maxWidth
+      ? ctx.config.maxWidth
+      : detectedWidth;
 
   let lines: string[];
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -32,6 +32,7 @@ test('loadConfig returns valid config structure', async () => {
 
   // showSeparators must be boolean
   assert.equal(typeof config.showSeparators, 'boolean', 'showSeparators should be boolean');
+  assert.ok(config.maxWidth === null || (typeof config.maxWidth === 'number' && config.maxWidth > 0), 'maxWidth should be null or a positive number');
   assert.ok(Array.isArray(config.elementOrder), 'elementOrder should be an array');
   assert.ok(config.elementOrder.length > 0, 'elementOrder should not be empty');
   assert.deepEqual(config.elementOrder, DEFAULT_ELEMENT_ORDER, 'elementOrder should default to the full expanded layout');
@@ -193,6 +194,26 @@ test('mergeConfig falls back to empty for non-string modelOverride', () => {
   assert.equal(mergeConfig({ display: { modelOverride: 123 } }).display.modelOverride, '');
   assert.equal(mergeConfig({ display: { modelOverride: null } }).display.modelOverride, '');
   assert.equal(mergeConfig({ display: { modelOverride: true } }).display.modelOverride, '');
+});
+
+test('mergeConfig defaults maxWidth to null', () => {
+  const config = mergeConfig({});
+  assert.equal(config.maxWidth, null);
+});
+
+test('mergeConfig preserves valid maxWidth', () => {
+  assert.equal(mergeConfig({ maxWidth: 50 }).maxWidth, 50);
+  assert.equal(mergeConfig({ maxWidth: 80 }).maxWidth, 80);
+  assert.equal(mergeConfig({ maxWidth: 30.7 }).maxWidth, 30);
+});
+
+test('mergeConfig rejects invalid maxWidth', () => {
+  assert.equal(mergeConfig({ maxWidth: 0 }).maxWidth, null);
+  assert.equal(mergeConfig({ maxWidth: -10 }).maxWidth, null);
+  assert.equal(mergeConfig({ maxWidth: NaN }).maxWidth, null);
+  assert.equal(mergeConfig({ maxWidth: 'wide' }).maxWidth, null);
+  assert.equal(mergeConfig({ maxWidth: null }).maxWidth, null);
+  assert.equal(mergeConfig({ maxWidth: Infinity }).maxWidth, null);
 });
 
 test('getConfigPath respects CLAUDE_CONFIG_DIR', async () => {

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -302,6 +302,60 @@ test('render does not wrap when no real terminal width is available', () => {
   assert.ok(lines.length >= 1, 'should still produce output');
 });
 
+test('render uses config.maxWidth as fallback when terminal width is unavailable', () => {
+  const ctx = baseContext();
+  ctx.stdin.model = { display_name: 'Sonnet 4.6' };
+  ctx.stdin.cwd = '/tmp/very-long-project-name-for-maxwidth-fallback';
+  ctx.config.maxWidth = 30;
+  ctx.usageData = {
+    fiveHour: 42,
+    sevenDay: null,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+  };
+
+  // When no terminal size is available, maxWidth should be used as fallback
+  const originalEnvColumns = process.env.COLUMNS;
+  let lines = [];
+  withColumns(process.stdout, undefined, () => {
+    withColumns(process.stderr, undefined, () => {
+      delete process.env.COLUMNS;
+      try {
+        lines = captureRender(ctx);
+      } finally {
+        if (originalEnvColumns === undefined) {
+          delete process.env.COLUMNS;
+        } else {
+          process.env.COLUMNS = originalEnvColumns;
+        }
+      }
+    });
+  });
+
+  assert.ok(lines.length > 0, 'should produce output');
+  assert.ok(lines.every(line => displayWidth(line) <= 30), 'all lines should fit within maxWidth');
+});
+
+test('render ignores config.maxWidth when terminal width is detected', () => {
+  const ctx = baseContext();
+  ctx.stdin.model = { display_name: 'Sonnet 4.6' };
+  ctx.stdin.cwd = '/tmp/project';
+  ctx.config.maxWidth = 30;
+
+  // When terminal reports a real width, maxWidth should NOT cap it
+  let lines = [];
+  withTerminal(120, () => {
+    lines = captureRender(ctx);
+  });
+
+  // Lines should use the detected 120 columns, not the 30 maxWidth
+  assert.ok(lines.length > 0, 'should produce output');
+  assert.ok(lines.every(line => displayWidth(line) <= 120), 'lines should fit detected width');
+  // Compact session line is typically wider than 30 when model+context are shown
+  const widest = Math.max(...lines.map(displayWidth));
+  assert.ok(widest > 30, 'should use detected terminal width, not maxWidth');
+});
+
 test('render does not strand a bare 5h continuation line in compact mode', () => {
   const ctx = baseContext();
   ctx.config.lineLayout = 'compact';


### PR DESCRIPTION
## Summary

Adds a `maxWidth` config option (`number | null`, default `null`) that replaces the hardcoded `UNKNOWN_TERMINAL_WIDTH` fallback when terminal width detection fails.

- When the terminal reports a real width (via `stdout.columns`, `stderr.columns`, or `COLUMNS` env), that width is used — `maxWidth` is **ignored**
- Only when all detection fails and the code falls back to `UNKNOWN_TERMINAL_WIDTH` (40), `maxWidth` is used instead
- When `maxWidth` is not set, the existing 40-column fallback is preserved

```json
{
  "maxWidth": 50
}
```

### Motivation

Several users have reported terminal width issues:

- **#385**: Windows Terminal detects ~50% of actual width, needs a way to tune the fallback
- **#404**: When stdout/stderr columns are unavailable (piped subprocesses, mobile clients), the 40-column fallback is too narrow

The hardcoded `UNKNOWN_TERMINAL_WIDTH = 40` is a reasonable default but not ideal for all devices. `maxWidth` lets users tune it without affecting environments where auto-detection works correctly.

### Priority logic

```
Terminal width detected (e.g. 120)  →  use 120, maxWidth ignored
Detection fails + maxWidth set      →  use maxWidth
Detection fails + no maxWidth       →  use UNKNOWN_TERMINAL_WIDTH (40)
```

### Changes

| File | Change |
|------|--------|
| `src/config.ts` | Add `maxWidth: number \| null` to `HudConfig`, validation in `mergeConfig()` |
| `src/render/index.ts` | Use `maxWidth` as fallback only when `getTerminalWidth()` returns `UNKNOWN_TERMINAL_WIDTH` |
| `tests/config.test.js` | Validation: default null, valid values, invalid values (0, negative, NaN, Infinity, string) |
| `tests/render-width.test.js` | Two render tests: maxWidth used as fallback when detection fails; maxWidth ignored when terminal width is detected |

## Testing

- [x] `npm test` — all tests pass (1 pre-existing flaky failure in `core.test.js` unrelated to this change)
- [x] `npm run build` — compiles cleanly

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed — user-facing config option is self-documenting; README update can follow separately

Closes #385, closes #404