### PR TITLE
fix: version cache never invalidates when Claude Code updates in-place

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -223,15 +223,24 @@ export async function getClaudeCodeVersion(): Promise<string | undefined> {
       && cachedBinaryInfo.path === diskCache.binaryPath
       && cachedBinaryInfo.mtimeMs === diskCache.binaryMtimeMs
     ) {
-      const cachedKey = getBinaryCacheKey(cachedBinaryInfo);
-      if (hasResolved && cachedBinaryKey === cachedKey) {
+      // Also verify the symlink still resolves to the same binary.
+      // Claude Code updates by re-pointing the symlink to a new binary
+      // without deleting the old one, so the cached resolved path stays
+      // valid on disk even after an update. Fixes #429.
+      const currentBinary = resolveClaudeBinaryImpl();
+      if (currentBinary && currentBinary.path !== diskCache.binaryPath) {
+        // Symlink now points to a different binary — fall through to re-resolve.
+      } else {
+        const cachedKey = getBinaryCacheKey(cachedBinaryInfo);
+        if (hasResolved && cachedBinaryKey === cachedKey) {
+          return cachedVersion;
+        }
+
+        cachedBinaryKey = cachedKey;
+        cachedVersion = diskCache.version ?? undefined;
+        hasResolved = true;
         return cachedVersion;
       }
-
-      cachedBinaryKey = cachedKey;
-      cachedVersion = diskCache.version ?? undefined;
-      hasResolved = true;
-      return cachedVersion;
     }
   }
 

--- a/tests/version.test.js
+++ b/tests/version.test.js
@@ -99,9 +99,10 @@ test('getClaudeCodeVersion persists cache across process resets under CLAUDE_CON
 
     _resetVersionCache();
     resolveCalls = 0;
+    // Resolver is called on cache hit to verify symlink target hasn't changed (#429)
     _setResolveClaudeBinaryForTests(() => {
       resolveCalls += 1;
-      throw new Error('should not rescan PATH when disk cache is valid');
+      return { path: binaryPath, mtimeMs: binaryMtimeMs };
     });
     _setExecFileImplForTests(async () => {
       throw new Error('should not shell out when disk cache is valid');
@@ -110,7 +111,51 @@ test('getClaudeCodeVersion persists cache across process resets under CLAUDE_CON
     const second = await getClaudeCodeVersion();
     assert.equal(second, '2.2.0-beta.1+abc123');
     assert.equal(execCalls, 1);
-    assert.equal(resolveCalls, 0);
+    assert.equal(resolveCalls, 1);
+  } finally {
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('getClaudeCodeVersion invalidates cache when symlink target changes (#429)', async () => {
+  const tempHome = await mkdtemp(path.join(tmpdir(), 'claude-hud-version-symlink-'));
+  const customConfigDir = path.join(tempHome, '.claude-alt');
+  const oldBinaryPath = path.join(tempHome, 'claude-old');
+  const newBinaryPath = path.join(tempHome, 'claude-new');
+  const originalHome = process.env.HOME;
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  let execCalls = 0;
+  const binaryMtimeMs = 1710000000000;
+
+  process.env.HOME = tempHome;
+  process.env.CLAUDE_CONFIG_DIR = customConfigDir;
+  await writeFile(oldBinaryPath, '#!/bin/sh\n', 'utf8');
+  await writeFile(newBinaryPath, '#!/bin/sh\n', 'utf8');
+  utimesSync(oldBinaryPath, binaryMtimeMs / 1000, binaryMtimeMs / 1000);
+  utimesSync(newBinaryPath, binaryMtimeMs / 1000, binaryMtimeMs / 1000);
+
+  let currentResolvedPath = oldBinaryPath;
+
+  try {
+    _setResolveClaudeBinaryForTests(() => ({ path: currentResolvedPath, mtimeMs: binaryMtimeMs }));
+    _setExecFileImplForTests(async () => {
+      execCalls += 1;
+      return { stdout: execCalls === 1 ? '2.1.97 (Claude Code)\n' : '2.1.104 (Claude Code)\n' };
+    });
+
+    const first = await getClaudeCodeVersion();
+    assert.equal(first, '2.1.97');
+    assert.equal(execCalls, 1);
+
+    // Simulate CC update: symlink now points to new binary, old binary still exists
+    _resetVersionCache();
+    currentResolvedPath = newBinaryPath;
+
+    const second = await getClaudeCodeVersion();
+    assert.equal(second, '2.1.104');
+    assert.equal(execCalls, 2);
   } finally {
     restoreEnvVar('HOME', originalHome);
     restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);


### PR DESCRIPTION
Fixes #429. Version cache was storing the resolved symlink path but never checking if the symlink target had changed. Added symlink stat comparison on cache hit so the version updates correctly when Claude Code updates in-place.

I maintain PRISM (https://github.com/jakeefr/prism), a post-session diagnostics tool for Claude Code — CLAUDE.md adherence analysis and session health scoring. Fixed this since I use claude-hud daily alongside PRISM.