### PR TITLE
fix(transcript): preserve taskIds for duplicate-content todos across TodoWrite

### DIFF
--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -306,29 +306,39 @@ function processEntry(
       } else if (block.name === 'TodoWrite') {
         const input = block.input as { todos?: TodoItem[] };
         if (input?.todos && Array.isArray(input.todos)) {
-          // Build reverse map: content → taskIds from existing state
+          // Build a FIFO queue of taskIds per content string, ordered by the
+          // old array position. Two todos that share the same content must
+          // each get their own taskId back after the rebuild, so we cannot
+          // collapse duplicates to one index.
           const contentToTaskIds = new Map<string, string[]>();
+          const taskIdsByOldIndex: Array<[number, string]> = [];
           for (const [taskId, idx] of taskIdToIndex) {
             if (idx < latestTodos.length) {
-              const content = latestTodos[idx].content;
-              const ids = contentToTaskIds.get(content) ?? [];
-              ids.push(taskId);
-              contentToTaskIds.set(content, ids);
+              taskIdsByOldIndex.push([idx, taskId]);
             }
+          }
+          taskIdsByOldIndex.sort((a, b) => a[0] - b[0]);
+          for (const [idx, taskId] of taskIdsByOldIndex) {
+            const content = latestTodos[idx].content;
+            const ids = contentToTaskIds.get(content) ?? [];
+            ids.push(taskId);
+            contentToTaskIds.set(content, ids);
           }
 
           latestTodos.length = 0;
           taskIdToIndex.clear();
           latestTodos.push(...input.todos);
 
-          // Re-register taskId mappings for items whose content matches
+          // Consume one queued taskId per new todo that matches by content,
+          // so duplicate-content items still each get their own taskId.
           for (let i = 0; i < latestTodos.length; i++) {
             const ids = contentToTaskIds.get(latestTodos[i].content);
-            if (ids) {
-              for (const taskId of ids) {
-                taskIdToIndex.set(taskId, i);
+            if (ids && ids.length > 0) {
+              const taskId = ids.shift() as string;
+              taskIdToIndex.set(taskId, i);
+              if (ids.length === 0) {
+                contentToTaskIds.delete(latestTodos[i].content);
               }
-              contentToTaskIds.delete(latestTodos[i].content);
             }
           }
         }

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -565,6 +565,48 @@ test('TaskCreate taskId is preserved across TodoWrite and usable by TaskUpdate',
   }
 });
 
+test('TaskCreate taskIds survive TodoWrite when two todos share the same content', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-'));
+  const filePath = path.join(dir, 'taskid-duplicate.jsonl');
+  const lines = [
+    JSON.stringify({
+      timestamp: '2024-01-01T00:00:00.000Z',
+      message: { content: [{ type: 'tool_use', id: 'tc-1', name: 'TaskCreate', input: { taskId: 'a1', subject: 'Duplicate task' } }] },
+    }),
+    JSON.stringify({
+      timestamp: '2024-01-01T00:00:01.000Z',
+      message: { content: [{ type: 'tool_use', id: 'tc-2', name: 'TaskCreate', input: { taskId: 'a2', subject: 'Duplicate task' } }] },
+    }),
+    JSON.stringify({
+      timestamp: '2024-01-01T00:00:02.000Z',
+      message: { content: [{ type: 'tool_use', id: 'tw-1', name: 'TodoWrite', input: { todos: [
+        { content: 'Duplicate task', status: 'pending' },
+        { content: 'Duplicate task', status: 'pending' },
+      ] } }] },
+    }),
+    // Update the SECOND duplicate's taskId specifically.
+    JSON.stringify({
+      timestamp: '2024-01-01T00:00:03.000Z',
+      message: { content: [{ type: 'tool_use', id: 'tu-1', name: 'TaskUpdate', input: { taskId: 'a2', status: 'completed' } }] },
+    }),
+  ];
+
+  await writeFile(filePath, lines.join('\n'), 'utf8');
+
+  try {
+    const result = await parseTranscript(filePath);
+    assert.equal(result.todos.length, 2);
+    assert.equal(result.todos[0].content, 'Duplicate task');
+    assert.equal(result.todos[0].status, 'pending',
+      'first occurrence must remain pending when only the second was updated');
+    assert.equal(result.todos[1].content, 'Duplicate task');
+    assert.equal(result.todos[1].status, 'completed',
+      'second occurrence must be reachable by its own taskId after TodoWrite');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('TodoWrite without prior TaskCreate works as before (no regression)', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-'));
   const filePath = path.join(dir, 'todowrite-only.jsonl');


### PR DESCRIPTION
## Summary

- Rebuild the per-content taskId queue in old-index order and consume one taskId per new occurrence so duplicate-content todos each retain their own taskId.
- Non-duplicate cases (and the `#357` flow) are unchanged.
- Add a regression test that performs two `TaskCreate` calls with identical subjects, a `TodoWrite` that preserves both, and a `TaskUpdate` that targets only the second taskId.

Closes #454. Builds on #357 (#345).

## Root cause

`src/transcript.ts` rebuilt `taskIdToIndex` on every `TodoWrite` by bucketing old taskIds by content string and then, for each new todo matching that content, writing every collected taskId to the same index before deleting the content entry:

```ts
for (const taskId of ids) {
  taskIdToIndex.set(taskId, i);   // all ids collapse to the first matching index
}
contentToTaskIds.delete(latestTodos[i].content);   // second occurrence has nothing to match against
```

When two todos shared the same content, both taskIds landed on the first occurrence and the second occurrence lost its mapping. Any subsequent `TaskUpdate` targeting the second taskId found no index and was silently dropped.

## Fix

Treat the per-content structure as a FIFO queue ordered by old array position:

```ts
const taskIdsByOldIndex: Array<[number, string]> = [];
for (const [taskId, idx] of taskIdToIndex) {
  if (idx < latestTodos.length) {
    taskIdsByOldIndex.push([idx, taskId]);
  }
}
taskIdsByOldIndex.sort((a, b) => a[0] - b[0]);
for (const [idx, taskId] of taskIdsByOldIndex) {
  const ids = contentToTaskIds.get(latestTodos[idx].content) ?? [];
  ids.push(taskId);
  contentToTaskIds.set(latestTodos[idx].content, ids);
}

// later: shift() one taskId per new todo
const taskId = ids.shift() as string;
taskIdToIndex.set(taskId, i);
```

Sorting by old index first ensures the oldest taskId lands on the first matching occurrence in the new array, which is the intuitive mapping and keeps the non-duplicate behavior identical to before.

## Changes

- `src/transcript.ts`: rebuild queue ordered by old index; consume FIFO on match.
- `tests/core.test.js`: add duplicate-content regression test.

## Testing

- [x] `npm run build`
- [x] `npm test` — 354 pass, 1 skipped, 0 fail (added 1 new test).
- [x] Existing `TaskCreate → TodoWrite → TaskUpdate` test from #357 still passes.
- [x] Existing `TodoWrite without prior TaskCreate` regression test still passes.

## Checklist

- [x] Tests updated.
- [x] Only `src/` files modified; `dist/` left for CI.
- [x] No new dependencies.
- [x] No behavior change for todos whose content strings are unique.