### PR TITLE
release: bump version to 0.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hud",
   "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hud",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hud",
-      "version": "0.0.12",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hud",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "description": "Real-time statusline HUD for Claude Code",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump package metadata from 0.0.12 to 0.1.0
- align the plugin manifest and lockfile with the release version

## Why
The repo has accumulated a full backlog batch of merged fixes and user-facing additions since v0.0.12. This release bump makes the published version match the current repo state.

## Test plan
- metadata-only change
