### PR TITLE
feat: opt-in per-component token breakdown line (display.showCostBreakdown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Opt-in `display.showCostBreakdown` adds a dedicated per-component token line, e.g. `7k in · 607k out · 2.5M cw · 88M cr`. Counts come from the same `transcript.sessionTokens` accumulator that already powers `display.showSessionTokens` and the merged `display.showCost`. Hidden when session tokens are missing or all zero. Token-only — no dollar figure on this line, so there's no risk of disagreeing with the cost line above when that line is using Claude Code's native `cost.total_cost_usd`.
+
 ## [0.0.12] - 2026-04-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.contextValue` | `percent` \| `tokens` \| `remaining` \| `both` | `percent` | Context display format (`45%`, `45k/200k`, `55%` remaining, or `45% (45k/200k)`) |
 | `display.showConfigCounts` | boolean | false | Show CLAUDE.md, rules, MCPs, hooks counts |
 | `display.showCost` | boolean | false | Show session cost using Claude Code's native `cost.total_cost_usd` when available, with a local estimate fallback for direct Anthropic sessions |
+| `display.showCostBreakdown` | boolean | false | Show a separate session-token breakdown line with cumulative input, output, cache write, and cache read counts (e.g. `7k in · 607k out · 2.5M cw · 88M cr`) |
 | `display.showOutputStyle` | boolean | false | Show the active Claude Code `outputStyle` from settings files as `style: <name>` |
 | `display.showDuration` | boolean | false | Show session duration `⏱️ 5m` |
 | `display.showSpeed` | boolean | false | Show output token speed `out: 42.1 tok/s` |

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,6 +79,7 @@ export interface HudConfig {
     contextValue: ContextValueMode;
     showConfigCounts: boolean;
     showCost: boolean;
+    showCostBreakdown: boolean;
     showDuration: boolean;
     showSpeed: boolean;
     showTokenBreakdown: boolean;
@@ -124,6 +125,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     contextValue: 'percent',
     showConfigCounts: false,
     showCost: false,
+    showCostBreakdown: false,
     showDuration: false,
     showSpeed: false,
     showTokenBreakdown: true,
@@ -332,6 +334,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showCost: typeof migrated.display?.showCost === 'boolean'
       ? migrated.display.showCost
       : DEFAULT_CONFIG.display.showCost,
+    showCostBreakdown: typeof migrated.display?.showCostBreakdown === 'boolean'
+      ? migrated.display.showCostBreakdown
+      : DEFAULT_CONFIG.display.showCostBreakdown,
     showDuration: typeof migrated.display?.showDuration === 'boolean'
       ? migrated.display.showDuration
       : DEFAULT_CONFIG.display.showDuration,

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -20,6 +20,8 @@ export const en: Messages = {
   "format.resetsIn": "resets in",
   "format.in": "in",
   "format.cache": "cache",
+  "format.cacheWrite": "cw",
+  "format.cacheRead": "cr",
   "format.out": "out",
   "format.tokPerSec": "tok/s",
 

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -16,6 +16,8 @@ export type MessageKey =
   | "format.resetsIn"
   | "format.in"
   | "format.cache"
+  | "format.cacheWrite"
+  | "format.cacheRead"
   | "format.out"
   | "format.tokPerSec"
   // Init

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -20,6 +20,8 @@ export const zh: Messages = {
   "format.resetsIn": "重置剩余",
   "format.in": "输入",
   "format.cache": "缓存",
+  "format.cacheWrite": "写入",
+  "format.cacheRead": "读取",
   "format.out": "输出",
   "format.tokPerSec": "tok/s",
 

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -13,6 +13,7 @@ import {
   renderUsageLine,
   renderMemoryLine,
   renderSessionTokensLine,
+  renderCostBreakdownLine,
 } from './lines/index.js';
 import { dim, RESET } from './colors.js';
 import { UNKNOWN_TERMINAL_WIDTH } from '../utils/terminal.js';
@@ -445,6 +446,19 @@ export function render(ctx: RenderContext): void {
 
   if (lineLayout === 'expanded') {
     const renderedLines = renderExpanded(ctx, terminalWidth);
+
+    // Cost breakdown sits with the meta block (context/usage/memory) — insert
+    // before the first activity line so it's adjacent to the cost line above
+    // instead of orphaned at the bottom of the HUD.
+    if (ctx.config?.display?.showCostBreakdown) {
+      const costBreakdownLine = renderCostBreakdownLine(ctx);
+      if (costBreakdownLine) {
+        const firstActivityIndex = renderedLines.findIndex(({ isActivity }) => isActivity);
+        const insertAt = firstActivityIndex >= 0 ? firstActivityIndex : renderedLines.length;
+        renderedLines.splice(insertAt, 0, { line: costBreakdownLine, isActivity: false });
+      }
+    }
+
     lines = renderedLines.map(({ line }) => line);
 
     // Session token usage (cumulative)

--- a/src/render/lines/cost-breakdown.ts
+++ b/src/render/lines/cost-breakdown.ts
@@ -1,0 +1,41 @@
+import type { RenderContext, SessionTokenUsage } from '../../types.js';
+import { t } from '../../i18n/index.js';
+import { label } from '../colors.js';
+
+function formatTokens(n: number): string {
+  if (n >= 1000000) {
+    return `${(n / 1000000).toFixed(1)}M`;
+  }
+  if (n >= 1000) {
+    return `${(n / 1000).toFixed(0)}k`;
+  }
+  return n.toString();
+}
+
+function formatBreakdown(tokens: SessionTokenUsage): string {
+  const parts = [
+    `${formatTokens(tokens.inputTokens)} ${t('format.in')}`,
+    `${formatTokens(tokens.outputTokens)} ${t('format.out')}`,
+    `${formatTokens(tokens.cacheCreationTokens)} ${t('format.cacheWrite')}`,
+    `${formatTokens(tokens.cacheReadTokens)} ${t('format.cacheRead')}`,
+  ];
+  return parts.join(' · ');
+}
+
+export function renderCostBreakdownLine(ctx: RenderContext): string | null {
+  if (ctx.config?.display?.showCostBreakdown !== true) {
+    return null;
+  }
+  const tokens = ctx.transcript.sessionTokens;
+  if (!tokens) {
+    return null;
+  }
+  const total = tokens.inputTokens
+    + tokens.outputTokens
+    + tokens.cacheCreationTokens
+    + tokens.cacheReadTokens;
+  if (total === 0) {
+    return null;
+  }
+  return label(formatBreakdown(tokens), ctx.config?.colors);
+}

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -4,3 +4,4 @@ export { renderEnvironmentLine } from './environment.js';
 export { renderUsageLine } from './usage.js';
 export { renderMemoryLine } from './memory.js';
 export { renderSessionTokensLine } from './session-tokens.js';
+export { renderCostBreakdownLine } from './cost-breakdown.js';

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -14,6 +14,7 @@ import { renderMemoryLine } from '../dist/render/lines/memory.js';
 import { renderIdentityLine } from '../dist/render/lines/identity.js';
 import { renderEnvironmentLine } from '../dist/render/lines/environment.js';
 import { renderSessionTokensLine } from '../dist/render/lines/session-tokens.js';
+import { renderCostBreakdownLine } from '../dist/render/lines/cost-breakdown.js';
 import { getContextColor, getQuotaColor } from '../dist/render/colors.js';
 import { setLanguage } from '../dist/i18n/index.js';
 
@@ -1841,6 +1842,53 @@ test('renderSessionTokensLine renders cumulative session token totals', () => {
 
   const line = stripAnsi(renderSessionTokensLine(ctx) ?? '');
   assert.equal(line, 'Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)');
+});
+
+test('renderCostBreakdownLine returns null when disabled', () => {
+  const ctx = baseContext();
+  ctx.transcript.sessionTokens = { inputTokens: 1000, outputTokens: 200, cacheCreationTokens: 3000, cacheReadTokens: 400 };
+  assert.equal(renderCostBreakdownLine(ctx), null);
+});
+
+test('renderCostBreakdownLine returns null when session tokens are missing', () => {
+  const ctx = baseContext();
+  ctx.config.display.showCostBreakdown = true;
+  assert.equal(renderCostBreakdownLine(ctx), null);
+});
+
+test('renderCostBreakdownLine returns null when all token counts are zero', () => {
+  const ctx = baseContext();
+  ctx.config.display.showCostBreakdown = true;
+  ctx.transcript.sessionTokens = { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 };
+  assert.equal(renderCostBreakdownLine(ctx), null);
+});
+
+test('renderCostBreakdownLine renders compact value-first breakdown for estimate-source sessions', () => {
+  const ctx = baseContext();
+  ctx.stdin.model = { display_name: 'Opus 4.6', id: 'claude-opus-4-6' };
+  ctx.config.display.showCostBreakdown = true;
+  ctx.transcript.sessionTokens = { inputTokens: 12000, outputTokens: 4000, cacheCreationTokens: 9000, cacheReadTokens: 88000 };
+  const line = stripAnsi(renderCostBreakdownLine(ctx) ?? '');
+  assert.equal(line, '12k in · 4k out · 9k cw · 88k cr');
+});
+
+test('renderCostBreakdownLine still renders for unknown-pricing sessions (counts only, no cost reconciliation needed)', () => {
+  const ctx = baseContext();
+  ctx.stdin.model = { display_name: 'Mystery Model', id: 'anthropic.claude-unknown-v9:0' };
+  ctx.config.display.showCostBreakdown = true;
+  ctx.transcript.sessionTokens = { inputTokens: 100, outputTokens: 50, cacheCreationTokens: 0, cacheReadTokens: 0 };
+  const line = stripAnsi(renderCostBreakdownLine(ctx) ?? '');
+  assert.equal(line, '100 in · 50 out · 0 cw · 0 cr');
+});
+
+test('renderCostBreakdownLine renders alongside a native cost.total_cost_usd (token counts can\'t mismatch)', () => {
+  const ctx = baseContext();
+  ctx.stdin.model = { display_name: 'Opus 4.6', id: 'claude-opus-4-6' };
+  ctx.stdin.cost = { total_cost_usd: 1.42 };
+  ctx.config.display.showCostBreakdown = true;
+  ctx.transcript.sessionTokens = { inputTokens: 12000, outputTokens: 4000, cacheCreationTokens: 9000, cacheReadTokens: 88000 };
+  const line = stripAnsi(renderCostBreakdownLine(ctx) ?? '');
+  assert.equal(line, '12k in · 4k out · 9k cw · 88k cr');
 });
 
 test('renderSessionLine includes compact session token summary when enabled', () => {


### PR DESCRIPTION
I've been running claude-hud daily since `display.showCost` shipped. The single dollar number is great when I just want a glance, but on long sessions where the bill is climbing I keep wanting to know *why* — was it output dominance, or did my prompt cache stop hitting? Right now I leave the terminal and run ccusage to find out, which kind of defeats having an always-on HUD.

So this adds a separate opt-in line below the cost line:

```
Cost $15.11
7k in · 607k out · 2.5M cw · 88M cr
```

Token-only on purpose. The dollar figure stays where it already lives, and this line shows the cumulative session counts from the same `transcript.sessionTokens` accumulator that already powers `display.showSessionTokens` and the merged cost line. Compact, value-first labels mean it fits in narrow terminals where the existing `Tokens X (in: …, out: …, cache: …)` line truncates.

I read the close notes on #358 and #304 carefully before writing this, and tried to stay strictly on the side of "raw pass-through, no heuristic interpretation." Things I deliberately didn't do:

- No per-query / per-turn delta tracking — needs a query-boundary heuristic
- No hourly burn rate — same problem
- No composite efficiency colors — your point about not changing the meaning of existing colors landed
- No reclaimable estimate
- No dollar figure on this new line — token counts come from the same source Claude Code itself uses for billing, but mixing in a locally-derived `$` next to a native `cost.total_cost_usd` is exactly the trust mismatch you flagged in #358

Splitting cache write vs cache read is the part I personally find most useful — for an Opus 4 session at $15/$75 per million, output dominates most bills, but a cache-hit dropoff is usually what makes a "fine" session suddenly expensive, and the existing `cache: 12.8M` aggregated label hides that.

The line lives in its own file (`src/render/lines/cost-breakdown.ts`) and is wired into the expanded layout next to where `renderSessionTokensLine` is already pushed.

### Tests

7 new tests in `tests/render.test.js`. They cover: disabled, missing transcript, all-zero counts, full render with known model, render for unknown-pricing models (just counts, no dollars to disagree with), render alongside a native `cost.total_cost_usd` (token counts can't mismatch since they come from the same upstream).

`npm test`: 358 pass, 1 skipped (the one that's also skipped on `main`), 0 fail. `npm run build` clean.

### Smoke test

Built locally, dropped into `~/.claude/plugins/cache/claude-hud/claude-hud/0.0.13/`, enabled `showCost` and `showCostBreakdown` in `~/.claude/plugins/claude-hud/config.json`, ran the actual `statusLine` command from `settings.json` against a 91M-token session transcript:

```
[Opus 4.6] │ shiplab git:(master ↑43)
⏱️  49h │ Cost $15.11
Context ██████░░░░ 60%
…
7k in · 607k out · 2.5M cw · 78.7M cr
```

Both lines fit, no truncation.

### Note on duplication

`formatTokens` is now the 4th copy in the codebase (the others live in `session-tokens.ts`, `session-line.ts`, and `identity.ts`). Happy to extract to a shared util in this PR or leave that for a separate cleanup PR — your call. I left it duplicated here to keep the diff narrow.