### PR TITLE
feat: display effort level from Claude Code settings

### DIFF
--- a/src/config-reader.ts
+++ b/src/config-reader.ts
@@ -13,6 +13,7 @@ export interface ConfigCounts {
   mcpCount: number;
   hooksCount: number;
   outputStyle?: string;
+  effortLevel?: string;
 }
 
 interface SentinelState {
@@ -255,6 +256,7 @@ function isConfigCounts(value: unknown): value is ConfigCounts {
     && Number.isFinite(counts.hooksCount)
     && counts.hooksCount >= 0
     && (counts.outputStyle === undefined || typeof counts.outputStyle === 'string')
+    && (counts.effortLevel === undefined || typeof counts.effortLevel === 'string')
   );
 }
 
@@ -291,6 +293,7 @@ function computeConfigCountsFresh(cwd?: string): ConfigCounts {
   let rulesCount = 0;
   let hooksCount = 0;
   let outputStyle: string | undefined;
+  let effortLevel: string | undefined;
 
   const homeDir = os.homedir();
   const claudeDir = getClaudeConfigDir(homeDir);
@@ -316,9 +319,11 @@ function computeConfigCountsFresh(cwd?: string): ConfigCounts {
   }
   hooksCount += countHooksInFile(userSettings);
   outputStyle = readStringSetting(userSettings, 'outputStyle');
+  effortLevel = readStringSetting(userSettings, 'effortLevel');
 
   const userLocalSettings = path.join(claudeDir, 'settings.local.json');
   outputStyle = readStringSetting(userLocalSettings, 'outputStyle') ?? outputStyle;
+  effortLevel = readStringSetting(userLocalSettings, 'effortLevel') ?? effortLevel;
 
   // {CLAUDE_CONFIG_DIR}.json (additional user-scope MCPs)
   const userClaudeJson = getClaudeConfigJsonPath(homeDir);
@@ -379,6 +384,7 @@ function computeConfigCountsFresh(cwd?: string): ConfigCounts {
       }
       hooksCount += countHooksInFile(projectSettings);
       outputStyle = readStringSetting(projectSettings, 'outputStyle') ?? outputStyle;
+      effortLevel = readStringSetting(projectSettings, 'effortLevel') ?? effortLevel;
     }
 
     // {cwd}/.claude/settings.local.json (local project settings)
@@ -388,6 +394,7 @@ function computeConfigCountsFresh(cwd?: string): ConfigCounts {
     }
     hooksCount += countHooksInFile(localSettings);
     outputStyle = readStringSetting(localSettings, 'outputStyle') ?? outputStyle;
+    effortLevel = readStringSetting(localSettings, 'effortLevel') ?? effortLevel;
 
     // Get disabled .mcp.json servers from settings.local.json
     const disabledMcpJsonServers = getDisabledMcpServers(localSettings, 'disabledMcpjsonServers');
@@ -406,7 +413,7 @@ function computeConfigCountsFresh(cwd?: string): ConfigCounts {
   // A server with the same name in both user and project scope counts as 2 (separate configs).
   const mcpCount = userMcpServers.size + projectMcpServers.size;
 
-  return { claudeMdCount, rulesCount, mcpCount, hooksCount, outputStyle };
+  return { claudeMdCount, rulesCount, mcpCount, hooksCount, outputStyle, effortLevel };
 }
 
 export async function countConfigs(cwd?: string): Promise<ConfigCounts> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,7 @@ export interface HudConfig {
     showMemoryUsage: boolean;
     showSessionTokens: boolean;
     showOutputStyle: boolean;
+    showEffortLevel: boolean;
     autocompactBuffer: AutocompactBufferMode;
     usageThreshold: number;
     sevenDayThreshold: number;
@@ -137,6 +138,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showMemoryUsage: false,
     showSessionTokens: false,
     showOutputStyle: false,
+    showEffortLevel: false,
     autocompactBuffer: 'enabled',
     usageThreshold: 0,
     sevenDayThreshold: 80,
@@ -371,6 +373,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showOutputStyle: typeof migrated.display?.showOutputStyle === 'boolean'
       ? migrated.display.showOutputStyle
       : DEFAULT_CONFIG.display.showOutputStyle,
+    showEffortLevel: typeof migrated.display?.showEffortLevel === 'boolean'
+      ? migrated.display.showEffortLevel
+      : DEFAULT_CONFIG.display.showEffortLevel,
     autocompactBuffer: validateAutocompactBuffer(migrated.display?.autocompactBuffer)
       ? migrated.display.autocompactBuffer
       : DEFAULT_CONFIG.display.autocompactBuffer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     const transcriptPath = stdin.transcript_path ?? "";
     const transcript = await deps.parseTranscript(transcriptPath);
 
-    const { claudeMdCount, rulesCount, mcpCount, hooksCount, outputStyle } =
+    const { claudeMdCount, rulesCount, mcpCount, hooksCount, outputStyle, effortLevel } =
       await deps.countConfigs(stdin.cwd);
 
     const config = await deps.loadConfig();
@@ -108,6 +108,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       config,
       extraLabel,
       outputStyle,
+      effortLevel,
       claudeCodeVersion,
     };
 

--- a/src/render/lines/environment.ts
+++ b/src/render/lines/environment.ts
@@ -33,6 +33,11 @@ export function renderEnvironmentLine(ctx: RenderContext): string | null {
     parts.push(`style: ${ctx.outputStyle}`);
   }
 
+  const showEffortLevel = display?.showEffortLevel === true;
+  if (showEffortLevel && ctx.effortLevel) {
+    parts.push(`effort: ${ctx.effortLevel}`);
+  }
+
   if (parts.length === 0) {
     return null;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,5 +112,6 @@ export interface RenderContext {
   config: HudConfig;
   extraLabel: string | null;
   outputStyle?: string;
+  effortLevel?: string;
   claudeCodeVersion?: string;
 }

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -153,6 +153,17 @@ test('mergeConfig preserves explicit showOutputStyle=true', () => {
   assert.equal(config.display.showOutputStyle, true);
 });
 
+test('mergeConfig defaults showEffortLevel to false', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.showEffortLevel, false);
+  assert.equal(DEFAULT_CONFIG.display.showEffortLevel, false);
+});
+
+test('mergeConfig preserves explicit showEffortLevel=true', () => {
+  const config = mergeConfig({ display: { showEffortLevel: true } });
+  assert.equal(config.display.showEffortLevel, true);
+});
+
 test('mergeConfig preserves customLine and truncates long values', () => {
   const customLine = 'x'.repeat(120);
   const config = mergeConfig({ display: { customLine } });

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1017,6 +1017,41 @@ test('countConfigs returns outputStyle with project local precedence', async () 
   }
 });
 
+test('countConfigs returns effortLevel with project local precedence', async () => {
+  const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
+  const projectDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-project-'));
+  const originalHome = process.env.HOME;
+  process.env.HOME = homeDir;
+
+  try {
+    await mkdir(path.join(homeDir, '.claude'), { recursive: true });
+    await mkdir(path.join(projectDir, '.claude'), { recursive: true });
+
+    await writeFile(
+      path.join(homeDir, '.claude', 'settings.json'),
+      JSON.stringify({ effortLevel: 'low' }),
+      'utf8',
+    );
+    await writeFile(
+      path.join(projectDir, '.claude', 'settings.json'),
+      JSON.stringify({ effortLevel: 'medium' }),
+      'utf8',
+    );
+    await writeFile(
+      path.join(projectDir, '.claude', 'settings.local.json'),
+      JSON.stringify({ effortLevel: 'high' }),
+      'utf8',
+    );
+
+    const counts = await countConfigs(projectDir);
+    assert.equal(counts.effortLevel, 'high');
+  } finally {
+    restoreEnvVar('HOME', originalHome);
+    await rm(homeDir, { recursive: true, force: true });
+    await rm(projectDir, { recursive: true, force: true });
+  }
+});
+
 test('countConfigs uses CLAUDE_CONFIG_DIR and matching .json sidecar for user scope', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
   const customConfigDir = path.join(homeDir, '.claude-2');

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -149,6 +149,7 @@ test("main executes the happy path with default dependencies", async () => {
         mcpCount: 0,
         hooksCount: 0,
         outputStyle: "tech-leader",
+        effortLevel: "high",
       }),
       getGitBranch: async () => null,
       getUsage: async () => null,
@@ -162,6 +163,7 @@ test("main executes the happy path with default dependencies", async () => {
 
   assert.equal(renderedContext?.sessionDuration, "1m");
   assert.equal(renderedContext?.outputStyle, "tech-leader");
+  assert.equal(renderedContext?.effortLevel, "high");
 });
 
 test("main includes git status in render context", async () => {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -582,6 +582,26 @@ test('renderEnvironmentLine appends output style after config counts', () => {
   assert.ok(line?.includes('style: learning'));
 });
 
+test('renderEnvironmentLine shows effort level when enabled', () => {
+  const ctx = baseContext();
+  ctx.effortLevel = 'high';
+  ctx.config.display.showConfigCounts = false;
+  ctx.config.display.showEffortLevel = true;
+
+  assert.ok(renderEnvironmentLine(ctx)?.includes('effort: high'));
+});
+
+test('renderEnvironmentLine appends effort level after config counts', () => {
+  const ctx = baseContext();
+  ctx.claudeMdCount = 1;
+  ctx.effortLevel = 'low';
+  ctx.config.display.showEffortLevel = true;
+
+  const line = renderEnvironmentLine(ctx);
+  assert.ok(line?.includes('1 CLAUDE.md'));
+  assert.ok(line?.includes('effort: low'));
+});
+
 test('renderProjectLine includes duration when showDuration is true', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = '/tmp/my-project';


### PR DESCRIPTION
## Summary

Resolves #201 and #271.

Read `effortLevel` from Claude Code's `settings.json` and display it on the environment line when `display.showEffortLevel` is enabled. Default: **off** (opt-in only).

## Context

Both #201 and #271 were closed as upstream-blocked because the statusline stdin JSON doesn't expose an effort field. However, Claude Code already persists the effort level in `settings.json` under the `effortLevel` key (as [noted by @Astro-Han in #271](https://github.com/jarrodwatts/claude-hud/issues/271)). This is the same data source that `outputStyle` already uses — `readStringSetting()` from `settings.json` with full scope precedence. No new data source or parsing strategy is introduced.

## What changed

| File | Change |
|------|--------|
| `src/config-reader.ts` | Read `effortLevel` with scope precedence (user → user.local → project → project.local) |
| `src/config.ts` | Add `showEffortLevel` display toggle (default: `false`) |
| `src/types.ts` | Add `effortLevel` to `RenderContext` |
| `src/index.ts` | Pipe `effortLevel` through to render context |
| `src/render/lines/environment.ts` | Render `effort: <level>` on environment line |

## Design decisions

- **Opt-in only** (`showEffortLevel: false` by default) — no HUD surface area added unless the user explicitly enables it, per the maintainer's preference in #271.
- **Same pattern as `outputStyle`** — no new abstractions, no new data sources. Just one more `readStringSetting()` call at each scope level.
- **Environment line placement** — shown alongside config counts and output style, not in the model badge. Keeps identity line unchanged.

## Config

```json
{
  "display": {
    "showEffortLevel": true
  }
}
```

Renders as: `effort: high` on the environment line.

## Limitations

This reads the configured default from `settings.json`, not per-session `/effort` overrides. If Claude Code adds effort to the stdin JSON in the future, this can be extended to prefer that signal.

## Tests

- `mergeConfig` defaults `showEffortLevel` to `false`
- `mergeConfig` preserves explicit `showEffortLevel: true`
- `renderEnvironmentLine` shows effort level when enabled
- `renderEnvironmentLine` appends effort level after config counts
- `countConfigs` returns `effortLevel` with project local precedence
- `main` pipes `effortLevel` through to render context
- All 358 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)