### PR TITLE
fix: show usage and cost for enterprise plan model aliases

### DIFF
--- a/src/cost.ts
+++ b/src/cost.ts
@@ -1,5 +1,5 @@
 import type { SessionTokenUsage, StdinData } from './types.js';
-import { getProviderLabel } from './stdin.js';
+import { isBedrockModelId } from './stdin.js';
 
 type ModelPricing = {
   inputUsdPerMillion: number;
@@ -29,6 +29,10 @@ const ANTHROPIC_MODEL_PRICING: Array<{ pattern: RegExp; pricing: ModelPricing }>
   { pattern: /\bsonnet 3 7\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
   { pattern: /\bsonnet 3 5\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
   { pattern: /\bhaiku 3 5\b/i, pricing: { inputUsdPerMillion: 0.8, outputUsdPerMillion: 4 } },
+  // Enterprise plan aliases (e.g. opusplan, sonnetplan, haikuplan)
+  { pattern: /\bopusplan\b/i, pricing: { inputUsdPerMillion: 15, outputUsdPerMillion: 75 } },
+  { pattern: /\bsonnetplan\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
+  { pattern: /\bhaikuplan\b/i, pricing: { inputUsdPerMillion: 0.8, outputUsdPerMillion: 4 } },
 ];
 
 function normalizeModelName(modelName: string): string {
@@ -83,7 +87,7 @@ export function estimateSessionCost(
     return null;
   }
 
-  if (getProviderLabel(stdin)) {
+  if (isBedrockModelId(stdin.model?.id)) {
     return null;
   }
 
@@ -120,7 +124,7 @@ function getNativeCostUsd(stdin: StdinData): number | null {
     return null;
   }
 
-  if (getProviderLabel(stdin)) {
+  if (isBedrockModelId(stdin.model?.id)) {
     return null;
   }
 

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -1,7 +1,7 @@
 import type { RenderContext } from "../../types.js";
 import { isLimitReached } from "../../types.js";
 import type { MessageKey } from "../../i18n/types.js";
-import { getProviderLabel } from "../../stdin.js";
+import { isBedrockModelId } from "../../stdin.js";
 import { critical, label, getQuotaColor, quotaBar, RESET } from "../colors.js";
 import { getAdaptiveBarWidth } from "../../utils/terminal.js";
 import { t } from "../../i18n/index.js";
@@ -24,7 +24,7 @@ export function renderUsageLine(
     return null;
   }
 
-  if (getProviderLabel(ctx.stdin)) {
+  if (isBedrockModelId(ctx.stdin.model?.id)) {
     return null;
   }
 

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -202,6 +202,13 @@ export function getBufferedPercent(stdin: StdinData): number {
   return Math.min(100, Math.round(((totalTokens + buffer) / size) * 100));
 }
 
+// Enterprise plan alias → human-readable display name
+const ENTERPRISE_ALIAS_LABELS: Record<string, string> = {
+  opusplan: 'Claude Opus',
+  sonnetplan: 'Claude Sonnet',
+  haikuplan: 'Claude Haiku',
+};
+
 export function getModelName(stdin: StdinData): string {
   const displayName = stdin.model?.display_name?.trim();
   if (displayName) {
@@ -211,6 +218,12 @@ export function getModelName(stdin: StdinData): string {
   const modelId = stdin.model?.id?.trim();
   if (!modelId) {
     return 'Unknown';
+  }
+
+  // Resolve enterprise plan aliases to readable labels
+  const enterpriseLabel = ENTERPRISE_ALIAS_LABELS[modelId.toLowerCase()];
+  if (enterpriseLabel) {
+    return enterpriseLabel;
   }
 
   const normalizedBedrockLabel = normalizeBedrockModelLabel(modelId);
@@ -225,9 +238,21 @@ export function isBedrockModelId(modelId?: string): boolean {
   return normalized.includes('anthropic.claude-');
 }
 
+const ENTERPRISE_MODEL_IDS = new Set(['opusplan', 'sonnetplan', 'haikuplan']);
+
+export function isEnterpriseModelId(modelId?: string): boolean {
+  if (!modelId) {
+    return false;
+  }
+  return ENTERPRISE_MODEL_IDS.has(modelId.toLowerCase());
+}
+
 export function getProviderLabel(stdin: StdinData): string | null {
   if (process.env.CLAUDE_CODE_USE_BEDROCK === '1') {
     return 'Bedrock';
+  }
+  if (isEnterpriseModelId(stdin.model?.id)) {
+    return 'Enterprise';
   }
   return null;
 }


### PR DESCRIPTION
## Problem

Enterprise Claude Code accounts use model IDs like `opusplan`, `sonnetplan`, and `haikuplan` instead of standard model names. With these model IDs, **usage and cost are completely hidden** in the statusline.

**Root cause:** `getProviderLabel()` returns a truthy value (`'Enterprise'`) for these model IDs, and all three display paths check `if (getProviderLabel(stdin))` to suppress output — the same condition used for Bedrock, which genuinely cannot report usage.

## Changes

- **`src/render/lines/usage.ts`** — narrow hide condition from `getProviderLabel()` to `isBedrockModelId()` so enterprise plans are no longer suppressed
- **`src/cost.ts`** — same fix for cost estimation paths; add enterprise alias entries to `ANTHROPIC_MODEL_PRICING` (`opusplan`, `sonnetplan`, `haikuplan`)
- **`src/stdin.ts`** — add `isEnterpriseModelId()` helper, readable label mapping (`opusplan` → `Claude Opus`, etc.), and update `getProviderLabel()` to return `'Enterprise'` for display purposes without suppressing usage

## Behavior after fix

| Model ID | Usage shown | Cost shown | Model label |
|---|---|---|---|
| `opusplan` | ✅ | ✅ | Claude Opus |
| `sonnetplan` | ✅ | ✅ | Claude Sonnet |
| `haikuplan` | ✅ | ✅ | Claude Haiku |
| Bedrock | ❌ (unchanged) | ❌ (unchanged) | Bedrock |