### PR TITLE
fix(render): only pad progress labels when lines stack

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -318,16 +318,21 @@ function collectActivityLines(ctx: RenderContext): string[] {
   return activityLines;
 }
 
-function renderElementLine(ctx: RenderContext, element: HudElement): string | null {
+function renderElementLine(
+  ctx: RenderContext,
+  element: HudElement,
+  options?: { alignProgressLabels?: boolean },
+): string | null {
   const display = ctx.config?.display;
+  const alignProgressLabels = options?.alignProgressLabels ?? false;
 
   switch (element) {
     case 'project':
       return renderProjectLine(ctx);
     case 'context':
-      return renderIdentityLine(ctx);
+      return renderIdentityLine(ctx, alignProgressLabels);
     case 'usage':
-      return renderUsageLine(ctx);
+      return renderUsageLine(ctx, alignProgressLabels);
     case 'memory':
       return renderMemoryLine(ctx);
     case 'environment':
@@ -382,8 +387,14 @@ function renderExpanded(ctx: RenderContext, terminalWidth: number | null = null)
         if (canCombine) {
           lines.push({ line: combinedLine, isActivity: false });
         } else {
-          lines.push({ line: firstLine, isActivity: false });
-          lines.push({ line: secondLine, isActivity: false });
+          const firstStackedLine = renderElementLine(ctx, element, {
+            alignProgressLabels: true,
+          }) ?? firstLine;
+          const secondStackedLine = renderElementLine(ctx, nextElement, {
+            alignProgressLabels: true,
+          }) ?? secondLine;
+          lines.push({ line: firstStackedLine, isActivity: false });
+          lines.push({ line: secondStackedLine, isActivity: false });
         }
       } else if (firstLine) {
         lines.push({ line: firstLine, isActivity: false });

--- a/src/render/lines/identity.ts
+++ b/src/render/lines/identity.ts
@@ -7,12 +7,15 @@ import {
 import { coloredBar, label, getContextColor, RESET } from "../colors.js";
 import { getAdaptiveBarWidth } from "../../utils/terminal.js";
 import { t } from "../../i18n/index.js";
-import { paddedLabel } from "./label-align.js";
+import { progressLabel } from "./label-align.js";
 
 const DEBUG =
   process.env.DEBUG?.includes("claude-hud") || process.env.DEBUG === "*";
 
-export function renderIdentityLine(ctx: RenderContext): string {
+export function renderIdentityLine(
+  ctx: RenderContext,
+  alignLabels = false,
+): string {
   const rawPercent = getContextPercent(ctx.stdin);
   const bufferedPercent = getBufferedPercent(ctx.stdin);
   const autocompactMode = ctx.config?.display?.autocompactBuffer ?? "enabled";
@@ -32,8 +35,8 @@ export function renderIdentityLine(ctx: RenderContext): string {
 
   let line =
     display?.showContextBar !== false
-      ? `${paddedLabel("label.context", colors)} ${coloredBar(percent, getAdaptiveBarWidth(), colors)} ${contextValueDisplay}`
-      : `${paddedLabel("label.context", colors)} ${contextValueDisplay}`;
+      ? `${progressLabel("label.context", colors, alignLabels)} ${coloredBar(percent, getAdaptiveBarWidth(), colors)} ${contextValueDisplay}`
+      : `${progressLabel("label.context", colors, alignLabels)} ${contextValueDisplay}`;
 
   if (display?.showTokenBreakdown !== false && percent >= 85) {
     const usage = ctx.stdin.context_window?.current_usage;

--- a/src/render/lines/label-align.ts
+++ b/src/render/lines/label-align.ts
@@ -70,5 +70,13 @@ export function paddedLabel(
   return label(padded, colors);
 }
 
+export function progressLabel(
+  key: MessageKey,
+  colors?: Partial<HudColorOverrides>,
+  align = false,
+): string {
+  return align ? paddedLabel(key, colors) : label(t(key), colors);
+}
+
 // Exported for testing only.
 export { plainTextWidth as _plainTextWidth, maxLabelWidth as _maxLabelWidth };

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -5,9 +5,12 @@ import { getProviderLabel } from "../../stdin.js";
 import { critical, label, getQuotaColor, quotaBar, RESET } from "../colors.js";
 import { getAdaptiveBarWidth } from "../../utils/terminal.js";
 import { t } from "../../i18n/index.js";
-import { paddedLabel } from "./label-align.js";
+import { progressLabel } from "./label-align.js";
 
-export function renderUsageLine(ctx: RenderContext): string | null {
+export function renderUsageLine(
+  ctx: RenderContext,
+  alignLabels = false,
+): string | null {
   const display = ctx.config?.display;
   const colors = ctx.config?.colors;
 
@@ -23,7 +26,7 @@ export function renderUsageLine(ctx: RenderContext): string | null {
     return null;
   }
 
-  const usageLabel = paddedLabel("label.usage", colors);
+  const usageLabel = progressLabel("label.usage", colors, alignLabels);
 
   if (isLimitReached(ctx.usageData)) {
     const resetTime =
@@ -56,6 +59,7 @@ export function renderUsageLine(ctx: RenderContext): string | null {
       usageBarEnabled,
       barWidth,
       forceLabel: true,
+      alignLabels,
     });
     return `${usageLabel} ${weeklyOnlyPart}`;
   }
@@ -79,6 +83,7 @@ export function renderUsageLine(ctx: RenderContext): string | null {
       usageBarEnabled,
       barWidth,
       forceLabel: true,
+      alignLabels,
     });
     return `${usageLabel} ${fiveHourPart} | ${sevenDayPart}`;
   }
@@ -106,6 +111,7 @@ function formatUsageWindowPart({
   usageBarEnabled,
   barWidth,
   forceLabel = false,
+  alignLabels = false,
 }: {
   label: string;
   labelKey?: MessageKey;
@@ -115,11 +121,12 @@ function formatUsageWindowPart({
   usageBarEnabled: boolean;
   barWidth: number;
   forceLabel?: boolean;
+  alignLabels?: boolean;
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors);
   const reset = formatResetTime(resetAt);
   const styledLabel = labelKey
-    ? paddedLabel(labelKey, colors)
+    ? progressLabel(labelKey, colors, alignLabels)
     : label(windowLabel, colors);
 
   if (usageBarEnabled) {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -554,7 +554,8 @@ test('label color overrides apply across shared secondary text surfaces', () => 
 
   const expected = '\x1b[38;2;171;205;239m';
   assert.ok(renderIdentityLine(ctx).includes(`${expected}Context\x1b[0m`));
-  assert.ok(renderUsageLine(ctx)?.includes(`${expected}Usage  \x1b[0m`));
+  assert.ok(renderUsageLine(ctx)?.includes(`${expected}Usage\x1b[0m`));
+  assert.ok(renderUsageLine(ctx, true)?.includes(`${expected}Usage  \x1b[0m`));
   assert.ok(renderEnvironmentLine(ctx)?.includes(`${expected}2 CLAUDE.md | 1 rules\x1b[0m`));
   assert.ok(renderMemoryLine({ ...ctx, config: { ...ctx.config, lineLayout: 'expanded', display: { ...ctx.config.display, showMemoryUsage: true } } })?.includes(`${expected}Approx RAM\x1b[0m`));
   assert.ok(renderToolsLine(ctx)?.includes(`${expected}: src/index.ts\x1b[0m`));
@@ -1240,7 +1241,7 @@ test('renderUsageLine shows 7d reset countdown in text-only mode', () => {
 
   const line = stripAnsi(renderUsageLine(ctx));
   assert.ok(line.includes('5h 45%'), `should include 5h text-only usage: ${line}`);
-  assert.ok(line.includes('Weekly  85%'), `should include 7d text-only usage: ${line}`);
+  assert.ok(line.includes('Weekly 85%'), `should include 7d text-only usage: ${line}`);
   assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in text-only mode: ${line}`);
 });
 
@@ -1785,6 +1786,10 @@ test('render expanded layout combines usage and context when adjacent in element
   assert.ok(lines[0].includes('Usage'), 'combined line should include usage');
   assert.ok(lines[0].includes('Context'), 'combined line should include context');
   assert.ok(lines[0].includes('│'), 'combined line should preserve the shared separator');
+  const stripped = stripAnsi(lines[0]);
+  assert.ok(stripped.includes('Usage 5h 30%'), `combined line should keep the default unpadded usage label: ${stripped}`);
+  assert.ok(!stripped.includes('Usage  5h 30%'), `combined line should not pad the usage label: ${stripped}`);
+  assert.ok(!stripped.includes('Weekly '), `combined line should not pad the weekly label: ${stripped}`);
 });
 
 test('render expanded layout keeps usage and context separate when not adjacent', () => {
@@ -1808,6 +1813,31 @@ test('render expanded layout keeps usage and context separate when not adjacent'
   assert.ok(usageLine, 'usage should render on its own line');
   assert.ok(contextLine, 'context should render on its own line');
   assert.equal(combinedLine, undefined, 'usage and context should not combine when separated by another element');
+});
+
+test('render expanded layout aligns progress labels only after wrapping to separate lines', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.usageData = {
+    planName: 'Team',
+    fiveHour: 45,
+    sevenDay: 85,
+    fiveHourResetAt: new Date(Date.now() + 90 * 60 * 1000),
+    sevenDayResetAt: new Date(Date.now() + 4 * 24 * 60 * 60 * 1000),
+  };
+  ctx.config.elementOrder = ['usage', 'context'];
+
+  const lines = withTerminal(24, () => captureRenderLines(ctx)).map(stripAnsi);
+  const usageLine = lines.find((line) => line.includes('Usage'));
+  const contextLine = lines.find((line) => line.includes('Context'));
+  const weeklyLine = lines.find((line) => line.includes('Weekly'));
+
+  assert.ok(usageLine, `narrow terminals should keep the usage line visible: ${lines.join(' | ')}`);
+  assert.ok(contextLine, `narrow terminals should keep the context line visible: ${lines.join(' | ')}`);
+  assert.ok(weeklyLine, `narrow terminals should keep the weekly segment visible: ${lines.join(' | ')}`);
+  assert.ok(usageLine.startsWith('Usage  '), `usage line should pad its label when stacked: ${usageLine}`);
+  assert.ok(weeklyLine.startsWith('Weekly '), `weekly label should pad when stacked: ${weeklyLine}`);
+  assert.ok(contextLine.startsWith('Context'), `context line should stay aligned with the padded usage label: ${contextLine}`);
 });
 
 test('render compact layout keeps activity lines even when elementOrder omits them', () => {


### PR DESCRIPTION
## Summary
- keep the default combined expanded line unpadded
- apply progress-label padding only when usage and context actually stack on separate lines
- add regression coverage for both combined and stacked layouts

## Testing
- npm test