### PR TITLE
fix(setup): inject COLUMNS width fallback into bash statusLine command

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -153,12 +153,12 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
    **When runtime is bun** - add `--env-file /dev/null` to prevent Bun from auto-loading project `.env` files:
    ```
-   bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
+   bash -c 'export COLUMNS=$(tmux display-message -p "#{pane_width}" 2>/dev/null || tput cols 2>/dev/null || echo 120); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
    ```
 
    **When runtime is node**:
    ```
-   bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
+   bash -c 'export COLUMNS=$(tmux display-message -p "#{pane_width}" 2>/dev/null || tput cols 2>/dev/null || echo 120); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
    ```
 
 **Windows + Git Bash** (Platform: `win32`, Shell: `bash`):


### PR DESCRIPTION
## Summary
- update /claude-hud:setup bash command templates (bun + node) to export COLUMNS before launching HUD
- use a robust width detection chain: tmux display-message -p '#{pane_width}' || tput cols || 120
- keep existing dynamic plugin-version lookup and runtime invocation unchanged

## Why
- addresses #416 where setup-generated commands can run with COLUMNS=0 or missing width in tmux/zellij subprocesses
- gives getTerminalWidth() a reliable env override without requiring manual user edits

## Testing
- node --test tests/terminal.test.js
- rg -n "tmux display-message -p|tput cols" commands/setup.md

Fixes #416.