### PR TITLE
fix(render): move speed field after cost to stabilize HUD layout

### DIFF
--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -85,13 +85,6 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     parts.push(label(ctx.extraLabel, colors));
   }
 
-  if (display?.showSpeed) {
-    const speed = getOutputSpeed(ctx.stdin);
-    if (speed !== null) {
-      parts.push(label(`${t('format.out')}: ${speed.toFixed(1)} ${t('format.tokPerSec')}`, colors));
-    }
-  }
-
   if (display?.showDuration !== false && ctx.sessionDuration) {
     parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
   }
@@ -99,6 +92,13 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   const costEstimate = renderCostEstimate(ctx);
   if (costEstimate) {
     parts.push(costEstimate);
+  }
+
+  if (display?.showSpeed) {
+    const speed = getOutputSpeed(ctx.stdin);
+    if (speed !== null) {
+      parts.push(label(`${t('format.out')}: ${speed.toFixed(1)} ${t('format.tokPerSec')}`, colors));
+    }
   }
 
   const customLine = display?.customLine;

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -207,14 +207,6 @@ export function renderSessionLine(ctx: RenderContext): string {
     }
   }
 
-  // Session duration
-  if (display?.showSpeed) {
-    const speed = getOutputSpeed(ctx.stdin);
-    if (speed !== null) {
-      parts.push(label(`${t('format.out')}: ${speed.toFixed(1)} ${t('format.tokPerSec')}`, colors));
-    }
-  }
-
   if (display?.showDuration !== false && ctx.sessionDuration) {
     parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
   }
@@ -222,6 +214,13 @@ export function renderSessionLine(ctx: RenderContext): string {
   const costEstimate = renderCostEstimate(ctx);
   if (costEstimate) {
     parts.push(costEstimate);
+  }
+
+  if (display?.showSpeed) {
+    const speed = getOutputSpeed(ctx.stdin);
+    if (speed !== null) {
+      parts.push(label(`${t('format.out')}: ${speed.toFixed(1)} ${t('format.tokPerSec')}`, colors));
+    }
   }
 
   if (ctx.extraLabel) {


### PR DESCRIPTION
## Problem

The output speed indicator (`out: N tok/s`) is transient — it only renders while stdin is actively streaming output and disappears once the turn ends.

Currently it renders between the git status and the duration/cost fields:

```
[Opus] │ shiplab git:(master) │ out: 42.1 tok/s │ ⏱️  11m │ Cost $2.42
                                └─ appears/disappears each turn ─┘
```

Because the field appears and disappears mid-line, the elements to its right (duration, cost) reflow horizontally on every turn. The jitter is especially noticeable in the expanded layout where this is the only line that shifts.

## Fix

Move the `showSpeed` render block to the end of the line, after cost (and before `customLine`). The transient field now only appends/disappears at the tail, leaving all stable elements in place.

```
[Opus] │ shiplab git:(master) │ ⏱️  11m │ Cost $2.42 │ out: 42.1 tok/s
                                                     └─ transient tail ─┘
```

Applied to both:
- `renderProjectLine` (expanded layout) — `src/render/lines/project.ts`
- `renderSessionLine` (compact layout) — `src/render/session-line.ts`

Also dropped an outdated `// Session duration` comment that was sitting above the speed block.

## Test plan

- [x] `npm test` — 352 pass, 0 fail, 1 skipped (unchanged)
- [x] Manually verified in both expanded and compact layouts: speed field only appears at end of line during output, duration/cost positions stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)