### PR TITLE
fix: stop wrapping at 40 columns when TTY width is unknown

### DIFF
--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -1,4 +1,10 @@
-export const UNKNOWN_TERMINAL_WIDTH = 40;
+// When no TTY width is detectable (stdout piped, stderr not a TTY, COLUMNS
+// unset) we must not fall back to a small ceiling — every line then wraps to
+// that value even on a 140-column terminal, defeating pair-merge and
+// truncating multi-segment lines. A very large fallback matches the
+// pre-0.0.12 behaviour of returning null (effectively "do not wrap") and
+// lets the render layer trust its own logic.
+export const UNKNOWN_TERMINAL_WIDTH = 10000;
 
 // Returns a progress bar width scaled to the current terminal width.
 // Wide (>=100): 10, Medium (60-99): 6, Narrow (<60): 4.


### PR DESCRIPTION
## Summary

- Raise `UNKNOWN_TERMINAL_WIDTH` from `40` to `10000` so the statusline no longer wraps every line at 40 columns when `process.stdout.columns` / `process.stderr.columns` / `process.env.COLUMNS` are all unavailable.

## Problem

`getTerminalWidth()` falls back to `UNKNOWN_TERMINAL_WIDTH` when none of the three width sources report a value. Under Claude Code the statusline is spawned as a subprocess with **stdout piped**, and depending on how the host wires the process, **stderr is not guaranteed to be a TTY** either. Hosts also don't always inject `COLUMNS`. The 40-column fallback then silently becomes the wrap ceiling.

Consequences on a normal wide terminal:

- `context` + `usage` pair merge fails (`canCombine` compares against 40)
- the project line wraps after the model badge, forcing `[Opus 4.6 (1M context) \| Max]` onto its own row
- multi-segment lines (Cache, Tools) get chopped with `...` mid-segment

Pre-0.0.12 `getTerminalWidth()` returned `null`, which made `wrapLineToWidth` and `canCombine` effectively no-op. The new 40 fallback is conservative in the wrong direction for typical Claude Code usage.

## Fix

Raise the sentinel to `10000`. When width is genuinely unknown, the render layer is back to trusting its own single-line output (matches pre-0.0.12 behaviour). When width *is* known, nothing changes.

## Reproduction (pre-fix)

1. Install claude-hud via Claude Code marketplace.
2. Enable the recommended statusLine command (bash + bun).
3. Open a terminal at ≥140 columns.
4. Start a Claude Code session and watch the HUD.

Expected: `[model] │ project git:(…) │ ⏱ …` on one line, `Context … │ Usage … (…)` on one line.
Actual (today): model and project on two rows, context and usage on separate rows, Cache/Tools lines truncated with `...`.

## Test plan
- [x] Manual: terminal wider than 40 — pair merge works, no mid-segment truncation.
- [x] Manual: `COLUMNS=40 bash -c '... statusline ...'` — wrap still honours the real 40-column ceiling when set explicitly.
- [x] No behavioural change when stdout/stderr report real columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)