### PR TITLE
fix: fall back to tput cols for terminal width in piped subprocess environments

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import type { HudElement } from '../config.js';
 import { DEFAULT_ELEMENT_ORDER } from '../config.js';
 import type { RenderContext } from '../types.js';
@@ -45,6 +46,18 @@ function getTerminalWidth(): number {
   const envColumns = Number.parseInt(process.env.COLUMNS ?? '', 10);
   if (Number.isFinite(envColumns) && envColumns > 0) {
     return envColumns;
+  }
+
+  // Last resort: ask tput. Works in environments where stdout/stderr are
+  // piped (e.g. cmux) and /dev/tty is unavailable, because tput reads the
+  // terminal size from the TERM/terminfo database or the controlling tty.
+  try {
+    const tputCols = Number.parseInt(execSync('tput cols', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim(), 10);
+    if (Number.isFinite(tputCols) && tputCols > 0) {
+      return tputCols;
+    }
+  } catch {
+    // tput unavailable or failed — fall through to default
   }
 
   return UNKNOWN_TERMINAL_WIDTH;


### PR DESCRIPTION
## Problem

When claude-hud runs as a Claude Code `statusLine` subprocess, both stdout and stderr are piped to Claude Code, so `process.stdout.columns` and `process.stderr.columns` are `undefined`. In some terminal hosts — most notably **cmux** (which embeds libghostty) — `/dev/tty` is also inaccessible, meaning none of the three current detection sources work and `getTerminalWidth()` falls back to `UNKNOWN_TERMINAL_WIDTH` (40).

With width 40, `wrapLineToWidth` wraps every line into many short fragments. Claude Code's statusLine renderer sees far more visual rows than its budget allows and collapses the entire status area down to a single row. The user ends up with only the first line of the HUD visible regardless of session activity.

## Root cause chain

```
Claude Code statusLine subprocess
  └─ stdout piped  → process.stdout.columns = undefined
  └─ stderr piped  → process.stderr.columns = undefined
  └─ /dev/tty inaccessible (cmux)
  └─ COLUMNS env unset
  └─ getTerminalWidth() → UNKNOWN_TERMINAL_WIDTH (40)
  └─ wrapLineToWidth at 40 → many tiny fragments
  └─ Claude Code sees N×visual rows > budget → collapses to 1 row
```

## Fix

Add a `tput cols` call as a last resort before `UNKNOWN_TERMINAL_WIDTH`. `tput` can derive the terminal width from the controlling tty or the terminfo capability database even when the process streams are all piped — covering the cmux case and any similar embedded-terminal environment.

## Testing

Verified with claude-hud running as Claude Code's `statusLine` command inside a cmux session:

**Before**: only 1 row visible (width detected as 40, excessive wrapping)  
**After**: full 5–7 row HUD visible, wraps correctly at actual pane width (80)

The `tput` call is wrapped in `try/catch`, so environments without `tput` (Windows, restricted containers) are unaffected.

## Related

- cmux issue manaflow-ai/cmux#2063 — requesting pane dimension API that would let this be solved host-side