### PR TITLE
fix: detect Windows terminal width via PowerShell when ConPTY reports 0

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -15,7 +15,7 @@ import {
   renderSessionTokensLine,
 } from './lines/index.js';
 import { dim, RESET } from './colors.js';
-import { UNKNOWN_TERMINAL_WIDTH } from '../utils/terminal.js';
+import { UNKNOWN_TERMINAL_WIDTH, getWindowsTerminalWidth } from '../utils/terminal.js';
 
 // eslint-disable-next-line no-control-regex
 const ANSI_ESCAPE_PATTERN = /^(?:\x1b\[[0-9;]*m|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\))/;
@@ -45,6 +45,15 @@ function getTerminalWidth(): number {
   const envColumns = Number.parseInt(process.env.COLUMNS ?? '', 10);
   if (Number.isFinite(envColumns) && envColumns > 0) {
     return envColumns;
+  }
+
+  // On Windows, stdout/stderr.columns are both 0 when Claude Code pipes the
+  // statusLine subprocess output (ConPTY wraps stdout as a pipe, discarding
+  // column info). Query the real width via the Windows Console API instead.
+  // See: https://github.com/jarrodwatts/claude-hud/issues/<issue-number>
+  const winWidth = getWindowsTerminalWidth();
+  if (winWidth !== null) {
+    return winWidth;
   }
 
   return UNKNOWN_TERMINAL_WIDTH;

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -1,4 +1,42 @@
+import { execSync } from 'child_process';
+
 export const UNKNOWN_TERMINAL_WIDTH = 40;
+
+/**
+ * Windows-specific fallback: query the actual terminal window width via PowerShell.
+ *
+ * When Claude Code runs the statusLine command as a subprocess with piped stdout,
+ * Windows ConPTY causes process.stdout.columns and process.stderr.columns to both
+ * return 0. The COLUMNS environment variable is also unset. As a result, the normal
+ * fallback chain silently bottoms out at UNKNOWN_TERMINAL_WIDTH (40), which causes
+ * the HUD to wrap into 4+ lines instead of the intended 2.
+ *
+ * $Host.UI.RawUI.WindowSize.Width reads the width from the Windows Console API,
+ * bypassing the ConPTY layer and returning the true terminal window width.
+ *
+ * Returns the width as a positive integer, or null if detection fails or the
+ * platform is not Windows.
+ */
+export function getWindowsTerminalWidth(): number | null {
+  if (process.platform !== 'win32') return null;
+  try {
+    const raw = execSync(
+      'powershell.exe -NoProfile -Command "$Host.UI.RawUI.WindowSize.Width"',
+      {
+        encoding: 'utf8',
+        // Prevent a slow or unavailable PowerShell from blocking HUD rendering.
+        timeout: 1000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      },
+    ).trim();
+    const width = parseInt(raw, 10);
+    return Number.isFinite(width) && width > 0 ? width : null;
+  } catch {
+    // PowerShell unavailable or returned a non-numeric value; fall through to
+    // the caller's own fallback.
+    return null;
+  }
+}
 
 // Returns a progress bar width scaled to the current terminal width.
 // Wide (>=100): 10, Medium (60-99): 6, Narrow (<60): 4.
@@ -13,5 +51,15 @@ export function getAdaptiveBarWidth(): number {
     if (cols >= 60) return 6;
     return 4;
   }
+
+  // Neither stdout.columns nor COLUMNS env var is available (e.g. Windows ConPTY).
+  // Try the PowerShell fallback before giving up.
+  const winWidth = getWindowsTerminalWidth();
+  if (winWidth !== null) {
+    if (winWidth >= 100) return 10;
+    if (winWidth >= 60) return 6;
+    return 4;
+  }
+
   return 10;
 }


### PR DESCRIPTION
## Problem

  On Windows, `process.stdout.columns` and `process.stderr.columns` both
  return `0` when Claude Code runs the statusLine command as a subprocess
  with piped stdout (ConPTY architecture). The `COLUMNS` environment
  variable is also unset. The fallback chain in both `getTerminalWidth()`
  and `getAdaptiveBarWidth()` therefore bottoms out at
  `UNKNOWN_TERMINAL_WIDTH = 40`, causing the HUD to wrap into 4+ lines
  instead of the intended 2-line layout.

## Root cause

  Windows Terminal uses ConPTY as an intermediary layer. When Claude Code
  spawns the statusLine subprocess with piped stdout, the inner pipe
  reports `columns = 0` — the actual window width is not propagated
  through the ConPTY layer to the child process's stream properties.

 ## Fix

  Add `getWindowsTerminalWidth()` in `src/utils/terminal.ts`. It queries
  the real terminal width via PowerShell's
  `$Host.UI.RawUI.WindowSize.Width`, which reads from the Windows Console
  API and correctly reflects the visible window width.

  Both `getAdaptiveBarWidth()` (terminal.ts) and `getTerminalWidth()`
  (render/index.ts) now call this as a last-resort fallback before
  returning the unknown-width sentinel.

 ## Tested on

  - Windows 11 + Windows Terminal + Claude Code statusLine
  - Actual terminal width: 120 columns
  - Before fix: HUD rendered as 4 lines
  - After fix: correct 2-line expanded layout