### PR TITLE
fix(cost): add Claude Haiku 4.x pricing

### DIFF
--- a/src/cost.ts
+++ b/src/cost.ts
@@ -23,11 +23,15 @@ const TOKENS_PER_MILLION = 1_000_000;
 const CACHE_WRITE_MULTIPLIER = 1.25;
 const CACHE_READ_MULTIPLIER = 0.1;
 
+// Patterns are tried in order; the first match wins. Families with more specific
+// model lines (Haiku 4.x differs from Haiku 3.5) must come before any broader
+// fallback patterns to avoid silent under-pricing.
 const ANTHROPIC_MODEL_PRICING: Array<{ pattern: RegExp; pricing: ModelPricing }> = [
   { pattern: /\bopus 4(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 15, outputUsdPerMillion: 75 } },
   { pattern: /\bsonnet 4(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
   { pattern: /\bsonnet 3 7\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
   { pattern: /\bsonnet 3 5\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
+  { pattern: /\bhaiku 4(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 1, outputUsdPerMillion: 5 } },
   { pattern: /\bhaiku 3 5\b/i, pricing: { inputUsdPerMillion: 0.8, outputUsdPerMillion: 4 } },
 ];
 

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -426,6 +426,31 @@ test('estimateSessionCost still calculates transcript-based Anthropic pricing', 
   assert.equal(formatUsd(estimate.totalUsd), '$1.09');
 });
 
+test('estimateSessionCost prices Claude Haiku 4.5 (and future 4.x minors)', () => {
+  const tokens = {
+    inputTokens: 1_000_000,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    outputTokens: 100_000,
+  };
+
+  const haiku45 = estimateSessionCost({ model: { display_name: 'Claude Haiku 4.5' } }, tokens);
+  assert.ok(haiku45, 'expected non-null estimate for Claude Haiku 4.5');
+  // 1M input @ $1 + 100k output @ $5 = $1 + $0.5 = $1.50
+  assert.equal(formatUsd(haiku45.totalUsd), '$1.50');
+
+  // Bare "Haiku 4" (short name) should also match.
+  const haiku4Bare = estimateSessionCost({ model: { display_name: 'Claude Haiku 4' } }, tokens);
+  assert.ok(haiku4Bare, 'expected non-null estimate for bare Claude Haiku 4');
+  assert.equal(formatUsd(haiku4Bare.totalUsd), '$1.50');
+
+  // Haiku 3.5 pricing stays on its own row.
+  const haiku35 = estimateSessionCost({ model: { display_name: 'Claude Haiku 3.5' } }, tokens);
+  assert.ok(haiku35, 'expected non-null estimate for Claude Haiku 3.5');
+  // 1M input @ $0.8 + 100k output @ $4 = $0.8 + $0.4 = $1.20
+  assert.equal(formatUsd(haiku35.totalUsd), '$1.20');
+});
+
 
 test('parseTranscript aggregates tools, agents, and todos', async () => {
   const fixturePath = fileURLToPath(new URL('./fixtures/transcript-basic.jsonl', import.meta.url));


### PR DESCRIPTION
## Summary

- Add a \`haiku 4(?: \d+)?\` entry to \`ANTHROPIC_MODEL_PRICING\` at Anthropic's current published rates (\$1 / \$5 per MTok).
- Position it before the more-specific Haiku 3.5 row so the first-match-wins semantics keep Haiku 3.5 on its own row.
- Add a regression test covering Haiku 4.5, the bare "Haiku 4" short form, and the existing Haiku 3.5 path.

Closes #452.

## Root cause

\`src/cost.ts::ANTHROPIC_MODEL_PRICING\` only contained a Haiku 3.5 entry. For Opus and Sonnet, the generic \`4(?: \d+)?\` pattern handled current 4.x releases, but Haiku had no such entry, so \`Claude Haiku 4.5\` normalized to \`haiku 4 5\` and fell through every pattern. \`estimateSessionCost\` returned \`null\`, which silently hides the cost line whenever Claude Code has not yet emitted native \`cost.total_cost_usd\` on stdin.

## Fix

Add one row and a short comment explaining the ordering requirement:

\`\`\`ts
{ pattern: /\bhaiku 4(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 1, outputUsdPerMillion: 5 } },
{ pattern: /\bhaiku 3 5\b/i, pricing: { inputUsdPerMillion: 0.8, outputUsdPerMillion: 4 } },
\`\`\`

The Haiku 3.5 pattern is unchanged and still reached for literal \`haiku 3 5\` inputs.

## Changes

- \`src/cost.ts\`: add Haiku 4.x pricing row; add an ordering comment above the table.
- \`tests/core.test.js\`: add a regression test covering Haiku 4.5, bare "Haiku 4", and Haiku 3.5 math.

## Testing

- [x] \`npm run build\`
- [x] \`npm test\` — 354 pass, 1 skipped, 0 fail (added 1 new test).
- [x] Verified that Haiku 3.5 pricing is unchanged and Haiku 4.5 returns \$1.50 for the 1M in / 100k out scenario (1M \* \$1 + 100k \* \$5).

## Checklist

- [x] Tests updated.
- [x] Only \`src/\` files modified; \`dist/\` left for CI.
- [x] No new dependencies.
- [x] No behavior change for non-Haiku-4.x models.