### PR TITLE
fix: show initial context tokens when used_percentage is 0 (#417)

### DIFF
--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -143,10 +143,16 @@ export function getTotalTokens(stdin: StdinData): number {
 /**
  * Get native percentage from Claude Code v2.1.6+ if available.
  * Returns null if not available or invalid, triggering fallback to manual calculation.
+ *
+ * A value of 0 is treated as "not yet populated": on a fresh session Claude Code
+ * may emit used_percentage=0 before the first API response arrives, while
+ * current_usage already contains the real initial-context tokens (system prompt,
+ * tools, memory files, etc.).  Falling through to the token-based calculation
+ * ensures those tokens are reflected in the context bar from the very first tick.
  */
 function getNativePercent(stdin: StdinData): number | null {
   const nativePercent = stdin.context_window?.used_percentage;
-  if (typeof nativePercent === 'number' && !Number.isNaN(nativePercent)) {
+  if (typeof nativePercent === 'number' && !Number.isNaN(nativePercent) && nativePercent > 0) {
     return Math.min(100, Math.max(0, Math.round(nativePercent)));
   }
   return null;

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -191,8 +191,38 @@ test('getBufferedPercent falls back when native is null', () => {
 });
 
 test('native percentage handles zero correctly', () => {
+  // used_percentage: 0 with no tokens → still 0
   assert.equal(getContextPercent({ context_window: { used_percentage: 0 } }), 0);
   assert.equal(getBufferedPercent({ context_window: { used_percentage: 0 } }), 0);
+});
+
+test('getContextPercent falls through to token-based calculation when used_percentage is 0 but tokens exist', () => {
+  // On a fresh session Claude Code emits used_percentage=0 before the first API
+  // response, while current_usage already contains the initial-context tokens
+  // (system prompt, tools, memory files).  The HUD should reflect them.
+  // 18200 / 200000 = 9.1% → rounds to 9%
+  const percent = getContextPercent({
+    context_window: {
+      context_window_size: 200000,
+      current_usage: { input_tokens: 18200 },
+      used_percentage: 0,
+    },
+  });
+  assert.equal(percent, 9);
+});
+
+test('getBufferedPercent falls through to token-based calculation when used_percentage is 0 but tokens exist', () => {
+  // Same fresh-session scenario for the buffered variant.
+  // 18200 / 200000 = 9.1% raw; scale = (0.091 - 0.05) / (0.50 - 0.05) ≈ 0.091
+  // buffer = 200000 * 0.165 * 0.091 ≈ 3003; (18200 + 3003) / 200000 ≈ 10.6% → 11%
+  const percent = getBufferedPercent({
+    context_window: {
+      context_window_size: 200000,
+      current_usage: { input_tokens: 18200 },
+      used_percentage: 0,
+    },
+  });
+  assert.ok(percent > 9, `expected buffered percent > 9, got ${percent}`);
 });
 
 test('native percentage clamps negative values to 0', () => {


### PR DESCRIPTION
## Problem

On a fresh session — before the user types anything — the HUD shows **Context 0%** while `/context` reports **~9%** (system prompt + tools + memory files already loaded).

Root cause: Claude Code emits `used_percentage: 0` during the first few status-line ticks, before the value is populated. `getNativePercent` treated `0` as a valid, accurate reading and returned it immediately, short-circuiting the token-based fallback. Even though `current_usage.input_tokens` already contained the real initial-context tokens (~18 k), they were never used.

## Fix

Treat `used_percentage: 0` the same as `null` — fall through to the manual calculation from `current_usage`. When tokens are present the context bar now reflects the true initial usage; when both are zero it still shows `0%`.

**Changed:**
- `src/stdin.ts` — `getNativePercent` only returns a value when `used_percentage > 0`; 0 triggers the token-based fallback.
- `tests/core.test.js` — two new tests covering the fresh-session scenario, plus a clarifying comment on the existing zero test.

## Testing

```
npm run build && node --test   # 354 pass, 1 pre-existing skip
```

Manually verified with:
```bash
echo '{"context_window":{"context_window_size":200000,"current_usage":{"input_tokens":18200},"used_percentage":0}}' \
  | node dist/index.js
# Before: Context ░░░░░░░░░░ 0%
# After:  Context ░░░░░░░░░░ 9%
```

Closes #417