### PR TITLE
fix: align progress-bar labels to equal visual width (fixes #437)

### DIFF
--- a/src/render/lines/identity.ts
+++ b/src/render/lines/identity.ts
@@ -7,6 +7,7 @@ import {
 import { coloredBar, label, getContextColor, RESET } from "../colors.js";
 import { getAdaptiveBarWidth } from "../../utils/terminal.js";
 import { t } from "../../i18n/index.js";
+import { paddedLabel } from "./label-align.js";
 
 const DEBUG =
   process.env.DEBUG?.includes("claude-hud") || process.env.DEBUG === "*";
@@ -31,8 +32,8 @@ export function renderIdentityLine(ctx: RenderContext): string {
 
   let line =
     display?.showContextBar !== false
-      ? `${label(t("label.context"), colors)} ${coloredBar(percent, getAdaptiveBarWidth(), colors)} ${contextValueDisplay}`
-      : `${label(t("label.context"), colors)} ${contextValueDisplay}`;
+      ? `${paddedLabel("label.context", colors)} ${coloredBar(percent, getAdaptiveBarWidth(), colors)} ${contextValueDisplay}`
+      : `${paddedLabel("label.context", colors)} ${contextValueDisplay}`;
 
   if (display?.showTokenBreakdown !== false && percent >= 85) {
     const usage = ctx.stdin.context_window?.current_usage;

--- a/src/render/lines/label-align.ts
+++ b/src/render/lines/label-align.ts
@@ -1,0 +1,74 @@
+import type { HudColorOverrides } from "../../config.js";
+import type { MessageKey } from "../../i18n/types.js";
+import { label } from "../colors.js";
+import { t } from "../../i18n/index.js";
+
+/** Label keys that should be aligned when rendered on separate lines. */
+const PROGRESS_LABEL_KEYS: MessageKey[] = [
+  "label.context",
+  "label.usage",
+  "label.weekly",
+];
+
+/**
+ * Compute the visual width of a plain-text string (no ANSI).
+ * CJK ideographs count as 2 cells; ASCII characters count as 1.
+ */
+function plainTextWidth(str: string): number {
+  let width = 0;
+  for (const char of str) {
+    const cp = char.codePointAt(0);
+    if (cp !== undefined && isWideCodePoint(cp)) {
+      width += 2;
+    } else {
+      width += 1;
+    }
+  }
+  return width;
+}
+
+function isWideCodePoint(codePoint: number): boolean {
+  return (
+    codePoint >= 0x1100 &&
+    (codePoint <= 0x115f ||
+      codePoint === 0x2329 ||
+      codePoint === 0x232a ||
+      (codePoint >= 0x2e80 && codePoint <= 0xa4cf && codePoint !== 0x303f) ||
+      (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+      (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+      (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+      (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+      (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+      (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+      (codePoint >= 0x1f300 && codePoint <= 0x1faff) ||
+      (codePoint >= 0x20000 && codePoint <= 0x3fffd))
+  );
+}
+
+/** Compute the max visual width across the three progress-bar labels. */
+function maxLabelWidth(): number {
+  let max = 0;
+  for (const key of PROGRESS_LABEL_KEYS) {
+    const w = plainTextWidth(t(key));
+    if (w > max) max = w;
+  }
+  return max;
+}
+
+/**
+ * Return a label whose visible text is right-padded to align with the widest
+ * progress-bar label in the current locale, then wrapped with the `label()`
+ * ANSI helper.
+ */
+export function paddedLabel(
+  key: MessageKey,
+  colors?: Partial<HudColorOverrides>,
+): string {
+  const text = t(key);
+  const pad = maxLabelWidth() - plainTextWidth(text);
+  const padded = pad > 0 ? text + " ".repeat(pad) : text;
+  return label(padded, colors);
+}
+
+// Exported for testing only.
+export { plainTextWidth as _plainTextWidth, maxLabelWidth as _maxLabelWidth };

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -1,9 +1,11 @@
 import type { RenderContext } from "../../types.js";
 import { isLimitReached } from "../../types.js";
+import type { MessageKey } from "../../i18n/types.js";
 import { getProviderLabel } from "../../stdin.js";
 import { critical, label, getQuotaColor, quotaBar, RESET } from "../colors.js";
 import { getAdaptiveBarWidth } from "../../utils/terminal.js";
 import { t } from "../../i18n/index.js";
+import { paddedLabel } from "./label-align.js";
 
 export function renderUsageLine(ctx: RenderContext): string | null {
   const display = ctx.config?.display;
@@ -21,7 +23,7 @@ export function renderUsageLine(ctx: RenderContext): string | null {
     return null;
   }
 
-  const usageLabel = label(t("label.usage"), colors);
+  const usageLabel = paddedLabel("label.usage", colors);
 
   if (isLimitReached(ctx.usageData)) {
     const resetTime =
@@ -47,6 +49,7 @@ export function renderUsageLine(ctx: RenderContext): string | null {
   if (fiveHour === null && sevenDay !== null) {
     const weeklyOnlyPart = formatUsageWindowPart({
       label: t("label.weekly"),
+      labelKey: "label.weekly",
       percent: sevenDay,
       resetAt: ctx.usageData.sevenDayResetAt,
       colors,
@@ -69,6 +72,7 @@ export function renderUsageLine(ctx: RenderContext): string | null {
   if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
     const sevenDayPart = formatUsageWindowPart({
       label: t("label.weekly"),
+      labelKey: "label.weekly",
       percent: sevenDay,
       resetAt: ctx.usageData.sevenDayResetAt,
       colors,
@@ -95,6 +99,7 @@ function formatUsagePercent(
 
 function formatUsageWindowPart({
   label: windowLabel,
+  labelKey,
   percent,
   resetAt,
   colors,
@@ -103,6 +108,7 @@ function formatUsageWindowPart({
   forceLabel = false,
 }: {
   label: string;
+  labelKey?: MessageKey;
   percent: number | null;
   resetAt: Date | null;
   colors?: RenderContext["config"]["colors"];
@@ -112,7 +118,9 @@ function formatUsageWindowPart({
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors);
   const reset = formatResetTime(resetAt);
-  const styledLabel = label(windowLabel, colors);
+  const styledLabel = labelKey
+    ? paddedLabel(labelKey, colors)
+    : label(windowLabel, colors);
 
   if (usageBarEnabled) {
     const body = reset

--- a/tests/label-align.test.js
+++ b/tests/label-align.test.js
@@ -1,0 +1,97 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { setLanguage } from "../dist/i18n/index.js";
+import {
+  paddedLabel,
+  _plainTextWidth,
+  _maxLabelWidth,
+} from "../dist/render/lines/label-align.js";
+
+// Strip ANSI escape sequences for content inspection.
+function stripAnsi(str) {
+  return str.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+test("plainTextWidth counts ASCII as 1 cell each", () => {
+  assert.equal(_plainTextWidth("Context"), 7);
+  assert.equal(_plainTextWidth("Usage"), 5);
+  assert.equal(_plainTextWidth("Weekly"), 6);
+});
+
+test("plainTextWidth counts CJK characters as 2 cells each", () => {
+  // 上下文 = 3 chars × 2 cells = 6
+  assert.equal(_plainTextWidth("上下文"), 6);
+  // 用量 = 2 chars × 2 cells = 4
+  assert.equal(_plainTextWidth("用量"), 4);
+  // 本周 = 2 chars × 2 cells = 4
+  assert.equal(_plainTextWidth("本周"), 4);
+});
+
+test("English labels are right-padded to equal visual width (7)", () => {
+  setLanguage("en");
+
+  // "Context" = 7 (max), no padding needed
+  // "Usage"   = 5, needs 2 spaces
+  // "Weekly"  = 6, needs 1 space
+  assert.equal(_maxLabelWidth(), 7);
+
+  const context = stripAnsi(paddedLabel("label.context"));
+  const usage = stripAnsi(paddedLabel("label.usage"));
+  const weekly = stripAnsi(paddedLabel("label.weekly"));
+
+  assert.equal(context, "Context");
+  assert.equal(usage, "Usage  ");
+  assert.equal(weekly, "Weekly ");
+
+  // All have the same visual width
+  assert.equal(_plainTextWidth(context), 7);
+  assert.equal(_plainTextWidth(usage), 7);
+  assert.equal(_plainTextWidth(weekly), 7);
+});
+
+test("Chinese labels are right-padded correctly (CJK awareness)", () => {
+  setLanguage("zh");
+
+  // 上下文 = 6 cells (max), 用量 = 4 cells, 本周 = 4 cells
+  assert.equal(_maxLabelWidth(), 6);
+
+  const context = stripAnsi(paddedLabel("label.context"));
+  const usage = stripAnsi(paddedLabel("label.usage"));
+  const weekly = stripAnsi(paddedLabel("label.weekly"));
+
+  // 上下文 needs no padding
+  assert.equal(context, "上下文");
+  // 用量 needs 2 spaces (6 - 4 = 2)
+  assert.equal(usage, "用量  ");
+  // 本周 needs 2 spaces (6 - 4 = 2)
+  assert.equal(weekly, "本周  ");
+
+  // All have the same visual width
+  assert.equal(_plainTextWidth(context), 6);
+  assert.equal(_plainTextWidth(usage), 6);
+  assert.equal(_plainTextWidth(weekly), 6);
+
+  // Restore
+  setLanguage("en");
+});
+
+test("paddedLabel output includes trailing spaces for shorter labels", () => {
+  setLanguage("en");
+
+  const usage = stripAnsi(paddedLabel("label.usage"));
+  const weekly = stripAnsi(paddedLabel("label.weekly"));
+
+  // "Usage" gets 2 trailing spaces, "Weekly" gets 1
+  assert.ok(usage.endsWith("  "), `Expected trailing spaces in "${usage}"`);
+  assert.ok(weekly.endsWith(" "), `Expected trailing space in "${weekly}"`);
+});
+
+test("paddedLabel wraps text with ANSI dim codes", () => {
+  setLanguage("en");
+
+  const result = paddedLabel("label.context");
+  // Should contain ANSI escape sequences (dim + reset)
+  assert.ok(result.includes("\x1b["), "Expected ANSI escape codes in output");
+  // The visible text should be "Context" with no padding (it's the widest)
+  assert.equal(stripAnsi(result), "Context");
+});

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -554,7 +554,7 @@ test('label color overrides apply across shared secondary text surfaces', () => 
 
   const expected = '\x1b[38;2;171;205;239m';
   assert.ok(renderIdentityLine(ctx).includes(`${expected}Context\x1b[0m`));
-  assert.ok(renderUsageLine(ctx)?.includes(`${expected}Usage\x1b[0m`));
+  assert.ok(renderUsageLine(ctx)?.includes(`${expected}Usage  \x1b[0m`));
   assert.ok(renderEnvironmentLine(ctx)?.includes(`${expected}2 CLAUDE.md | 1 rules\x1b[0m`));
   assert.ok(renderMemoryLine({ ...ctx, config: { ...ctx.config, lineLayout: 'expanded', display: { ...ctx.config.display, showMemoryUsage: true } } })?.includes(`${expected}Approx RAM\x1b[0m`));
   assert.ok(renderToolsLine(ctx)?.includes(`${expected}: src/index.ts\x1b[0m`));
@@ -1240,7 +1240,7 @@ test('renderUsageLine shows 7d reset countdown in text-only mode', () => {
 
   const line = stripAnsi(renderUsageLine(ctx));
   assert.ok(line.includes('5h 45%'), `should include 5h text-only usage: ${line}`);
-  assert.ok(line.includes('Weekly 85%'), `should include 7d text-only usage: ${line}`);
+  assert.ok(line.includes('Weekly  85%'), `should include 7d text-only usage: ${line}`);
   assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in text-only mode: ${line}`);
 });
 


### PR DESCRIPTION
## Summary

When Context, Usage, and Weekly lines wrap to separate rows on narrow terminals, their progress bars don't align vertically because label widths differ (`Context`=7, `Usage`=5, `Weekly`=6 in English; `上下文`=6, `用量`=4, `本周`=4 cells in Chinese).

This adds a shared `paddedLabel()` helper that pads each label with trailing spaces to the max visual width, accounting for CJK double-width characters.

**Before:**
```
Context █░░░░░░░░░ 7%
Usage ███░░░░░░░ 33% (resets in 1h 28m)
Weekly ██░░░░░░░░ 21% (resets in 4d 1h)
```

**After:**
```
Context █░░░░░░░░░ 7%
Usage   ███░░░░░░░ 33% (resets in 1h 28m)
Weekly  ██░░░░░░░░ 21% (resets in 4d 1h)
```

## Changes

- **`src/render/lines/label-align.ts`** (new): `paddedLabel(key, colors)` computes the max visual width of Context/Usage/Weekly labels and pads shorter labels with spaces before wrapping with `label()`. CJK-aware width calculation.
- **`src/render/lines/identity.ts`**: Use `paddedLabel('label.context')` instead of `label(t('label.context'))`.
- **`src/render/lines/usage.ts`**: Use `paddedLabel('label.usage')` and `paddedLabel('label.weekly')` instead of raw `label()` calls.
- **`tests/label-align.test.js`**: 6 tests covering English/Chinese alignment, CJK width, trailing spaces, and ANSI wrapping.

## Testing

359 tests total, 357 pass, 1 pre-existing upstream failure (`countConfigs cache`), 1 skipped. All new tests pass.

Closes #437