### PR TITLE
fix(setup): inject COLUMNS env for accurate terminal width detection

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -151,14 +151,20 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
 5. Generate command (quotes around runtime path handle spaces):
 
+   The command injects `COLUMNS` so the HUD knows the real terminal width.
+   Claude Code pipes the subprocess stdout, so `process.stdout.columns` is
+   unavailable at runtime. `stty size </dev/tty` reads from the controlling
+   terminal. The `- 4` accounts for Claude Code's input area padding
+   (2 columns on each side).
+
    **When runtime is bun** - add `--env-file /dev/null` to prevent Bun from auto-loading project `.env` files:
    ```
-   bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
+   bash -c 'COLUMNS=$(( $(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"' || echo 120) - 4 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
    ```
 
    **When runtime is node**:
    ```
-   bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
+   bash -c 'COLUMNS=$(( $(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"' || echo 120) - 4 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
    ```
 
 **Windows + Git Bash** (Platform: `win32`, Shell: `bash`):
@@ -191,14 +197,18 @@ Use the macOS/Linux bash command format above, but on Windows prefer `node` firs
 
 4. Generate command (note: quotes around runtime path handle spaces in paths):
 
+   The command injects `COLUMNS` so the HUD knows the real terminal width.
+   `[Console]::WindowWidth` reads the console buffer width. The `- 4`
+   accounts for Claude Code's input area padding (2 columns on each side).
+
    **When runtime is bun** - add `--env-file NUL` to prevent Bun from auto-loading project `.env` files:
    ```
-   powershell -Command "& {$claudeDir=if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME '.claude' }; $p=(Get-ChildItem (Join-Path $claudeDir 'plugins\cache\claude-hud\claude-hud') -Directory | Where-Object { $_.Name -match '^\d+(\.\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName; & '{RUNTIME_PATH}' '--env-file' 'NUL' (Join-Path $p '{SOURCE}')}"
+   powershell -Command "& {$env:COLUMNS=[Math]::Max(1,[Console]::WindowWidth-4); $claudeDir=if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME '.claude' }; $p=(Get-ChildItem (Join-Path $claudeDir 'plugins\cache\claude-hud\claude-hud') -Directory | Where-Object { $_.Name -match '^\d+(\.\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName; & '{RUNTIME_PATH}' '--env-file' 'NUL' (Join-Path $p '{SOURCE}')}"
    ```
 
    **When runtime is node**:
    ```
-   powershell -Command "& {$claudeDir=if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME '.claude' }; $p=(Get-ChildItem (Join-Path $claudeDir 'plugins\cache\claude-hud\claude-hud') -Directory | Where-Object { $_.Name -match '^\d+(\.\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName; & '{RUNTIME_PATH}' (Join-Path $p '{SOURCE}')}"
+   powershell -Command "& {$env:COLUMNS=[Math]::Max(1,[Console]::WindowWidth-4); $claudeDir=if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME '.claude' }; $p=(Get-ChildItem (Join-Path $claudeDir 'plugins\cache\claude-hud\claude-hud') -Directory | Where-Object { $_.Name -match '^\d+(\.\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName; & '{RUNTIME_PATH}' (Join-Path $p '{SOURCE}')}"
    ```
 
 **WSL (Windows Subsystem for Linux)**: If running in WSL, use the macOS/Linux instructions. Ensure the plugin is installed in the Linux environment (`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/...`), not the Windows side.


### PR DESCRIPTION
## Problem

Claude Code runs the `statusLine` command as a subprocess with piped stdout/stderr. In this context:

- `process.stdout.columns` → `undefined` (piped)
- `process.stderr.columns` → `undefined` (piped)
- `process.env.COLUMNS` → not set by default

`getTerminalWidth()` falls back to `UNKNOWN_TERMINAL_WIDTH` (40), and all width-dependent layout decisions (line combining, wrapping, truncation) use this incorrect value.

Even with #427 (which guards against using the fallback for layout), without real width information the HUD simply cannot do width-aware formatting at all — it skips wrapping/splitting entirely.

## Fix

Inject `COLUMNS` into the generated `statusLine` command during `/claude-hud:setup`:

| Platform | Method | Why it works |
|----------|--------|-------------|
| macOS/Linux/WSL | `stty size </dev/tty` | Reads from the controlling terminal, which is the real terminal even when stdout is piped |
| Windows PowerShell | `[Console]::WindowWidth` | Reads the console buffer width directly |

Both subtract 4 columns to account for Claude Code's `PromptInputFooter` padding (`paddingX={2}` → 2 columns on each side). This prevents the rightmost content from being clipped by the padding.

## How We Found This

Running claude-hud as a vendored statusLine plugin, we discovered that `process.stdout.columns` is never available in the CC subprocess context. The `stty size </dev/tty` workaround was validated across iTerm2, Ghostty, and tmux, and has been stable in production for several days.

## Related

- #427 — Guards `canCombine` and `wrapLineToWidth` against using the `UNKNOWN_TERMINAL_WIDTH` fallback. That PR is the defensive layer; this PR is the capability layer (actually providing the real width).