### PR TITLE
feat: add display.timeFormat config for absolute/relative reset times

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ After choosing a preset, you can turn individual elements on or off.
 ### Manual Configuration
 
 Edit `~/.claude/plugins/claude-hud/config.json` directly for advanced settings such as `colors.*`,
-`pathLevels`, and threshold overrides. Running `/claude-hud:configure` preserves those manual settings while still letting you change `language`, layout, and the common guided toggles.
+`pathLevels`, threshold overrides, and `display.timeFormat`. Running `/claude-hud:configure`
+preserves those manual settings while still letting you change `language`, layout, and the common
+guided toggles.
 
 Chinese HUD labels are available as an explicit opt-in. English stays the default unless you choose `中文` in `/claude-hud:configure` or set `language` in config.
 
@@ -172,6 +174,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showSpeed` | boolean | false | Show output token speed `out: 42.1 tok/s` |
 | `display.showUsage` | boolean | true | Show Claude subscriber usage limits when available |
 | `display.usageBarEnabled` | boolean | true | Display usage as visual bar instead of text |
+| `display.timeFormat` | `relative` \| `absolute` \| `both` | `relative` | How reset times are shown in usage windows: countdown only (`resets in 2h 30m`), wall-clock time (`resets at 14:30`), or both (`resets in 2h 30m, at 14:30`) |
 | `display.sevenDayThreshold` | 0-100 | 80 | Show 7-day usage when >= threshold (0 = always) |
 | `display.showTokenBreakdown` | boolean | true | Show token details at high context (85%+) |
 | `display.showTools` | boolean | false | Show tools activity line |
@@ -213,6 +216,10 @@ Context █████░░░░░ 45% │ Usage ██░░░░░░░
 ```
 
 To disable, set `display.showUsage` to `false`.
+
+Reset times use relative countdowns by default. Set `display.timeFormat` to `absolute` for wall-clock
+times or `both` to show both forms. This setting is manual-only today; `/claude-hud:configure`
+preserves it without editing it.
 
 **Requirements:**
 - Claude Code must include subscriber `rate_limits` data on stdin for the current session

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -15,8 +15,9 @@ These are always enabled and NOT configurable:
 - Model name `[Opus]`
 - Context bar `████░░░░░░ 45%`
 
-Advanced settings such as `colors.*`, `pathLevels`, `display.usageThreshold`, and
-`display.environmentThreshold` are preserved when saving but are not edited by this guided flow.
+Advanced settings such as `colors.*`, `pathLevels`, `display.timeFormat`,
+`display.usageThreshold`, and `display.environmentThreshold` are preserved when saving but are not
+edited by this guided flow.
 
 ---
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export type ContextValueMode = 'percent' | 'tokens' | 'remaining' | 'both';
  *   short:   Strip context suffix AND "Claude " prefix (e.g. "Opus 4.6")
  */
 export type ModelFormatMode = 'full' | 'compact' | 'short';
+export type TimeFormatMode = 'relative' | 'absolute' | 'both';
 export type HudElement = 'project' | 'context' | 'usage' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos';
 export type HudColorName =
   | 'dim'
@@ -99,6 +100,7 @@ export interface HudConfig {
     modelFormat: ModelFormatMode;
     modelOverride: string;
     customLine: string;
+    timeFormat: TimeFormatMode;
   };
   colors: HudColorOverrides;
 }
@@ -144,6 +146,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     modelFormat: 'full',
     modelOverride: '',
     customLine: '',
+    timeFormat: 'relative',
   },
   colors: {
     context: 'green',
@@ -187,6 +190,10 @@ function validateLanguage(value: unknown): value is Language {
 
 function validateModelFormat(value: unknown): value is ModelFormatMode {
   return value === 'full' || value === 'compact' || value === 'short';
+}
+
+function validateTimeFormat(value: unknown): value is TimeFormatMode {
+  return value === 'relative' || value === 'absolute' || value === 'both';
 }
 
 function validateColorName(value: unknown): value is HudColorName {
@@ -386,6 +393,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     customLine: typeof migrated.display?.customLine === 'string'
       ? migrated.display.customLine.slice(0, 80)
       : DEFAULT_CONFIG.display.customLine,
+    timeFormat: validateTimeFormat(migrated.display?.timeFormat)
+      ? migrated.display.timeFormat
+      : DEFAULT_CONFIG.display.timeFormat,
   };
 
   const colors = {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -18,6 +18,7 @@ export const en: Messages = {
   // Format
   "format.resets": "resets",
   "format.resetsIn": "resets in",
+  "format.at": "at",
   "format.in": "in",
   "format.cache": "cache",
   "format.out": "out",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -14,6 +14,7 @@ export type MessageKey =
   // Format
   | "format.resets"
   | "format.resetsIn"
+  | "format.at"
   | "format.in"
   | "format.cache"
   | "format.out"

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -18,6 +18,7 @@ export const zh: Messages = {
   // Format
   "format.resets": "重置于",
   "format.resetsIn": "重置剩余",
+  "format.at": "",
   "format.in": "输入",
   "format.cache": "缓存",
   "format.out": "输出",

--- a/src/render/format-reset-time.ts
+++ b/src/render/format-reset-time.ts
@@ -1,4 +1,5 @@
 import type { TimeFormatMode } from '../config.js';
+import { t } from '../i18n/index.js';
 
 /**
  * Formats a usage-window reset timestamp for display in the HUD.
@@ -6,8 +7,8 @@ import type { TimeFormatMode } from '../config.js';
  * @param resetAt - The reset timestamp, or null if unknown.
  * @param mode    - How to express the time:
  *   - `'relative'` (default) — duration until reset, e.g. `2h 30m`
- *   - `'absolute'`           — wall-clock time,       e.g. `at 14:30`
- *   - `'both'`               — both combined,          e.g. `2h 30m, at 14:30`
+ *   - `'absolute'`           — wall-clock time,       e.g. `at 14:30` (locale-aware)
+ *   - `'both'`               — both combined,          e.g. `2h 30m, at 14:30` (locale-aware)
  * @returns A formatted string, or an empty string when the reset is in the past
  *          or the date is unknown.
  */
@@ -53,13 +54,18 @@ function formatRelative(diffMs: number): string {
 }
 
 function formatAbsolute(resetAt: Date, now: Date): string {
+  // The "at" prefix is i18n-aware. Locales that bake the preposition into
+  // "format.resets" (e.g. zh: "重置于") set "format.at" to "" so the time
+  // is returned bare ("14:30") and the preposition is supplied by the caller.
+  const at = t('format.at');
+  const prefix = at ? `${at} ` : '';
   const timeStr = resetAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
   // Show the date only when the reset falls on a different calendar day
   if (resetAt.toDateString() === now.toDateString()) {
-    return `at ${timeStr}`;
+    return `${prefix}${timeStr}`;
   }
 
   const dateStr = resetAt.toLocaleDateString([], { month: 'short', day: 'numeric' });
-  return `at ${dateStr} ${timeStr}`;
+  return `${prefix}${dateStr} ${timeStr}`;
 }

--- a/src/render/format-reset-time.ts
+++ b/src/render/format-reset-time.ts
@@ -1,0 +1,65 @@
+import type { TimeFormatMode } from '../config.js';
+
+/**
+ * Formats a usage-window reset timestamp for display in the HUD.
+ *
+ * @param resetAt - The reset timestamp, or null if unknown.
+ * @param mode    - How to express the time:
+ *   - `'relative'` (default) — duration until reset, e.g. `2h 30m`
+ *   - `'absolute'`           — wall-clock time,       e.g. `at 14:30`
+ *   - `'both'`               — both combined,          e.g. `2h 30m, at 14:30`
+ * @returns A formatted string, or an empty string when the reset is in the past
+ *          or the date is unknown.
+ */
+export function formatResetTime(resetAt: Date | null, mode: TimeFormatMode = 'relative'): string {
+  if (!resetAt) return '';
+
+  const now = new Date();
+  const diffMs = resetAt.getTime() - now.getTime();
+  if (diffMs <= 0) return '';
+
+  if (mode === 'relative') {
+    return formatRelative(diffMs);
+  }
+
+  const absolute = formatAbsolute(resetAt, now);
+
+  if (mode === 'absolute') {
+    return absolute;
+  }
+
+  // 'both' — comma separator avoids nested parentheses when the caller
+  // wraps the result in its own (...) parenthetical
+  return `${formatRelative(diffMs)}, ${absolute}`;
+}
+
+function formatRelative(diffMs: number): string {
+  const diffMins = Math.ceil(diffMs / 60000);
+
+  if (diffMins < 60) {
+    return `${diffMins}m`;
+  }
+
+  const hours = Math.floor(diffMins / 60);
+  const mins = diffMins % 60;
+
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24);
+    const remHours = hours % 24;
+    return remHours > 0 ? `${days}d ${remHours}h` : `${days}d`;
+  }
+
+  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+function formatAbsolute(resetAt: Date, now: Date): string {
+  const timeStr = resetAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+  // Show the date only when the reset falls on a different calendar day
+  if (resetAt.toDateString() === now.toDateString()) {
+    return `at ${timeStr}`;
+  }
+
+  const dateStr = resetAt.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  return `at ${dateStr} ${timeStr}`;
+}

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -30,14 +30,14 @@ export function renderUsageLine(
 
   const usageLabel = progressLabel("label.usage", colors, alignLabels);
   const timeFormat: TimeFormatMode = display?.timeFormat ?? 'relative';
-  const usageLabel = progressLabel("label.usage", colors, alignLabels);
+  const resetsKey = timeFormat === 'absolute' ? "format.resets" : "format.resetsIn";
 
   if (isLimitReached(ctx.usageData)) {
     const resetTime =
       ctx.usageData.fiveHour === 100
         ? formatResetTime(ctx.usageData.fiveHourResetAt, timeFormat)
         : formatResetTime(ctx.usageData.sevenDayResetAt, timeFormat);
-    return `${usageLabel} ${critical(`⚠ ${t("status.limitReached")}${resetTime ? ` (${t("format.resets")} ${resetTime})` : ""}`, colors)}`;
+    return `${usageLabel} ${critical(`⚠ ${t("status.limitReached")}${resetTime ? ` (${t(resetsKey)} ${resetTime})` : ""}`, colors)}`;
   }
 
   const threshold = display?.usageThreshold ?? 0;

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -6,6 +6,8 @@ import { critical, label, getQuotaColor, quotaBar, RESET } from "../colors.js";
 import { getAdaptiveBarWidth } from "../../utils/terminal.js";
 import { t } from "../../i18n/index.js";
 import { progressLabel } from "./label-align.js";
+import type { TimeFormatMode } from "../../config.js";
+import { formatResetTime } from "../format-reset-time.js";
 
 export function renderUsageLine(
   ctx: RenderContext,
@@ -27,12 +29,14 @@ export function renderUsageLine(
   }
 
   const usageLabel = progressLabel("label.usage", colors, alignLabels);
+  const timeFormat: TimeFormatMode = display?.timeFormat ?? 'relative';
+  const usageLabel = progressLabel("label.usage", colors, alignLabels);
 
   if (isLimitReached(ctx.usageData)) {
     const resetTime =
       ctx.usageData.fiveHour === 100
-        ? formatResetTime(ctx.usageData.fiveHourResetAt)
-        : formatResetTime(ctx.usageData.sevenDayResetAt);
+        ? formatResetTime(ctx.usageData.fiveHourResetAt, timeFormat)
+        : formatResetTime(ctx.usageData.sevenDayResetAt, timeFormat);
     return `${usageLabel} ${critical(`⚠ ${t("status.limitReached")}${resetTime ? ` (${t("format.resets")} ${resetTime})` : ""}`, colors)}`;
   }
 
@@ -58,6 +62,7 @@ export function renderUsageLine(
       colors,
       usageBarEnabled,
       barWidth,
+      timeFormat,
       forceLabel: true,
       alignLabels,
     });
@@ -71,6 +76,7 @@ export function renderUsageLine(
     colors,
     usageBarEnabled,
     barWidth,
+    timeFormat,
   });
 
   if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
@@ -82,6 +88,7 @@ export function renderUsageLine(
       colors,
       usageBarEnabled,
       barWidth,
+      timeFormat,
       forceLabel: true,
       alignLabels,
     });
@@ -110,6 +117,7 @@ function formatUsageWindowPart({
   colors,
   usageBarEnabled,
   barWidth,
+  timeFormat = 'relative',
   forceLabel = false,
   alignLabels = false,
 }: {
@@ -120,45 +128,26 @@ function formatUsageWindowPart({
   colors?: RenderContext["config"]["colors"];
   usageBarEnabled: boolean;
   barWidth: number;
+  timeFormat?: TimeFormatMode;
   forceLabel?: boolean;
   alignLabels?: boolean;
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors);
-  const reset = formatResetTime(resetAt);
+  const reset = formatResetTime(resetAt, timeFormat);
   const styledLabel = labelKey
     ? progressLabel(labelKey, colors, alignLabels)
     : label(windowLabel, colors);
+  // "resets in X" for relative/both; "resets X" for absolute (avoids "resets in at 14:30")
+  const resetsKey = timeFormat === 'absolute' ? "format.resets" : "format.resetsIn";
 
   if (usageBarEnabled) {
     const body = reset
-      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${t(resetsKey)} ${reset})`
       : `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay}`;
     return forceLabel ? `${styledLabel} ${body}` : body;
   }
 
   return reset
-    ? `${styledLabel} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+    ? `${styledLabel} ${usageDisplay} (${t(resetsKey)} ${reset})`
     : `${styledLabel} ${usageDisplay}`;
-}
-
-function formatResetTime(resetAt: Date | null): string {
-  if (!resetAt) return "";
-  const now = new Date();
-  const diffMs = resetAt.getTime() - now.getTime();
-  if (diffMs <= 0) return "";
-
-  const diffMins = Math.ceil(diffMs / 60000);
-  if (diffMins < 60) return `${diffMins}m`;
-
-  const hours = Math.floor(diffMins / 60);
-  const mins = diffMins % 60;
-
-  if (hours >= 24) {
-    const days = Math.floor(hours / 24);
-    const remHours = hours % 24;
-    if (remHours > 0) return `${days}d ${remHours}h`;
-    return `${days}d`;
-  }
-
-  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
 }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -324,8 +324,13 @@ function formatUsageWindowPart({
   const resetsKey = timeFormat === 'absolute' ? 'format.resets' : 'format.resetsIn';
 
   if (usageBarEnabled) {
-    const body = reset
-      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${reset} / ${windowLabel})`
+    // Relative mode keeps the upstream "(duration / windowLabel)" pattern (e.g. "2h 30m / 5h").
+    // Absolute/both modes use the preposition form instead — "(at 14:30 / 5h)" is incoherent.
+    const barReset = timeFormat === 'relative'
+      ? (reset ? `${reset} / ${windowLabel}` : null)
+      : (reset ? `${t(resetsKey)} ${reset}` : null);
+    const body = barReset
+      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${barReset})`
       : `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay}`;
     return forceLabel ? `${styledLabel} ${body}` : body;
   }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -34,6 +34,7 @@ export function renderSessionLine(ctx: RenderContext): string {
   const parts: string[] = [];
   const display = ctx.config?.display;
   const timeFormat: TimeFormatMode = display?.timeFormat ?? 'relative';
+  const resetsKey = timeFormat === 'absolute' ? 'format.resets' : 'format.resetsIn';
   const contextValueMode = display?.contextValue ?? 'percent';
   const contextValue = formatContextValue(ctx, percent, contextValueMode);
   const contextValueDisplay = `${getContextColor(percent, colors)}${contextValue}${RESET}`;
@@ -150,7 +151,7 @@ export function renderSessionLine(ctx: RenderContext): string {
       const resetTime = ctx.usageData.fiveHour === 100
         ? formatResetTime(ctx.usageData.fiveHourResetAt, timeFormat)
         : formatResetTime(ctx.usageData.sevenDayResetAt, timeFormat);
-      parts.push(critical(`⚠ ${t('status.limitReached')}${resetTime ? ` (${t('format.resets')} ${resetTime})` : ''}`, colors));
+      parts.push(critical(`⚠ ${t('status.limitReached')}${resetTime ? ` (${t(resetsKey)} ${resetTime})` : ''}`, colors));
     } else {
       const usageThreshold = display?.usageThreshold ?? 0;
       const fiveHour = ctx.usageData.fiveHour;

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -6,6 +6,8 @@ import { coloredBar, critical, git as gitColor, gitBranch as gitBranchColor, lab
 import { getAdaptiveBarWidth } from '../utils/terminal.js';
 import { renderCostEstimate } from './lines/cost.js';
 import { t } from '../i18n/index.js';
+import type { TimeFormatMode } from '../config.js';
+import { formatResetTime } from './format-reset-time.js';
 
 const DEBUG = process.env.DEBUG?.includes('claude-hud') || process.env.DEBUG === '*';
 
@@ -31,6 +33,7 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   const parts: string[] = [];
   const display = ctx.config?.display;
+  const timeFormat: TimeFormatMode = display?.timeFormat ?? 'relative';
   const contextValueMode = display?.contextValue ?? 'percent';
   const contextValue = formatContextValue(ctx, percent, contextValueMode);
   const contextValueDisplay = `${getContextColor(percent, colors)}${contextValue}${RESET}`;
@@ -145,8 +148,8 @@ export function renderSessionLine(ctx: RenderContext): string {
   if (display?.showUsage !== false && ctx.usageData && !providerLabel) {
     if (isLimitReached(ctx.usageData)) {
       const resetTime = ctx.usageData.fiveHour === 100
-        ? formatResetTime(ctx.usageData.fiveHourResetAt)
-        : formatResetTime(ctx.usageData.sevenDayResetAt);
+        ? formatResetTime(ctx.usageData.fiveHourResetAt, timeFormat)
+        : formatResetTime(ctx.usageData.sevenDayResetAt, timeFormat);
       parts.push(critical(`⚠ ${t('status.limitReached')}${resetTime ? ` (${t('format.resets')} ${resetTime})` : ''}`, colors));
     } else {
       const usageThreshold = display?.usageThreshold ?? 0;
@@ -164,6 +167,7 @@ export function renderSessionLine(ctx: RenderContext): string {
             colors,
             usageBarEnabled,
             barWidth,
+            timeFormat,
             forceLabel: true,
           });
           parts.push(weeklyOnlyPart);
@@ -175,6 +179,7 @@ export function renderSessionLine(ctx: RenderContext): string {
             colors,
             usageBarEnabled,
             barWidth,
+            timeFormat,
           });
 
           const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
@@ -186,6 +191,7 @@ export function renderSessionLine(ctx: RenderContext): string {
               colors,
               usageBarEnabled,
               barWidth,
+              timeFormat,
               forceLabel: true,
             });
             parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
@@ -298,6 +304,7 @@ function formatUsageWindowPart({
   colors,
   usageBarEnabled,
   barWidth,
+  timeFormat = 'relative',
   forceLabel = false,
 }: {
   label: string;
@@ -306,11 +313,14 @@ function formatUsageWindowPart({
   colors?: RenderContext['config']['colors'];
   usageBarEnabled: boolean;
   barWidth: number;
+  timeFormat?: TimeFormatMode;
   forceLabel?: boolean;
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors);
-  const reset = formatResetTime(resetAt);
+  const reset = formatResetTime(resetAt, timeFormat);
   const styledLabel = label(windowLabel, colors);
+  // "resets in X" for relative/both; "resets X" for absolute (avoids "resets in at 14:30")
+  const resetsKey = timeFormat === 'absolute' ? 'format.resets' : 'format.resetsIn';
 
   if (usageBarEnabled) {
     const body = reset
@@ -320,28 +330,6 @@ function formatUsageWindowPart({
   }
 
   return reset
-    ? `${styledLabel} ${usageDisplay} (${t('format.resetsIn')} ${reset})`
+    ? `${styledLabel} ${usageDisplay} (${t(resetsKey)} ${reset})`
     : `${styledLabel} ${usageDisplay}`;
-}
-
-function formatResetTime(resetAt: Date | null): string {
-  if (!resetAt) return '';
-  const now = new Date();
-  const diffMs = resetAt.getTime() - now.getTime();
-  if (diffMs <= 0) return '';
-
-  const diffMins = Math.ceil(diffMs / 60000);
-  if (diffMins < 60) return `${diffMins}m`;
-
-  const hours = Math.floor(diffMins / 60);
-  const mins = diffMins % 60;
-
-  if (hours >= 24) {
-    const days = Math.floor(hours / 24);
-    const remHours = hours % 24;
-    if (remHours > 0) return `${days}d ${remHours}h`;
-    return `${days}d`;
-  }
-
-  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
 }

--- a/tests/format-reset-time.test.js
+++ b/tests/format-reset-time.test.js
@@ -86,11 +86,20 @@ test('absolute: returns a non-empty string for a future date', () => {
 });
 
 test('absolute: includes date component when reset is tomorrow or later', () => {
-  // Reset in 30 hours — guaranteed to be a different calendar day
-  const result = formatResetTime(future(30 * HOUR), 'absolute');
+  const resetAt = future(30 * HOUR); // guaranteed to be a different calendar day
+  const result = formatResetTime(resetAt, 'absolute');
+  const expectedDate = resetAt.toLocaleDateString([], {
+    month: 'short',
+    day: 'numeric',
+  });
+  const expectedTime = resetAt.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
   assert.ok(result.startsWith('at '), `Expected "at " prefix, got: ${result}`);
-  // Must contain a month abbreviation (Jan, Feb, …) to prove the date is included
-  assert.match(result, /at [A-Z][a-z]+ \d+/, `Expected month abbreviation in next-day reset, got: ${result}`);
+  assert.ok(result.includes(expectedDate), `Expected localized date in next-day reset, got: ${result}`);
+  assert.ok(result.endsWith(expectedTime), `Expected localized time in next-day reset, got: ${result}`);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/format-reset-time.test.js
+++ b/tests/format-reset-time.test.js
@@ -1,0 +1,142 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatResetTime } from '../dist/render/format-reset-time.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns a Date that is `ms` milliseconds in the future. */
+function future(ms) {
+  return new Date(Date.now() + ms);
+}
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+// ---------------------------------------------------------------------------
+// Null / past guard
+// ---------------------------------------------------------------------------
+
+test('returns empty string for null', () => {
+  assert.equal(formatResetTime(null), '');
+  assert.equal(formatResetTime(null, 'absolute'), '');
+  assert.equal(formatResetTime(null, 'both'), '');
+});
+
+test('returns empty string for a date in the past', () => {
+  const past = new Date(Date.now() - HOUR);
+  assert.equal(formatResetTime(past), '');
+  assert.equal(formatResetTime(past, 'absolute'), '');
+  assert.equal(formatResetTime(past, 'both'), '');
+});
+
+// ---------------------------------------------------------------------------
+// relative mode (default)
+// ---------------------------------------------------------------------------
+
+test('relative: shows minutes when < 1 hour', () => {
+  const result = formatResetTime(future(30 * MINUTE));
+  assert.match(result, /^\d+m$/);
+});
+
+test('relative: shows hours + minutes when < 24 hours', () => {
+  const result = formatResetTime(future(2 * HOUR + 30 * MINUTE));
+  assert.match(result, /^2h 30m$/);
+});
+
+test('relative: shows hours only when minutes == 0', () => {
+  // Exactly N hours: Math.ceil(N*60 mins) = N*60 → mins % 60 === 0
+  const result = formatResetTime(future(3 * HOUR));
+  assert.match(result, /^3h$/);
+});
+
+test('relative: shows days + hours for durations >= 24 hours', () => {
+  const result = formatResetTime(future(6 * DAY + 7 * HOUR));
+  assert.match(result, /^6d 7h$/);
+});
+
+test('relative: shows days only when remaining hours == 0', () => {
+  // Exactly N days → hours % 24 === 0
+  const result = formatResetTime(future(3 * DAY));
+  assert.match(result, /^3d$/);
+});
+
+test('relative: is the default when mode is omitted', () => {
+  const withDefault = formatResetTime(future(90 * MINUTE));
+  const withExplicit = formatResetTime(future(90 * MINUTE), 'relative');
+  // Both should match the same pattern (values may differ by a few ms)
+  assert.match(withDefault, /^\d+h( \d+m)?$/);
+  assert.match(withExplicit, /^\d+h( \d+m)?$/);
+});
+
+// ---------------------------------------------------------------------------
+// absolute mode
+// ---------------------------------------------------------------------------
+
+test('absolute: starts with "at " prefix', () => {
+  const result = formatResetTime(future(2 * HOUR), 'absolute');
+  assert.ok(result.startsWith('at '), `Expected "at " prefix, got: ${result}`);
+});
+
+test('absolute: returns a non-empty string for a future date', () => {
+  const result = formatResetTime(future(2 * HOUR), 'absolute');
+  assert.ok(result.length > 3, `Expected a non-trivial absolute string, got: ${result}`);
+});
+
+test('absolute: includes date component when reset is tomorrow or later', () => {
+  // Reset in 30 hours — guaranteed to be a different calendar day
+  const result = formatResetTime(future(30 * HOUR), 'absolute');
+  assert.ok(result.startsWith('at '), `Expected "at " prefix, got: ${result}`);
+  // Must contain a month abbreviation (Jan, Feb, …) to prove the date is included
+  assert.match(result, /at [A-Z][a-z]+ \d+/, `Expected month abbreviation in next-day reset, got: ${result}`);
+});
+
+// ---------------------------------------------------------------------------
+// both mode
+// ---------------------------------------------------------------------------
+
+test('both: contains the relative duration', () => {
+  const result = formatResetTime(future(2 * HOUR + 30 * MINUTE), 'both');
+  assert.match(result, /2h 30m/);
+});
+
+test('both: contains the absolute "at" part after a comma', () => {
+  const result = formatResetTime(future(2 * HOUR), 'both');
+  assert.match(result, /, at .+/);
+});
+
+test('both: format is "<relative>, <absolute>"', () => {
+  const result = formatResetTime(future(2 * HOUR), 'both');
+  // e.g. "2h, at 14:30" — comma avoids nested parens when caller wraps in (...)
+  assert.match(result, /^\d+h( \d+m)?, at .+$/);
+});
+
+// ---------------------------------------------------------------------------
+// config integration — mergeConfig accepts and validates timeFormat
+// ---------------------------------------------------------------------------
+
+test('mergeConfig defaults timeFormat to "relative"', async () => {
+  const { mergeConfig } = await import('../dist/config.js');
+  const config = mergeConfig({});
+  assert.equal(config.display.timeFormat, 'relative');
+});
+
+test('mergeConfig accepts "absolute" timeFormat', async () => {
+  const { mergeConfig } = await import('../dist/config.js');
+  const config = mergeConfig({ display: { timeFormat: 'absolute' } });
+  assert.equal(config.display.timeFormat, 'absolute');
+});
+
+test('mergeConfig accepts "both" timeFormat', async () => {
+  const { mergeConfig } = await import('../dist/config.js');
+  const config = mergeConfig({ display: { timeFormat: 'both' } });
+  assert.equal(config.display.timeFormat, 'both');
+});
+
+test('mergeConfig rejects invalid timeFormat and falls back to "relative"', async () => {
+  const { mergeConfig } = await import('../dist/config.js');
+  const config = mergeConfig({ display: { timeFormat: 'invalid-value' } });
+  assert.equal(config.display.timeFormat, 'relative');
+});

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1896,3 +1896,85 @@ test('renderSessionLine includes compact session token summary when enabled', ()
   const line = stripAnsi(renderSessionLine(ctx));
   assert.ok(line.includes('tok: 2k (in: 2k, out: 250)'), 'should include compact token summary');
 });
+
+// ---------------------------------------------------------------------------
+// display.timeFormat — absolute and both modes
+// ---------------------------------------------------------------------------
+
+test('renderUsageLine uses "resets in" preposition for default relative mode in bar-mode', () => {
+  const ctx = baseContext();
+  ctx.config.display.usageBarEnabled = true;
+  ctx.usageData = {
+    planName: 'Pro',
+    fiveHour: 45,
+    sevenDay: 20,
+    fiveHourResetAt: new Date(Date.now() + 2 * 60 * 60 * 1000),
+    sevenDayResetAt: null,
+  };
+  const plain = stripAnsi(renderUsageLine(ctx));
+  assert.ok(plain.includes('resets in'), `should use "resets in" for relative mode, got: ${plain}`);
+});
+
+test('renderUsageLine uses "resets at" when timeFormat is "absolute" (bar mode)', () => {
+  const ctx = baseContext();
+  ctx.config.display.usageBarEnabled = true;
+  ctx.config.display.timeFormat = 'absolute';
+  ctx.usageData = {
+    planName: 'Pro',
+    fiveHour: 45,
+    sevenDay: 20,
+    fiveHourResetAt: new Date(Date.now() + 2 * 60 * 60 * 1000),
+    sevenDayResetAt: null,
+  };
+  const plain = stripAnsi(renderUsageLine(ctx));
+  assert.ok(plain.includes('resets at'), `expected "resets at" in absolute bar mode, got: ${plain}`);
+  assert.ok(!plain.includes('resets in'), `should not say "resets in" for absolute mode, got: ${plain}`);
+});
+
+test('renderUsageLine shows relative and absolute time when timeFormat is "both"', () => {
+  const ctx = baseContext();
+  ctx.config.display.usageBarEnabled = false;
+  ctx.config.display.timeFormat = 'both';
+  ctx.usageData = {
+    planName: 'Pro',
+    fiveHour: 45,
+    sevenDay: 20,
+    fiveHourResetAt: new Date(Date.now() + 2 * 60 * 60 * 1000 + 30 * 60 * 1000),
+    sevenDayResetAt: null,
+  };
+  const plain = stripAnsi(renderUsageLine(ctx));
+  // "both" produces "Xh Ym, at HH:MM" — must contain relative part and " at " from i18n
+  assert.match(plain, /\dh/, 'should contain relative duration hours');
+  assert.ok(plain.includes(' at '), `should contain absolute "at" prefix, got: ${plain}`);
+  assert.ok(plain.includes('resets in'), `should use "resets in" preposition for both mode, got: ${plain}`);
+});
+
+test('renderUsageLine limit-reached uses "resets in" for default relative mode', () => {
+  const ctx = baseContext();
+  ctx.usageData = {
+    planName: 'Pro',
+    fiveHour: 100,
+    sevenDay: 45,
+    fiveHourResetAt: new Date(Date.now() + 2 * 60 * 60 * 1000),
+    sevenDayResetAt: null,
+  };
+  const plain = stripAnsi(renderUsageLine(ctx));
+  assert.ok(plain.includes('Limit reached'), 'should show limit reached');
+  assert.ok(plain.includes('resets in'), `should use "resets in" preposition for relative mode, got: ${plain}`);
+});
+
+test('renderUsageLine limit-reached uses "resets at" for absolute timeFormat', () => {
+  const ctx = baseContext();
+  ctx.config.display.timeFormat = 'absolute';
+  ctx.usageData = {
+    planName: 'Pro',
+    fiveHour: 100,
+    sevenDay: 45,
+    fiveHourResetAt: new Date(Date.now() + 2 * 60 * 60 * 1000),
+    sevenDayResetAt: null,
+  };
+  const plain = stripAnsi(renderUsageLine(ctx));
+  assert.ok(plain.includes('Limit reached'), 'should show limit reached');
+  assert.ok(plain.includes('resets at'), `should use "resets at" for absolute mode, got: ${plain}`);
+  assert.ok(!plain.includes('resets in'), `should not say "resets in" for absolute mode, got: ${plain}`);
+});

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1334,7 +1334,7 @@ test('renderUsageLine shows limit reset in days when >= 24 hours', () => {
   assert.ok(line, 'should render usage line');
   const plain = stripAnsi(line);
   assert.ok(plain.includes('Limit reached'), 'should show limit reached');
-  assert.ok(/resets \d+d( \d+h)?/.test(plain), `expected day/hour reset format, got: ${plain}`);
+  assert.ok(/resets in \d+d( \d+h)?/.test(plain), `expected day/hour reset format, got: ${plain}`);
   assert.ok(!plain.includes('151h'), `should avoid raw hour format for long durations: ${plain}`);
 });
 


### PR DESCRIPTION
## Summary

Closes #432

Adds a \`display.timeFormat\` config option that lets users choose how usage-window reset times appear in the HUD:

| Value | Example output |
|-------|---------------|
| \`"relative"\` (default — existing behaviour) | \`resets in 2h 30m\` |
| \`"absolute"\` | \`resets at 14:30\` / \`resets at Apr 13 14:30\` (different day) |
| \`"both"\` | \`resets in 2h 30m, at 14:30\` |

The absolute format uses \`toLocaleTimeString\` / \`toLocaleDateString\` so it respects the user's system locale and timezone automatically. The \`both\` mode uses a comma separator (not nested parentheses) to avoid doubled brackets when the caller wraps the reset in its own \`(...)\` parenthetical.

## Changes

- **\`src/config.ts\`** — new \`TimeFormatMode\` union type; \`display.timeFormat\` field with default \`'relative'\`; \`validateTimeFormat\` validator; wired into \`mergeConfig\`
- **\`src/render/format-reset-time.ts\`** _(new)_ — shared utility replacing the previously-duplicated \`formatResetTime\` in \`usage.ts\` and \`session-line.ts\`; uses \`t("format.at")\` so the "at" prefix is i18n-aware
- **\`src/i18n/types.ts\` / \`en.ts\` / \`zh.ts\`** — new \`"format.at"\` key (en: \`"at"\`, zh: \`""\` — zh omits the prefix since \`"重置于"\` already encodes the preposition)
- **\`src/render/lines/usage.ts\`** — removed private \`formatResetTime\`; threads \`timeFormat\` through \`formatUsageWindowPart\`; applies correct i18n preposition in both normal and limit-reached paths
- **\`src/render/session-line.ts\`** — same; bar mode preserves the upstream \`(duration / windowLabel)\` pattern for relative mode but switches to the preposition form for absolute/both (avoids incoherent \`at 14:30 / 5h\`)
- **\`tests/format-reset-time.test.js\`** _(new)_ — 18 unit tests covering all three modes, null/past guards, and \`mergeConfig\` validation
- **\`tests/render.test.js\`** — 5 new integration tests; updated one existing assertion that was written against the old (incorrect) limit-reached preposition

## Test plan

- [x] All existing tests pass (\`npm test\`)
- [x] 18 new unit tests for \`formatResetTime\` all pass
- [x] 5 new integration tests for \`renderUsageLine\` with each \`timeFormat\` mode pass
- [x] \`display.timeFormat: "relative"\` (default) produces identical output to before
- [x] \`display.timeFormat: "absolute"\` shows \`at HH:MM\` for same-day resets
- [x] \`display.timeFormat: "absolute"\` shows \`at Mon DD HH:MM\` for next-day resets
- [x] \`display.timeFormat: "both"\` shows \`Xh Ym, at HH:MM\`
- [x] Invalid \`timeFormat\` values fall back to \`"relative"\` silently
- [x] Limit-reached path uses correct preposition for each mode
- [x] zh locale: absolute mode renders \`重置于 14:30\` (no doubled preposition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)