### PR TITLE
fix: UNKNOWN_TERMINAL_WIDTH fallback of 40 wraps status line to multiple lines

### DIFF
--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -1,4 +1,4 @@
-export const UNKNOWN_TERMINAL_WIDTH = 40;
+export const UNKNOWN_TERMINAL_WIDTH = 220;
 
 // Returns a progress bar width scaled to the current terminal width.
 // Wide (>=100): 10, Medium (60-99): 6, Narrow (<60): 4.


### PR DESCRIPTION
Fixes #436. Changed `UNKNOWN_TERMINAL_WIDTH` fallback from 40 to 220 so the status line doesn't wrap on terminals where width detection fails.

## What changed

When Claude Code runs the statusline as a subprocess, `process.stdout.columns` and `process.stderr.columns` are both unavailable (piped), so `getTerminalWidth()` falls back to `UNKNOWN_TERMINAL_WIDTH`. At 40 columns, virtually every status line gets wrapped into 3+ lines. Changed to 220 — wide enough to avoid wrapping on any realistic terminal, while still providing an upper bound for `wrapLineToWidth()`.

## Test plan

- [x] Build passes (`tsc`)
- [x] All terminal-related tests pass
- [x] Full test suite: 330 pass (23 pre-existing platform failures unrelated to this change)

I maintain [PRISM](https://github.com/jakeefr/prism), a post-session diagnostics tool for Claude Code — CLAUDE.md adherence analysis and session health scoring from the same JSONL files. claude-hud does real-time visibility, PRISM does post-session forensics — complementary tools.