### PR TITLE
fix(context): add session-scoped cache fallback for zero-usage frames

### DIFF
--- a/src/context-cache.ts
+++ b/src/context-cache.ts
@@ -8,9 +8,9 @@ import type { StdinData } from "./types.js";
 const CACHE_DIRNAME = "context-cache";
 
 /**
- * Minimum interval between cache rewrites when the reported usage hasn't changed.
- * Status line runs every ~300ms so this cuts write frequency by roughly 10x
- * while still keeping the on-disk snapshot fresh for fallback purposes.
+ * Minimum interval between cache rewrites for the same session.
+ * Status line runs every ~300ms so this keeps the steady-state write path cheap
+ * while still refreshing the fallback snapshot regularly.
  */
 const WRITE_TTL_MS = 3_000;
 
@@ -94,28 +94,16 @@ function readCache(
 }
 
 /**
- * Decide whether the current write can be skipped because the on-disk
- * snapshot already records the same used_percentage and is still fresh.
+ * Decide whether the current write can be skipped because the cached snapshot
+ * for this session was refreshed recently enough.
  */
 function shouldSkipWrite(
   cachePath: string,
-  contextWindow: ContextWindow,
   now: number
 ): boolean {
   try {
-    if (!fs.existsSync(cachePath)) return false;
-    const parsed = JSON.parse(
-      fs.readFileSync(cachePath, "utf8")
-    ) as ContextCache;
-    if (
-      typeof parsed.used_percentage !== "number" ||
-      typeof parsed.saved_at !== "number"
-    ) {
-      return false;
-    }
-    const current = contextWindow.used_percentage ?? 0;
-    if (parsed.used_percentage !== current) return false;
-    return now - parsed.saved_at < WRITE_TTL_MS;
+    const stat = fs.statSync(cachePath);
+    return now - stat.mtimeMs < WRITE_TTL_MS;
   } catch {
     return false;
   }
@@ -134,7 +122,7 @@ function writeCache(
 ): void {
   try {
     const cachePath = getCachePath(homeDir, transcriptPath);
-    if (shouldSkipWrite(cachePath, contextWindow, now)) {
+    if (shouldSkipWrite(cachePath, now)) {
       return;
     }
     const cacheDir = path.dirname(cachePath);
@@ -150,6 +138,8 @@ function writeCache(
       session_name: sessionName ?? null,
     };
     fs.writeFileSync(cachePath, JSON.stringify(payload), "utf8");
+    const timestampSeconds = now / 1000;
+    fs.utimesSync(cachePath, timestampSeconds, timestampSeconds);
   } catch {
     // Ignore cache write failures
   }
@@ -216,8 +206,10 @@ function isAllUsageZero(usage: ContextWindow["current_usage"]): boolean {
  * despite a large accumulated input token count.
  */
 function isSuspiciousZero(contextWindow: ContextWindow): boolean {
-  if (!contextWindow.context_window_size) {
-    return true;
+  const contextWindowSize = contextWindow.context_window_size ?? 0;
+  const totalInputTokens = contextWindow.total_input_tokens ?? 0;
+  if (contextWindowSize <= 0 || totalInputTokens <= contextWindowSize) {
+    return false;
   }
   if ((contextWindow.used_percentage ?? 0) !== 0) {
     return false;

--- a/src/context-cache.ts
+++ b/src/context-cache.ts
@@ -1,0 +1,302 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createHash } from "node:crypto";
+import { getHudPluginDir } from "./claude-config-dir.js";
+import type { StdinData } from "./types.js";
+
+const CACHE_DIRNAME = "context-cache";
+
+/**
+ * Minimum interval between cache rewrites when the reported usage hasn't changed.
+ * Status line runs every ~300ms so this cuts write frequency by roughly 10x
+ * while still keeping the on-disk snapshot fresh for fallback purposes.
+ */
+const WRITE_TTL_MS = 3_000;
+
+/**
+ * Sweep parameters bounding long-term growth of the cache directory.
+ * A sweep is attempted probabilistically on cache writes to avoid paying
+ * directory-scan cost on every status line tick.
+ */
+const MAX_CACHE_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_CACHE_ENTRIES = 100;
+const SWEEP_SAMPLE_RATE = 0.01;
+
+type CurrentUsage = NonNullable<
+  NonNullable<StdinData["context_window"]>["current_usage"]
+>;
+type ContextWindow = NonNullable<StdinData["context_window"]>;
+
+type ContextCache = {
+  used_percentage: number;
+  remaining_percentage?: number | null;
+  current_usage?: CurrentUsage | null;
+  context_window_size?: number | null;
+  saved_at?: number;
+  session_name?: string | null;
+};
+
+export type ContextCacheDeps = {
+  homeDir: () => string;
+  now: () => number;
+  random: () => number;
+};
+
+const defaultDeps: ContextCacheDeps = {
+  homeDir: () => os.homedir(),
+  now: () => Date.now(),
+  random: () => Math.random(),
+};
+
+/**
+ * Resolve the session-scoped cache file used for context window fallback.
+ * Uses a sha256 of the transcript path so that concurrent Claude Code
+ * sessions never share or overwrite each other's cached snapshots.
+ */
+function getCachePath(homeDir: string, transcriptPath: string): string {
+  const hash = createHash("sha256")
+    .update(path.resolve(transcriptPath))
+    .digest("hex");
+  return path.join(getHudPluginDir(homeDir), CACHE_DIRNAME, `${hash}.json`);
+}
+
+/**
+ * Resolve the cache directory that holds all session-scoped snapshots.
+ */
+function getCacheDir(homeDir: string): string {
+  return path.join(getHudPluginDir(homeDir), CACHE_DIRNAME);
+}
+
+/**
+ * Read the last known good context snapshot from disk.
+ * Returns null when the cache is missing, malformed, or invalid.
+ */
+function readCache(
+  homeDir: string,
+  transcriptPath: string
+): ContextCache | null {
+  try {
+    const cachePath = getCachePath(homeDir, transcriptPath);
+    if (!fs.existsSync(cachePath)) return null;
+    const content = fs.readFileSync(cachePath, "utf8");
+    const parsed = JSON.parse(content) as ContextCache;
+    if (
+      typeof parsed.used_percentage !== "number" ||
+      !Number.isFinite(parsed.used_percentage)
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decide whether the current write can be skipped because the on-disk
+ * snapshot already records the same used_percentage and is still fresh.
+ */
+function shouldSkipWrite(
+  cachePath: string,
+  contextWindow: ContextWindow,
+  now: number
+): boolean {
+  try {
+    if (!fs.existsSync(cachePath)) return false;
+    const parsed = JSON.parse(
+      fs.readFileSync(cachePath, "utf8")
+    ) as ContextCache;
+    if (
+      typeof parsed.used_percentage !== "number" ||
+      typeof parsed.saved_at !== "number"
+    ) {
+      return false;
+    }
+    const current = contextWindow.used_percentage ?? 0;
+    if (parsed.used_percentage !== current) return false;
+    return now - parsed.saved_at < WRITE_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Persist a known-good context snapshot for future fallback use.
+ * Any write failure is intentionally ignored to keep rendering non-blocking.
+ */
+function writeCache(
+  homeDir: string,
+  transcriptPath: string,
+  contextWindow: ContextWindow,
+  now: number,
+  sessionName?: string
+): void {
+  try {
+    const cachePath = getCachePath(homeDir, transcriptPath);
+    if (shouldSkipWrite(cachePath, contextWindow, now)) {
+      return;
+    }
+    const cacheDir = path.dirname(cachePath);
+    if (!fs.existsSync(cacheDir)) {
+      fs.mkdirSync(cacheDir, { recursive: true });
+    }
+    const payload: ContextCache = {
+      used_percentage: contextWindow.used_percentage ?? 0,
+      remaining_percentage: contextWindow.remaining_percentage ?? null,
+      current_usage: contextWindow.current_usage ?? null,
+      context_window_size: contextWindow.context_window_size ?? null,
+      saved_at: now,
+      session_name: sessionName ?? null,
+    };
+    fs.writeFileSync(cachePath, JSON.stringify(payload), "utf8");
+  } catch {
+    // Ignore cache write failures
+  }
+}
+
+/**
+ * Remove stale cache entries and enforce a hard cap on total file count.
+ * Safe to run opportunistically; every per-file failure is swallowed.
+ */
+function sweepCacheDir(cacheDir: string, now: number): void {
+  try {
+    if (!fs.existsSync(cacheDir)) return;
+    const entries = fs.readdirSync(cacheDir, { withFileTypes: true });
+    const survivors: { fullPath: string; mtimeMs: number }[] = [];
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+      const fullPath = path.join(cacheDir, entry.name);
+      try {
+        const stat = fs.statSync(fullPath);
+        if (now - stat.mtimeMs > MAX_CACHE_AGE_MS) {
+          fs.unlinkSync(fullPath);
+          continue;
+        }
+        survivors.push({ fullPath, mtimeMs: stat.mtimeMs });
+      } catch {
+        // Ignore per-file failure
+      }
+    }
+
+    if (survivors.length > MAX_CACHE_ENTRIES) {
+      survivors.sort((a, b) => a.mtimeMs - b.mtimeMs);
+      const toDelete = survivors.length - MAX_CACHE_ENTRIES;
+      for (let i = 0; i < toDelete; i += 1) {
+        try {
+          fs.unlinkSync(survivors[i].fullPath);
+        } catch {
+          // Ignore per-file failure
+        }
+      }
+    }
+  } catch {
+    // Ignore top-level sweep errors
+  }
+}
+
+/**
+ * Check whether all tracked token counters in current_usage are zero.
+ */
+function isAllUsageZero(usage: ContextWindow["current_usage"]): boolean {
+  if (!usage) {
+    return true;
+  }
+  return (
+    (usage.input_tokens ?? 0) === 0 &&
+    (usage.output_tokens ?? 0) === 0 &&
+    (usage.cache_creation_input_tokens ?? 0) === 0 &&
+    (usage.cache_read_input_tokens ?? 0) === 0
+  );
+}
+
+/**
+ * Detect the known Claude Code glitch where usage is reported as zero
+ * despite a large accumulated input token count.
+ */
+function isSuspiciousZero(contextWindow: ContextWindow): boolean {
+  if (!contextWindow.context_window_size) {
+    return true;
+  }
+  if ((contextWindow.used_percentage ?? 0) !== 0) {
+    return false;
+  }
+  return isAllUsageZero(contextWindow.current_usage);
+}
+
+/**
+ * Determine whether the current frame contains a usable context snapshot.
+ */
+function hasGoodContext(contextWindow: ContextWindow): boolean {
+  return (
+    (contextWindow.context_window_size ?? 0) > 0 &&
+    typeof contextWindow.used_percentage === "number" &&
+    contextWindow.used_percentage > 0
+  );
+}
+
+/**
+ * Merge cached context fields into the current frame.
+ * Prefer the frame's context_window_size when already present.
+ */
+function applyCachedContext(
+  contextWindow: ContextWindow,
+  cache: ContextCache
+): void {
+  contextWindow.used_percentage = cache.used_percentage;
+  contextWindow.remaining_percentage = cache.remaining_percentage ?? null;
+  contextWindow.current_usage = cache.current_usage ?? null;
+  contextWindow.context_window_size =
+    contextWindow.context_window_size ?? cache.context_window_size ?? undefined;
+}
+
+/**
+ * Apply context-window fallback in-place:
+ * - For suspicious zero frames, try restoring from the session-scoped cache.
+ * - For healthy frames, refresh the cache snapshot for this session
+ *   (subject to TTL + value-change throttling to avoid hot-path writes).
+ *
+ * No-op when stdin has no transcript_path, since without a stable session key
+ * we cannot safely isolate cache entries across concurrent Claude Code sessions.
+ */
+export function applyContextWindowFallback(
+  stdin: StdinData,
+  overrides: Partial<ContextCacheDeps> = {},
+  sessionName?: string
+): void {
+  const contextWindow = stdin.context_window;
+  if (!contextWindow) {
+    return;
+  }
+
+  const transcriptPath = stdin.transcript_path?.trim();
+  if (!transcriptPath) {
+    return;
+  }
+
+  const deps = { ...defaultDeps, ...overrides };
+  const homeDir = deps.homeDir();
+  const now = deps.now();
+
+  if (isSuspiciousZero(contextWindow)) {
+    const cached = readCache(homeDir, transcriptPath);
+    if (cached) {
+      applyCachedContext(contextWindow, cached);
+    }
+  }
+
+  if (hasGoodContext(contextWindow)) {
+    writeCache(homeDir, transcriptPath, contextWindow, now, sessionName);
+    if (deps.random() < SWEEP_SAMPLE_RATE) {
+      sweepCacheDir(getCacheDir(homeDir), now);
+    }
+  }
+}
+
+/**
+ * Test-only entrypoint for deterministically exercising the sweep logic.
+ */
+export function _sweepCacheForTests(homeDir: string, now: number): void {
+  sweepCacheDir(getCacheDir(homeDir), now);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { parseExtraCmdArg, runExtraCmd } from "./extra-cmd.js";
 import { getClaudeCodeVersion } from "./version.js";
 import { getMemoryUsage } from "./memory.js";
 import { resolveEffortLevel } from "./effort.js";
+import { applyContextWindowFallback } from "./context-cache.js";
 import { setLanguage, t } from "./i18n/index.js";
 import type { RenderContext } from "./types.js";
 import { fileURLToPath } from "node:url";
@@ -24,6 +25,7 @@ export type MainDeps = {
   runExtraCmd: typeof runExtraCmd;
   getClaudeCodeVersion: typeof getClaudeCodeVersion;
   getMemoryUsage: typeof getMemoryUsage;
+  applyContextWindowFallback: typeof applyContextWindowFallback;
   render: typeof render;
   now: () => number;
   log: (...args: unknown[]) => void;
@@ -41,6 +43,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     runExtraCmd,
     getClaudeCodeVersion,
     getMemoryUsage,
+    applyContextWindowFallback,
     render,
     now: () => Date.now(),
     log: console.log,
@@ -64,6 +67,8 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
 
     const transcriptPath = stdin.transcript_path ?? "";
     const transcript = await deps.parseTranscript(transcriptPath);
+
+    deps.applyContextWindowFallback(stdin, {}, transcript.sessionName);
 
     const { claudeMdCount, rulesCount, mcpCount, hooksCount, outputStyle } =
       await deps.countConfigs(stdin.cwd);

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface StdinData {
   };
   context_window?: {
     context_window_size?: number;
+    total_input_tokens?: number | null;
     current_usage?: {
       input_tokens?: number;
       output_tokens?: number;

--- a/tests/context-cache.test.js
+++ b/tests/context-cache.test.js
@@ -170,16 +170,37 @@ test('applyContextWindowFallback ignores corrupted cache without throwing', asyn
   }
 });
 
-test('applyContextWindowFallback does not treat low-input zero frames as suspicious', async () => {
+test('applyContextWindowFallback does not restore cache when zero frame has not overflowed the context window', async () => {
   const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
 
   try {
+    const cachePath = getCachePath(tempHome, transcriptPath);
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await writeFile(
+      cachePath,
+      JSON.stringify({
+        used_percentage: 61,
+        remaining_percentage: 39,
+        context_window_size: 200000,
+        current_usage: {
+          input_tokens: 120000,
+          output_tokens: 5000,
+          cache_creation_input_tokens: 1000,
+          cache_read_input_tokens: 800,
+        },
+        saved_at: 999_000,
+      }),
+      'utf8',
+    );
+
     const stdin = makeSuspiciousFrame({ total_input_tokens: 200000 });
+    stdin.transcript_path = transcriptPath;
 
     applyContextWindowFallback(stdin, makeDeps(tempHome));
 
     assert.equal(stdin.context_window.used_percentage, 0);
-    assert.equal(existsSync(getCacheDir(tempHome)), false);
+    assert.equal(stdin.context_window.remaining_percentage, 100);
   } finally {
     await rm(tempHome, { recursive: true, force: true });
   }
@@ -244,7 +265,7 @@ test('applyContextWindowFallback isolates cache between concurrent sessions', as
   }
 });
 
-test('applyContextWindowFallback skips write when value unchanged and within TTL', async () => {
+test('applyContextWindowFallback skips write when cache is fresh within TTL', async () => {
   const tempHome = await createTempHome();
   const transcriptPath = '/tmp/session-a.jsonl';
 
@@ -278,7 +299,7 @@ test('applyContextWindowFallback rewrites cache after TTL elapses even with unch
   }
 });
 
-test('applyContextWindowFallback rewrites cache immediately when used_percentage changes', async () => {
+test('applyContextWindowFallback keeps the earlier snapshot when usage changes within TTL', async () => {
   const tempHome = await createTempHome();
   const transcriptPath = '/tmp/session-a.jsonl';
 
@@ -292,8 +313,8 @@ test('applyContextWindowFallback rewrites cache immediately when used_percentage
     applyContextWindowFallback(changed, makeDeps(tempHome, 1_002_000));
 
     const refreshed = JSON.parse(await readFile(getCachePath(tempHome, transcriptPath), 'utf8'));
-    assert.equal(refreshed.used_percentage, 59);
-    assert.equal(refreshed.saved_at, 1_002_000);
+    assert.equal(refreshed.used_percentage, 58);
+    assert.equal(refreshed.saved_at, 1_000_000);
   } finally {
     await rm(tempHome, { recursive: true, force: true });
   }

--- a/tests/context-cache.test.js
+++ b/tests/context-cache.test.js
@@ -1,0 +1,384 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile, utimes } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  applyContextWindowFallback,
+  _sweepCacheForTests,
+} from '../dist/context-cache.js';
+
+async function createTempHome() {
+  return await mkdtemp(path.join(tmpdir(), 'claude-hud-context-'));
+}
+
+function getCacheDir(homeDir) {
+  return path.join(homeDir, '.claude', 'plugins', 'claude-hud', 'context-cache');
+}
+
+function getCachePath(homeDir, transcriptPath) {
+  const hash = createHash('sha256').update(path.resolve(transcriptPath)).digest('hex');
+  return path.join(getCacheDir(homeDir), `${hash}.json`);
+}
+
+function makeSuspiciousFrame(overrides = {}) {
+  return {
+    transcript_path: '/tmp/session-a.jsonl',
+    context_window: {
+      context_window_size: 200000,
+      total_input_tokens: 250000,
+      used_percentage: 0,
+      remaining_percentage: 100,
+      current_usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      ...overrides,
+    },
+  };
+}
+
+function makeHealthyFrame(transcriptPath, overrides = {}) {
+  return {
+    transcript_path: transcriptPath,
+    context_window: {
+      context_window_size: 200000,
+      total_input_tokens: 120000,
+      used_percentage: 58,
+      remaining_percentage: 42,
+      current_usage: {
+        input_tokens: 110000,
+        output_tokens: 4000,
+        cache_creation_input_tokens: 1200,
+        cache_read_input_tokens: 800,
+      },
+      ...overrides,
+    },
+  };
+}
+
+/**
+ * Default test deps: fixed homeDir + fixed now + random that never triggers sweep.
+ * Sweep logic is verified separately via `_sweepCacheForTests`.
+ */
+function makeDeps(homeDir, now = 1_000_000) {
+  return { homeDir: () => homeDir, now: () => now, random: () => 1 };
+}
+
+test('applyContextWindowFallback applies cached context for suspicious zero frames', async () => {
+  const tempHome = await createTempHome();
+
+  try {
+    const transcriptPath = '/tmp/session-a.jsonl';
+    const cachePath = getCachePath(tempHome, transcriptPath);
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await writeFile(
+      cachePath,
+      JSON.stringify({
+        used_percentage: 61,
+        remaining_percentage: 39,
+        context_window_size: 200000,
+        current_usage: {
+          input_tokens: 120000,
+          output_tokens: 5000,
+          cache_creation_input_tokens: 1000,
+          cache_read_input_tokens: 800,
+        },
+        saved_at: 999_000,
+      }),
+      'utf8',
+    );
+
+    const stdin = makeSuspiciousFrame();
+    stdin.transcript_path = transcriptPath;
+
+    applyContextWindowFallback(stdin, makeDeps(tempHome));
+
+    assert.equal(stdin.context_window.used_percentage, 61);
+    assert.equal(stdin.context_window.remaining_percentage, 39);
+    assert.deepEqual(stdin.context_window.current_usage, {
+      input_tokens: 120000,
+      output_tokens: 5000,
+      cache_creation_input_tokens: 1000,
+      cache_read_input_tokens: 800,
+    });
+    assert.equal(stdin.context_window.context_window_size, 200000);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback keeps suspicious frame unchanged when cache is missing', async () => {
+  const tempHome = await createTempHome();
+
+  try {
+    const stdin = makeSuspiciousFrame();
+
+    applyContextWindowFallback(stdin, makeDeps(tempHome));
+
+    assert.equal(stdin.context_window.used_percentage, 0);
+    assert.equal(stdin.context_window.remaining_percentage, 100);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback writes cache for good context frames', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+
+  try {
+    const stdin = makeHealthyFrame(transcriptPath);
+
+    applyContextWindowFallback(stdin, makeDeps(tempHome, 1_000_000));
+
+    const cachePath = getCachePath(tempHome, transcriptPath);
+    assert.equal(existsSync(cachePath), true);
+    const cacheContent = JSON.parse(await readFile(cachePath, 'utf8'));
+    assert.equal(cacheContent.used_percentage, 58);
+    assert.equal(cacheContent.remaining_percentage, 42);
+    assert.equal(cacheContent.context_window_size, 200000);
+    assert.deepEqual(cacheContent.current_usage, stdin.context_window.current_usage);
+    assert.equal(cacheContent.saved_at, 1_000_000);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback ignores corrupted cache without throwing', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+
+  try {
+    const cachePath = getCachePath(tempHome, transcriptPath);
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await writeFile(cachePath, '{not-json', 'utf8');
+
+    const stdin = makeSuspiciousFrame();
+    stdin.transcript_path = transcriptPath;
+
+    assert.doesNotThrow(() => {
+      applyContextWindowFallback(stdin, makeDeps(tempHome));
+    });
+    assert.equal(stdin.context_window.used_percentage, 0);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback does not treat low-input zero frames as suspicious', async () => {
+  const tempHome = await createTempHome();
+
+  try {
+    const stdin = makeSuspiciousFrame({ total_input_tokens: 200000 });
+
+    applyContextWindowFallback(stdin, makeDeps(tempHome));
+
+    assert.equal(stdin.context_window.used_percentage, 0);
+    assert.equal(existsSync(getCacheDir(tempHome)), false);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback safely returns when context_window is missing', () => {
+  assert.doesNotThrow(() => {
+    applyContextWindowFallback({ transcript_path: '/tmp/x.jsonl' }, makeDeps('/tmp/unused'));
+  });
+});
+
+test('applyContextWindowFallback is a no-op when transcript_path is missing', async () => {
+  const tempHome = await createTempHome();
+
+  try {
+    const stdin = makeHealthyFrame(undefined);
+    delete stdin.transcript_path;
+
+    applyContextWindowFallback(stdin, makeDeps(tempHome));
+
+    assert.equal(existsSync(getCacheDir(tempHome)), false);
+    assert.equal(stdin.context_window.used_percentage, 58);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback isolates cache between concurrent sessions', async () => {
+  const tempHome = await createTempHome();
+  const sessionA = '/tmp/session-a.jsonl';
+  const sessionB = '/tmp/session-b.jsonl';
+
+  try {
+    applyContextWindowFallback(makeHealthyFrame(sessionA), makeDeps(tempHome, 1_000_000));
+
+    const healthyB = makeHealthyFrame(sessionB, {
+      total_input_tokens: 60000,
+      used_percentage: 17,
+      remaining_percentage: 83,
+      current_usage: {
+        input_tokens: 40000,
+        output_tokens: 1200,
+        cache_creation_input_tokens: 300,
+        cache_read_input_tokens: 100,
+      },
+    });
+    applyContextWindowFallback(healthyB, makeDeps(tempHome, 1_000_001));
+
+    const cacheA = JSON.parse(await readFile(getCachePath(tempHome, sessionA), 'utf8'));
+    const cacheB = JSON.parse(await readFile(getCachePath(tempHome, sessionB), 'utf8'));
+    assert.equal(cacheA.used_percentage, 58);
+    assert.equal(cacheB.used_percentage, 17);
+
+    const suspiciousB = makeSuspiciousFrame();
+    suspiciousB.transcript_path = sessionB;
+    applyContextWindowFallback(suspiciousB, makeDeps(tempHome, 1_000_002));
+
+    assert.equal(suspiciousB.context_window.used_percentage, 17);
+    assert.equal(suspiciousB.context_window.remaining_percentage, 83);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback skips write when value unchanged and within TTL', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+
+  try {
+    applyContextWindowFallback(makeHealthyFrame(transcriptPath), makeDeps(tempHome, 1_000_000));
+
+    const first = JSON.parse(await readFile(getCachePath(tempHome, transcriptPath), 'utf8'));
+    assert.equal(first.saved_at, 1_000_000);
+
+    applyContextWindowFallback(makeHealthyFrame(transcriptPath), makeDeps(tempHome, 1_002_000));
+
+    const second = JSON.parse(await readFile(getCachePath(tempHome, transcriptPath), 'utf8'));
+    assert.equal(second.saved_at, 1_000_000, 'saved_at must not advance within TTL when value is unchanged');
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback rewrites cache after TTL elapses even with unchanged value', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+
+  try {
+    applyContextWindowFallback(makeHealthyFrame(transcriptPath), makeDeps(tempHome, 1_000_000));
+    applyContextWindowFallback(makeHealthyFrame(transcriptPath), makeDeps(tempHome, 1_015_000));
+
+    const refreshed = JSON.parse(await readFile(getCachePath(tempHome, transcriptPath), 'utf8'));
+    assert.equal(refreshed.saved_at, 1_015_000);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback rewrites cache immediately when used_percentage changes', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+
+  try {
+    applyContextWindowFallback(makeHealthyFrame(transcriptPath), makeDeps(tempHome, 1_000_000));
+
+    const changed = makeHealthyFrame(transcriptPath, {
+      used_percentage: 59,
+      remaining_percentage: 41,
+    });
+    applyContextWindowFallback(changed, makeDeps(tempHome, 1_002_000));
+
+    const refreshed = JSON.parse(await readFile(getCachePath(tempHome, transcriptPath), 'utf8'));
+    assert.equal(refreshed.used_percentage, 59);
+    assert.equal(refreshed.saved_at, 1_002_000);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback triggers sweep when random sample falls under the rate', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+  const cacheDir = getCacheDir(tempHome);
+  const now = 10_000_000_000;
+  const EIGHT_DAYS_MS = 8 * 24 * 60 * 60 * 1000;
+
+  try {
+    await mkdir(cacheDir, { recursive: true });
+    const stalePath = path.join(cacheDir, 'stale.json');
+    await writeFile(stalePath, '{}', 'utf8');
+    const staleTimeSec = (now - EIGHT_DAYS_MS) / 1000;
+    await utimes(stalePath, staleTimeSec, staleTimeSec);
+
+    applyContextWindowFallback(makeHealthyFrame(transcriptPath), {
+      homeDir: () => tempHome,
+      now: () => now,
+      random: () => 0,
+    });
+
+    assert.equal(existsSync(stalePath), false, 'stale file should be removed by sweep');
+    assert.equal(existsSync(getCachePath(tempHome, transcriptPath)), true, 'current session cache must survive');
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('_sweepCacheForTests removes entries older than the max age', async () => {
+  const tempHome = await createTempHome();
+  const cacheDir = getCacheDir(tempHome);
+  const now = 10_000_000_000;
+  const EIGHT_DAYS_MS = 8 * 24 * 60 * 60 * 1000;
+
+  try {
+    await mkdir(cacheDir, { recursive: true });
+    const stalePath = path.join(cacheDir, 'stale.json');
+    const freshPath = path.join(cacheDir, 'fresh.json');
+    await writeFile(stalePath, '{}', 'utf8');
+    await writeFile(freshPath, '{}', 'utf8');
+
+    const staleTimeSec = (now - EIGHT_DAYS_MS) / 1000;
+    await utimes(stalePath, staleTimeSec, staleTimeSec);
+    const freshTimeSec = (now - 1000) / 1000;
+    await utimes(freshPath, freshTimeSec, freshTimeSec);
+
+    _sweepCacheForTests(tempHome, now);
+
+    assert.equal(existsSync(stalePath), false);
+    assert.equal(existsSync(freshPath), true);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('_sweepCacheForTests evicts oldest entries when over the entry cap', async () => {
+  const tempHome = await createTempHome();
+  const cacheDir = getCacheDir(tempHome);
+  const now = 10_000_000_000;
+  const TOTAL = 105;
+  const CAP = 100;
+
+  try {
+    await mkdir(cacheDir, { recursive: true });
+
+    for (let i = 0; i < TOTAL; i += 1) {
+      const filePath = path.join(cacheDir, `entry-${i}.json`);
+      await writeFile(filePath, '{}', 'utf8');
+      const timeSec = (now - (TOTAL - i) * 1000) / 1000;
+      await utimes(filePath, timeSec, timeSec);
+    }
+
+    _sweepCacheForTests(tempHome, now);
+
+    for (let i = 0; i < TOTAL - CAP; i += 1) {
+      assert.equal(existsSync(path.join(cacheDir, `entry-${i}.json`)), false, `entry-${i} should be evicted`);
+    }
+    for (let i = TOTAL - CAP; i < TOTAL; i += 1) {
+      assert.equal(existsSync(path.join(cacheDir, `entry-${i}.json`)), true, `entry-${i} should survive`);
+    }
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Add session-scoped disk cache that preserves the last known-good context window snapshot and restores it when Claude Code reports a suspicious zero-usage frame
- Cache entries are isolated per session (sha256 of transcript path), TTL-throttled to reduce writes on the ~300ms statusline tick, and periodically swept to bound directory growth
- Include 384-line test suite covering: cache restore, missing/corrupted cache, concurrent session isolation, TTL skip/refresh, value-change immediate write, and stale entry cleanup

## Context

Claude Code occasionally emits context window frames where `used_percentage` and all token counters are zero despite accumulated conversation history. This causes the statusline to momentarily display an empty context bar, which is misleading to users.

Fixes #417

## Test plan

- [x] Unit tests in `tests/context-cache.test.js` (14 cases) pass via `node --test`
- [x] Verified cache files are created under `~/.claude/plugins/claude-hud/context-cache/`
- [x] Verified concurrent sessions use separate cache files
- [x] Verified corrupted cache files are silently ignored without crashing
- [x] Verified stale entries (>7 days) and excess entries (>100) are cleaned up
- [x] Manual: run claude-hud during a session and confirm context bar no longer drops to 0% intermittently