### PR TITLE
feat: effort level display in model bracket

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -112,7 +112,7 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
 1. Get plugin path (sorted by dotted numeric version, not modification time):
    ```bash
-   ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '{ print $(NF-1) "\t" $(0) }' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-
+   ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '{ print $(NF-1) "\t" $(0) }' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\t' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-
    ```
    If empty, the plugin is not installed. Go back to Step 0 to check for ghost installation or EXDEV issues. If Step 0 was clean, ask the user to install via `/plugin install claude-hud` first.
 
@@ -159,12 +159,12 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
    **When runtime is bun** - add `--env-file /dev/null` to prevent Bun from auto-loading project `.env` files:
    ```
-   bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
+   bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | grep -E '"'"'^[0-9]+\.[0-9]+\.[0-9]+\t'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
    ```
 
    **When runtime is node**:
    ```
-   bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
+   bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | grep -E '"'"'^[0-9]+\.[0-9]+\.[0-9]+\t'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
    ```
 
 **Windows + Git Bash** (Platform: `win32`, Shell: `bash`):

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,6 +90,7 @@ export interface HudConfig {
     showTodos: boolean;
     showSessionName: boolean;
     showClaudeCodeVersion: boolean;
+    showEffortLevel: boolean;
     showMemoryUsage: boolean;
     showSessionTokens: boolean;
     showOutputStyle: boolean;
@@ -136,6 +137,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showTodos: false,
     showSessionName: false,
     showClaudeCodeVersion: false,
+    showEffortLevel: false,
     showMemoryUsage: false,
     showSessionTokens: false,
     showOutputStyle: false,
@@ -369,6 +371,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showClaudeCodeVersion: typeof migrated.display?.showClaudeCodeVersion === 'boolean'
       ? migrated.display.showClaudeCodeVersion
       : DEFAULT_CONFIG.display.showClaudeCodeVersion,
+    showEffortLevel: typeof migrated.display?.showEffortLevel === 'boolean'
+      ? migrated.display.showEffortLevel
+      : DEFAULT_CONFIG.display.showEffortLevel,
     showMemoryUsage: typeof migrated.display?.showMemoryUsage === 'boolean'
       ? migrated.display.showMemoryUsage
       : DEFAULT_CONFIG.display.showMemoryUsage,

--- a/src/effort.ts
+++ b/src/effort.ts
@@ -1,0 +1,66 @@
+import { execFileSync } from 'node:child_process';
+
+export interface EffortInfo {
+  level: string;
+  symbol: string;
+}
+
+const KNOWN_SYMBOLS: Record<string, string> = {
+  low: '○',
+  medium: '◔',
+  high: '◑',
+  xhigh: '◕',
+  max: '●',
+};
+
+/**
+ * Resolve the current session's effort level.
+ *
+ * Priority:
+ * 1. stdin.effort (future — when Claude Code exposes it in statusline JSON)
+ * 2. Parent process CLI args (reflects --effort flag at session start)
+ *
+ * Returns null if effort cannot be determined.
+ */
+export function resolveEffortLevel(stdinEffort?: string | null): EffortInfo | null {
+  if (stdinEffort) {
+    return formatEffort(stdinEffort);
+  }
+
+  const cliEffort = readParentProcessEffort();
+  if (cliEffort) {
+    return formatEffort(cliEffort);
+  }
+
+  return null;
+}
+
+function formatEffort(level: string): EffortInfo {
+  const normalized = level.toLowerCase().trim();
+  const symbol = KNOWN_SYMBOLS[normalized] ?? '';
+  return { level: normalized, symbol };
+}
+
+function readParentProcessEffort(): string | null {
+  if (process.platform === 'win32') {
+    return null;
+  }
+
+  try {
+    const ppid = process.ppid;
+    if (!ppid || ppid <= 1) {
+      return null;
+    }
+
+    const output = execFileSync('ps', ['-o', 'args=', '-p', String(ppid)], {
+      encoding: 'utf8',
+      timeout: 500,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    const match = output.match(/--effort[= ]+(\w+)/);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { loadConfig } from "./config.js";
 import { parseExtraCmdArg, runExtraCmd } from "./extra-cmd.js";
 import { getClaudeCodeVersion } from "./version.js";
 import { getMemoryUsage } from "./memory.js";
+import { resolveEffortLevel } from "./effort.js";
 import { setLanguage, t } from "./i18n/index.js";
 import type { RenderContext } from "./types.js";
 import { fileURLToPath } from "node:url";
@@ -89,6 +90,9 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     const claudeCodeVersion = config.display.showClaudeCodeVersion
       ? await deps.getClaudeCodeVersion()
       : undefined;
+    const effortInfo = config.display.showEffortLevel
+      ? resolveEffortLevel(stdin.effort)
+      : null;
     const memoryUsage =
       config.display.showMemoryUsage && config.lineLayout === "expanded"
         ? await deps.getMemoryUsage()
@@ -109,6 +113,8 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       extraLabel,
       outputStyle,
       claudeCodeVersion,
+      effortLevel: effortInfo?.level,
+      effortSymbol: effortInfo?.symbol,
     };
 
     deps.render(ctx);

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -22,7 +22,12 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     const model = formatModelName(getModelName(ctx.stdin), ctx.config?.display?.modelFormat, ctx.config?.display?.modelOverride);
     const providerLabel = getProviderLabel(ctx.stdin);
     const modelQualifier = providerLabel ?? undefined;
-    const modelDisplay = modelQualifier ? `${model} | ${modelQualifier}` : model;
+    let modelDisplay = modelQualifier ? `${model} | ${modelQualifier}` : model;
+    if (ctx.effortLevel && ctx.effortSymbol) {
+      modelDisplay += ` ${ctx.effortSymbol}${ctx.effortLevel}`;
+    } else if (ctx.effortLevel) {
+      modelDisplay += ` ${ctx.effortLevel}`;
+    }
     parts.push(modelColor(`[${modelDisplay}]`, colors));
   }
 

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -42,7 +42,12 @@ export function renderSessionLine(ctx: RenderContext): string {
   // Model and context bar (FIRST)
   const providerLabel = getProviderLabel(ctx.stdin);
   const modelQualifier = providerLabel ?? undefined;
-  const modelDisplay = modelQualifier ? `${model} | ${modelQualifier}` : model;
+  let modelDisplay = modelQualifier ? `${model} | ${modelQualifier}` : model;
+  if (ctx.effortLevel && ctx.effortSymbol) {
+    modelDisplay += ` ${ctx.effortSymbol}${ctx.effortLevel}`;
+  } else if (ctx.effortLevel) {
+    modelDisplay += ` ${ctx.effortLevel}`;
+  }
 
   if (display?.showModel !== false && display?.showContextBar !== false) {
     parts.push(`${modelColor(`[${modelDisplay}]`, colors)} ${bar} ${contextValueDisplay}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,8 @@ export interface StdinData {
       resets_at?: number | null;
     } | null;
   } | null;
+  // Future: Claude Code may expose effort level directly in stdin JSON
+  effort?: string | null;
 }
 
 export interface ToolEntry {
@@ -113,4 +115,6 @@ export interface RenderContext {
   extraLabel: string | null;
   outputStyle?: string;
   claudeCodeVersion?: string;
+  effortLevel?: string;
+  effortSymbol?: string;
 }

--- a/tests/effort.test.js
+++ b/tests/effort.test.js
@@ -1,0 +1,54 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { resolveEffortLevel } from '../dist/effort.js';
+
+describe('resolveEffortLevel', () => {
+  describe('stdin effort (future Claude Code support)', () => {
+    it('returns effort info when stdin provides effort level', () => {
+      const result = resolveEffortLevel('max');
+      assert.deepStrictEqual(result, { level: 'max', symbol: '●' });
+    });
+
+    it('normalizes effort level to lowercase', () => {
+      const result = resolveEffortLevel('HIGH');
+      assert.deepStrictEqual(result, { level: 'high', symbol: '◑' });
+    });
+
+    it('handles all known effort levels', () => {
+      assert.deepStrictEqual(resolveEffortLevel('low'), { level: 'low', symbol: '○' });
+      assert.deepStrictEqual(resolveEffortLevel('medium'), { level: 'medium', symbol: '◔' });
+      assert.deepStrictEqual(resolveEffortLevel('high'), { level: 'high', symbol: '◑' });
+      assert.deepStrictEqual(resolveEffortLevel('xhigh'), { level: 'xhigh', symbol: '◕' });
+      assert.deepStrictEqual(resolveEffortLevel('max'), { level: 'max', symbol: '●' });
+    });
+
+    it('handles unknown future effort levels with empty symbol', () => {
+      const result = resolveEffortLevel('turbo');
+      assert.deepStrictEqual(result, { level: 'turbo', symbol: '' });
+    });
+
+    it('returns null when stdin effort is null', () => {
+      const result = resolveEffortLevel(null);
+      // Falls through to parent process detection (may or may not find effort)
+      // We just verify it doesn't throw
+      assert.ok(result === null || typeof result.level === 'string');
+    });
+
+    it('returns null when stdin effort is undefined', () => {
+      const result = resolveEffortLevel(undefined);
+      assert.ok(result === null || typeof result.level === 'string');
+    });
+
+    it('returns null for empty string', () => {
+      const result = resolveEffortLevel('');
+      assert.ok(result === null || typeof result.level === 'string');
+    });
+  });
+
+  describe('stdin takes priority over parent process', () => {
+    it('uses stdin value even if parent process has different effort', () => {
+      const result = resolveEffortLevel('low');
+      assert.strictEqual(result?.level, 'low');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Displays reasoning effort level inside the model bracket: `[Opus 4.6 ●max]`
- Opt-in via `display.showEffortLevel: true` (off by default)
- **Data source**: Reads `stdin.effort` first (future-proof for when Claude Code adds it — see anthropics/claude-code#39399, #50060, #50577, #45805), falls back to parent process CLI args (`--effort` flag)
- Progressive fill symbols for visual clarity: `○` low · `◔` medium · `◑` high · `◕` xhigh · `●` max
- Unknown future levels display as plain text (forward-compatible)
- Works in both compact and expanded layouts

## Bug Fix (setup.md)

The bash version selector in `commands/setup.md` doesn't filter non-semver directories, unlike the PowerShell version which has `Where-Object { $_.Name -match '^\d+(\.\d+)+$' }`. This causes the HUD to silently use the wrong directory if backup/temp directories exist (e.g., `0.0.10.bak`).

**Fix**: Added `grep -E '^[0-9]+\.[0-9]+\.[0-9]+\t'` before `sort` in all bash templates.

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| Model bracket placement | Effort is a property of the model's behavior — natural to group together |
| stdin.effort priority | Authoritative source when available; ready for upstream support |
| Parent process fallback | `ps -o args=` detects `--effort` CLI flag at session start |
| No settings.json fallback | Settings reflect defaults, not per-session state — would be misleading |
| String-based (not enum) | Forward-compatible with any future effort levels Claude Code may add |

## Configuration

```json
{
  "display": {
    "showEffortLevel": true
  }
}
```

## Visual Examples

```
[Opus 4.6 ●max] ████░░░░░░ 45%     ← effort max
[Sonnet 4.6 ◑high] ██░░░░░░░░ 20%   ← effort high  
[Opus 4.6] ████░░░░░░ 45%           ← effort not detected (graceful)
```

## Test Plan

- [x] All 399 existing tests pass (0 failures)
- [x] 8 new effort tests pass (stdin priority, all levels, normalization, unknown levels)
- [x] `npm run build` succeeds
- [x] Manual test: compact layout shows `[Model ●max]`
- [x] Manual test: expanded layout shows `[Model ●max]`
- [x] Manual test: unknown level shows plain text (no symbol)
- [ ] Verify with real Claude Code session (requires `showEffortLevel: true` in config)

Closes #201
Relates to anthropics/claude-code#39399, #50060, #50577, #45805