### PR TITLE
feat(config): add usageCompact option for shorter usage display

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showSpeed` | boolean | false | Show output token speed `out: 42.1 tok/s` |
 | `display.showUsage` | boolean | true | Show Claude subscriber usage limits when available |
 | `display.usageBarEnabled` | boolean | true | Display usage as visual bar instead of text |
-| `display.timeFormat` | `relative` \| `absolute` \| `both` | `relative` | How reset times are shown in usage windows: countdown only (`resets in 2h 30m`), wall-clock time (`resets at 14:30`), or both (`resets in 2h 30m, at 14:30`) |
+| `display.usageCompact` | boolean | false | Display usage in a shorter text form such as `5h: 25% (1h 30m)`; takes precedence over `display.usageBarEnabled` |
 | `display.showResetLabel` | boolean | true | Show the `resets in` prefix before usage countdowns |
 | `display.timeFormat` | `relative` \| `absolute` \| `both` | `relative` | How reset times are shown in usage windows: countdown only (`resets in 2h 30m`), wall-clock time (`resets at 14:30`), or both (`resets in 2h 30m, at 14:30`) |
 | `display.sevenDayThreshold` | 0-100 | 80 | Show 7-day usage when >= threshold (0 = always) |
@@ -227,6 +227,8 @@ times or `both` to show both forms. This setting is manual-only today; `/claude-
 preserves it without editing it.
 
 Set `display.showResetLabel` to `false` if you want shorter usage countdowns such as `(3h 17m)` instead of `(resets in 3h 17m)`.
+
+Set `display.usageCompact` to `true` if you want the shorter usage-only form, for example `5h: 25% (1h 30m)`. Compact usage takes precedence over `display.usageBarEnabled`.
 
 **Requirements:**
 - Claude Code must include subscriber `rate_limits` data on stdin for the current session

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -75,6 +75,7 @@ Save as `language: "en"` or `language: "zh"`.
   - "Token breakdown" - (in: 45k, cache: 12k)
   - "Output speed" - out: 42.1 tok/s
   - "Usage limits" - 5h: 25% | 7d: 10%
+  - "Compact usage" - 5h: 25% (1h 30m) shorter format
   - "Session duration" - ⏱️ 5m
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
@@ -116,6 +117,7 @@ If user chooses "Enter custom text", use AskUserQuestion to get their text. Save
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
   - "Usage bar style" - ██░░ 25% visual bar (only if usageBarEnabled is true)
+  - "Compact usage" - 5h: 25% (1h 30m) shorter format (only if usageCompact is false)
 
 If more than 4 items ON, show Activity items (Tools, Agents, Todos, Project, Git) first.
 Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset to Minimal" in Q4.
@@ -130,6 +132,7 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
   - "Output speed" - out: 42.1 tok/s
   - "Usage limits" - 5h: 25% | 7d: 10%
   - "Usage bar style" - ██░░ 25% visual bar (only if usageBarEnabled is false)
+  - "Compact usage" - 5h: 25% (1h 30m) shorter format (only if usageCompact is false)
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
   - "Session duration" - ⏱️ 5m
@@ -247,6 +250,7 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 | Output speed | `display.showSpeed` |
 | Usage limits | `display.showUsage` |
 | Usage bar style | `display.usageBarEnabled` |
+| Compact usage | `display.usageCompact` |
 | Session name | `display.showSessionName` |
 | Session duration | `display.showDuration` |
 | Session tokens | `display.showSessionTokens` |
@@ -260,10 +264,13 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 
 ## Usage Style Mapping
 
-| Option | Config |
-|--------|--------|
-| Bar style | `display.usageBarEnabled: true` — Shows `██░░ 25% (1h 30m / 5h)` |
-| Text style | `display.usageBarEnabled: false` — Shows `5h: 25% (1h 30m)` |
+| Option | Config | Example |
+|--------|--------|---------|
+| Bar style | `usageBarEnabled: true` | `Usage ██░░ 25% (resets in 1h 30m)` |
+| Text style | `usageBarEnabled: false` | `Usage 5h 25% (resets in 1h 30m)` |
+| Compact | `usageCompact: true` | `5h: 25% (1h 30m)` — no "Usage" label, shorter reset format |
+
+`usageCompact` takes precedence over `usageBarEnabled` when both are set. Compact mode always uses the text format (no bar).
 
 **Note**: Usage style only applies when `display.showUsage: true`. When 7d usage >= 80%, it also shows with the same style.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,6 +87,7 @@ export interface HudConfig {
     showUsage: boolean;
     usageBarEnabled: boolean;
     showResetLabel: boolean;
+    usageCompact: boolean;
     showTools: boolean;
     showAgents: boolean;
     showTodos: boolean;
@@ -136,6 +137,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showUsage: true,
     usageBarEnabled: true,
     showResetLabel: true,
+    usageCompact: false,
     showTools: false,
     showAgents: false,
     showTodos: false,
@@ -368,6 +370,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showResetLabel: typeof migrated.display?.showResetLabel === 'boolean'
       ? migrated.display.showResetLabel
       : DEFAULT_CONFIG.display.showResetLabel,
+    usageCompact: typeof migrated.display?.usageCompact === 'boolean'
+      ? migrated.display.usageCompact
+      : DEFAULT_CONFIG.display.usageCompact,
     showTools: typeof migrated.display?.showTools === 'boolean'
       ? migrated.display.showTools
       : DEFAULT_CONFIG.display.showTools,

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -33,7 +33,6 @@ export function renderUsageLine(
   const showResetLabel = display?.showResetLabel ?? true;
   const resetsKey = timeFormat === 'absolute' ? "format.resets" : "format.resetsIn";
   const usageCompact = display?.usageCompact ?? false;
-  const usageLabel = progressLabel("label.usage", colors, alignLabels);
 
   if (isLimitReached(ctx.usageData)) {
     const resetTime =

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -32,12 +32,17 @@ export function renderUsageLine(
   const timeFormat: TimeFormatMode = display?.timeFormat ?? 'relative';
   const showResetLabel = display?.showResetLabel ?? true;
   const resetsKey = timeFormat === 'absolute' ? "format.resets" : "format.resetsIn";
+  const usageCompact = display?.usageCompact ?? false;
+  const usageLabel = progressLabel("label.usage", colors, alignLabels);
 
   if (isLimitReached(ctx.usageData)) {
     const resetTime =
       ctx.usageData.fiveHour === 100
         ? formatResetTime(ctx.usageData.fiveHourResetAt, timeFormat)
         : formatResetTime(ctx.usageData.sevenDayResetAt, timeFormat);
+    if (usageCompact) {
+      return critical(`⚠ Limit${resetTime ? ` (${resetTime})` : ""}`, colors);
+    }
     const resetSuffix = resetTime
       ? showResetLabel
         ? ` (${t(resetsKey)} ${resetTime})`
@@ -55,8 +60,23 @@ export function renderUsageLine(
     return null;
   }
 
-  const usageBarEnabled = display?.usageBarEnabled ?? true;
   const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
+
+  if (usageCompact) {
+    const fiveHourPart = fiveHour !== null
+      ? formatCompactWindowPart("5h", fiveHour, ctx.usageData.fiveHourResetAt, timeFormat, colors)
+      : null;
+    const sevenDayPart = (sevenDay !== null && (fiveHour === null || sevenDay >= sevenDayThreshold))
+      ? formatCompactWindowPart("7d", sevenDay, ctx.usageData.sevenDayResetAt, timeFormat, colors)
+      : null;
+
+    if (fiveHourPart && sevenDayPart) {
+      return `${fiveHourPart} | ${sevenDayPart}`;
+    }
+    return fiveHourPart ?? sevenDayPart ?? null;
+  }
+
+  const usageBarEnabled = display?.usageBarEnabled ?? true;
   const barWidth = getAdaptiveBarWidth();
 
   if (fiveHour === null && sevenDay !== null) {
@@ -105,6 +125,21 @@ export function renderUsageLine(
   }
 
   return `${usageLabel} ${fiveHourPart}`;
+}
+
+function formatCompactWindowPart(
+  windowLabel: string,
+  percent: number | null,
+  resetAt: Date | null,
+  timeFormat: TimeFormatMode,
+  colors?: RenderContext["config"]["colors"],
+): string {
+  const usageDisplay = formatUsagePercent(percent, colors);
+  const reset = formatResetTime(resetAt, timeFormat);
+  const styledLabel = label(`${windowLabel}:`, colors);
+  return reset
+    ? `${styledLabel} ${usageDisplay} ${label(`(${reset})`, colors)}`
+    : `${styledLabel} ${usageDisplay}`;
 }
 
 function formatUsagePercent(

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -152,17 +152,23 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   // Usage limits display (shown when enabled in config, respects usageThreshold)
   if (display?.showUsage !== false && ctx.usageData && !providerLabel) {
+    const usageCompact = display?.usageCompact ?? false;
+    const showResetLabel = display?.showResetLabel ?? true;
+
     if (isLimitReached(ctx.usageData)) {
-      const showResetLabel = display?.showResetLabel ?? true;
       const resetTime = ctx.usageData.fiveHour === 100
         ? formatResetTime(ctx.usageData.fiveHourResetAt, timeFormat)
         : formatResetTime(ctx.usageData.sevenDayResetAt, timeFormat);
-      const resetSuffix = resetTime
-        ? showResetLabel
-          ? ` (${t(resetsKey)} ${resetTime})`
-          : ` (${resetTime})`
-        : '';
-      parts.push(critical(`⚠ ${t('status.limitReached')}${resetSuffix}`, colors));
+      if (usageCompact) {
+        parts.push(critical(`⚠ Limit${resetTime ? ` (${resetTime})` : ''}`, colors));
+      } else {
+        const resetSuffix = resetTime
+          ? showResetLabel
+            ? ` (${t(resetsKey)} ${resetTime})`
+            : ` (${resetTime})`
+          : '';
+        parts.push(critical(`⚠ ${t('status.limitReached')}${resetSuffix}`, colors));
+      }
     } else {
       const usageThreshold = display?.usageThreshold ?? 0;
       const fiveHour = ctx.usageData.fiveHour;
@@ -171,8 +177,24 @@ export function renderSessionLine(ctx: RenderContext): string {
 
       if (effectiveUsage >= usageThreshold) {
         const usageBarEnabled = display?.usageBarEnabled ?? true;
-        const showResetLabel = display?.showResetLabel ?? true;
-        if (fiveHour === null && sevenDay !== null) {
+        if (usageCompact) {
+          const fiveHourPart = fiveHour !== null
+            ? formatCompactWindowPart('5h', fiveHour, ctx.usageData.fiveHourResetAt, timeFormat, colors)
+            : null;
+          const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
+          const sevenDayPart = (sevenDay !== null && (fiveHour === null || sevenDay >= sevenDayThreshold))
+            ? formatCompactWindowPart('7d', sevenDay, ctx.usageData.sevenDayResetAt, timeFormat, colors)
+            : null;
+
+          if (fiveHourPart && sevenDayPart) {
+            parts.push(fiveHourPart);
+            parts.push(sevenDayPart);
+          } else if (fiveHourPart) {
+            parts.push(fiveHourPart);
+          } else if (sevenDayPart) {
+            parts.push(sevenDayPart);
+          }
+        } else if (fiveHour === null && sevenDay !== null) {
           const weeklyOnlyPart = formatUsageWindowPart({
             label: t('label.weekly'),
             percent: sevenDay,
@@ -303,6 +325,21 @@ function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent'
   }
 
   return `${percent}%`;
+}
+
+function formatCompactWindowPart(
+  windowLabel: string,
+  percent: number | null,
+  resetAt: Date | null,
+  timeFormat: TimeFormatMode,
+  colors?: RenderContext['config']['colors'],
+): string {
+  const usageDisplay = formatUsagePercent(percent, colors);
+  const reset = formatResetTime(resetAt, timeFormat);
+  const styledLabel = label(`${windowLabel}:`, colors);
+  return reset
+    ? `${styledLabel} ${usageDisplay} ${label(`(${reset})`, colors)}`
+    : `${styledLabel} ${usageDisplay}`;
 }
 
 function formatUsagePercent(percent: number | null, colors?: RenderContext['config']['colors']): string {


### PR DESCRIPTION
## Summary

Adds `display.usageCompact` (`boolean`, default `false`) that renders usage stats in a shorter format, saving horizontal space on narrow terminals and compact layouts.

```json
{ "display": { "usageCompact": true } }
```

### Before / After

| Scenario | Default | Compact |
|----------|---------|---------|
| 5h only | `Usage 5h 25% (resets in 3h 45m)` | `5h: 25% (3h 45m)` |
| 5h + 7d | `Usage 5h 25% (resets in 3h 45m) \| Weekly 8% (resets in 2d)` | `5h: 25% (3h 45m) \| 7d: 8% (2d)` |
| Limit reached | `⚠ Limit reached (resets 3h 45m)` | `⚠ Limit (3h 45m)` |

When enabled: drops the "Usage" label, uses `5h:`/`7d:` prefixes with a colon, and shortens `(resets in X)` to `(X)`.

`usageCompact` takes precedence over `usageBarEnabled` — compact mode always uses text format (no bar).

### Note on configure.md fix

The existing Usage Style Mapping table described the "Text style" as showing `5h: 25% (1h 30m)`, but the actual code output was `Usage 5h 25% (resets in 1h 30m)`. This PR fixes the table to accurately document all three styles (bar, text, compact). The compact format now matches what the docs originally described.

### Changes

| File | Change |
|------|--------|
| `src/config.ts` | Add `usageCompact: boolean` to `HudConfig.display`, default `false`, validation in `mergeConfig()` |
| `src/render/session-line.ts` | Compact rendering path for compact layout |
| `src/render/lines/usage.ts` | Compact rendering path for expanded layout |
| `commands/configure.md` | Add "Compact usage" to element mapping, fix Usage Style Mapping table |

## Testing

- [x] `npm test` — all tests pass (1 pre-existing flaky failure in `core.test.js` unrelated)
- [x] `npm run build` — compiles cleanly
- [x] Manually verified compact output: `15% | 5h: 40% (3h 33m) | 7d: 8% (2d 5h)`

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed

Closes #411