### PR TITLE
fix(setup): harden Windows statusline runtime path

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ After that, reload plugins:
 <details>
 <summary><strong>⚠️ Windows users: Click here if setup says no JavaScript runtime was found</strong></summary>
 
-On Windows, Node.js LTS is the recommended runtime for Claude HUD. If setup says no JavaScript runtime was found, install Node.js for your shell first:
+On Windows, Node.js LTS is the supported runtime for Claude HUD setup. If setup says no JavaScript runtime was found, install Node.js for your shell first:
 ```powershell
 winget install OpenJS.NodeJS.LTS
 ```
@@ -321,7 +321,8 @@ Set `display.usageCompact` to `true` if you want the shorter usage-only form, fo
 ## Requirements
 
 - Claude Code v1.0.80+
-- Node.js 18+ or Bun
+- macOS/Linux: Node.js 18+ or Bun
+- Windows: Node.js 18+
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -55,7 +55,7 @@ mkdir -p ~/.cache/tmp && TMPDIR=~/.cache/tmp claude
 <details>
 <summary><strong>⚠️ Windows 用户：如果 setup 提示未找到 JavaScript 运行时，请点击此处</strong></summary>
 
-在 Windows 上，推荐使用 Node.js LTS 作为 Claude HUD 的运行时。如果 setup 提示未找到 JavaScript 运行时，请先为你的 shell 安装 Node.js：
+在 Windows 上，Claude HUD setup 支持的运行时是 Node.js LTS。如果 setup 提示未找到 JavaScript 运行时，请先为你的 shell 安装 Node.js：
 ```powershell
 winget install OpenJS.NodeJS.LTS
 ```
@@ -307,7 +307,8 @@ ClaudeHUD 有意仅信任官方的 statusline stdin 负载中的实时使用率�
 ## 运行环境要求
 
 - Claude Code v1.0.80+
-- Node.js 18+ 或 Bun
+- macOS/Linux：Node.js 18+ 或 Bun
+- Windows：Node.js 18+
 
 ---
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -103,7 +103,7 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 |----------|-------|----------------|
 | `darwin` | any | bash (macOS instructions) |
 | `linux` | any | bash (Linux instructions) |
-| `win32` | `bash` (Git Bash, MSYS2) | bash - use macOS/Linux instructions. Never use PowerShell commands with bash. |
+| `win32` | `bash` (Git Bash, MSYS2) | bash - use Windows + Git Bash instructions. Never use PowerShell commands with bash. |
 | `win32` | `powershell`, `pwsh`, or `cmd` | PowerShell (use Windows + PowerShell instructions) |
 
 ---
@@ -121,19 +121,20 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
      ```bash
      command -v bun 2>/dev/null || command -v node 2>/dev/null
      ```
-   - On `win32` + `bash`, prefer node first and only fall back to bun because Bun is currently unstable for frequent statusLine invocations on Windows:
+   - On `win32` + `bash`, require node. Do not fall back to bun on Windows:
      ```bash
-     command -v node 2>/dev/null || command -v bun 2>/dev/null
+     command -v node 2>/dev/null
      ```
 
-   If empty, stop setup and explain that the current shell cannot find `bun` or `node`.
-   - On **Windows + Git Bash/MSYS2**, explicitly explain that the current Git Bash session could not find `bun` or `node`, even if Claude Code itself is installed.
+   If empty, stop setup and explain that the current shell cannot find the required runtime.
+   - On **Windows + Git Bash/MSYS2**, explicitly explain that the current Git Bash session could not find Node.js, even if Claude Code itself is installed.
    - If `winget` is available, recommend:
      ```bash
      winget install OpenJS.NodeJS.LTS
      ```
-   - Otherwise ask the user to install one of these:
-     - Node.js LTS from https://nodejs.org/ (recommended on Windows)
+   - On Windows, ask the user to install Node.js LTS from https://nodejs.org/
+   - On macOS/Linux, ask the user to install one of these:
+     - Node.js LTS from https://nodejs.org/
      - Bun from https://bun.sh/
    - After installation, ask the user to restart their shell and re-run `/claude-hud:setup`.
 
@@ -144,10 +145,8 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
    If it doesn't exist, re-detect or ask user to verify their installation.
 
 4. Determine source file based on runtime:
-   ```bash
-   basename {RUNTIME_PATH}
-   ```
-   If result is "bun", use `src/index.ts` (bun has native TypeScript support). Otherwise use `dist/index.js` (pre-compiled).
+   - On `darwin` or `linux`, use `src/index.ts` when the runtime is bun. Otherwise use `dist/index.js`.
+   - On Windows, always use `dist/index.js`.
 
 5. Generate command (quotes around runtime path handle spaces):
 
@@ -171,20 +170,14 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
 Do not use PowerShell commands when the shell is bash. Claude Code invokes statusLine commands through bash, which will interpret PowerShell variables like `$env` and `$p` before PowerShell ever sees them.
 
-On Windows prefer `node` first and only fall back to `bun`.
+On Windows require `node` and always use `dist/index.js`.
 
 **Important**: Do **not** reuse the macOS/Linux awk-based command on Windows + Git Bash. The `awk` fragment requires `'"'"'` quoting to nest single quotes inside `bash -c '...'`. After JSON encoding and decoding, this quoting breaks on Windows Git Bash, causing a silent syntax error that prevents the HUD process from starting (see [#326](https://github.com/jarrodwatts/claude-hud/issues/326)).
 
-Instead, use `sort -V` (GNU version sort, included with Git for Windows) which avoids nested single quotes entirely. The command still exports `COLUMNS` so the HUD receives the real terminal width, and it uses the marketplace-aware cache glob:
+Instead, use `sort -V` (GNU version sort, included with Git for Windows) which avoids nested single quotes entirely. Also avoid wrapping the generated command in a second `bash -c ...` layer. Claude Code is already invoking the statusline through bash, so the direct shell command lets `exec` replace that shell instead of spawning an extra bash wrapper first. The command still exports `COLUMNS` so the HUD receives the real terminal width, and it uses the marketplace-aware cache glob:
 
-   **When runtime is bun** - add `--env-file /dev/null` to prevent Bun from auto-loading project `.env` files:
    ```
-   bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -1d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | sort -V | tail -1); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
-   ```
-
-   **When runtime is node**:
-   ```
-   bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -1d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | sort -V | tail -1); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
+   cols=$(stty size </dev/tty 2>/dev/null | awk '{print $2}'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -1d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | sort -V | tail -1); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"
    ```
 
 **Windows + PowerShell** (Platform: `win32`, Shell: `powershell`, `pwsh`, or `cmd`):
@@ -196,20 +189,20 @@ Instead, use `sort -V` (GNU version sort, included with Git for Windows) which a
    ```
    If empty or errors, the plugin is not installed. Ask the user to install via marketplace first.
 
-2. Get runtime absolute path (prefer node, fallback to bun on Windows):
+2. Get runtime absolute path (require node on Windows):
    ```powershell
-   if (Get-Command node -ErrorAction SilentlyContinue) { (Get-Command node).Source } elseif (Get-Command bun -ErrorAction SilentlyContinue) { (Get-Command bun).Source } else { Write-Error "Neither node nor bun found" }
+   if (Get-Command node -ErrorAction SilentlyContinue) { (Get-Command node).Source } else { Write-Error "Node.js not found" }
    ```
 
-   If neither found, stop setup and explain that the current PowerShell session cannot find `bun` or `node`.
+   If node is not found, stop setup and explain that the current PowerShell session cannot find Node.js.
    - If `winget` is available, recommend:
      ```powershell
      winget install OpenJS.NodeJS.LTS
      ```
-   - Otherwise ask the user to install either Node.js LTS or Bun, then restart PowerShell and re-run `/claude-hud:setup`.
-   - On Windows, prefer Node.js when both are available because Bun is currently unstable for repeated statusLine execution.
+   - Otherwise ask the user to install Node.js LTS, then restart PowerShell and re-run `/claude-hud:setup`.
+   - On Windows, do not offer Bun for statusLine setup. Use Node.js only.
 
-3. Check if runtime is bun (by filename). If bun, use `src\index.ts`. Otherwise use `dist\index.js`.
+3. Use `dist\index.js`.
 
 4. Generate command (note: quotes around runtime path handle spaces in paths):
 
@@ -217,12 +210,6 @@ Instead, use `sort -V` (GNU version sort, included with Git for Windows) which a
    `[Console]::WindowWidth` reads the console buffer width. The `- 4`
    accounts for Claude Code's input area padding (2 columns on each side).
 
-   **When runtime is bun** - add `--env-file NUL` to prevent Bun from auto-loading project `.env` files:
-   ```
-   powershell -Command "& {$env:COLUMNS=[Math]::Max(1,[Console]::WindowWidth-4); $claudeDir=if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME '.claude' }; $p=(Get-ChildItem (Join-Path $claudeDir 'plugins\cache\*\claude-hud') -Directory | Where-Object { $_.Name -match '^\d+(\.\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName; & '{RUNTIME_PATH}' '--env-file' 'NUL' (Join-Path $p '{SOURCE}')}"
-   ```
-
-   **When runtime is node**:
    ```
    powershell -Command "& {$env:COLUMNS=[Math]::Max(1,[Console]::WindowWidth-4); $claudeDir=if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME '.claude' }; $p=(Get-ChildItem (Join-Path $claudeDir 'plugins\cache\*\claude-hud') -Directory | Where-Object { $_.Name -match '^\d+(\.\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName; & '{RUNTIME_PATH}' (Join-Path $p '{SOURCE}')}"
    ```
@@ -266,7 +253,7 @@ After successfully writing the config, tell the user:
 > Once restarted, run `/claude-hud:setup` again to complete Step 4 and verify the HUD is working.
 
 **Windows note**: Keep the restart guidance separate from runtime installation guidance.
-- If the user just installed Node.js or Bun, they should restart their shell first so `bun` or `node` is available in `PATH`.
+- If the user just installed Node.js, they should restart their shell first so `node` is available in `PATH`.
 - After `statusLine` is written successfully, they should fully quit Claude Code and launch a fresh session before judging whether the HUD setup worked.
 
 **Note**: The generated command dynamically finds and runs the latest installed plugin version. Updates are automatic - no need to re-run setup after plugin updates. If the HUD suddenly stops working, re-run `/claude-hud:setup` to verify the plugin is still installed.
@@ -335,7 +322,7 @@ Use AskUserQuestion:
    - Runtime path might be wrong: `ls -la {RUNTIME_PATH}`
    - On macOS with mise/nvm/asdf: the absolute path may have changed after a runtime update
    - Symlinks may be stale: `command -v node` often returns a symlink that can break after version updates
-   - Solution: re-detect with `command -v bun` or `command -v node`, and verify with `realpath {RUNTIME_PATH}` (or `readlink -f {RUNTIME_PATH}`) to get the true absolute path
+   - Solution: re-detect the runtime path (`command -v node` on Windows, `command -v bun` or `command -v node` on macOS/Linux), and verify with `realpath {RUNTIME_PATH}` (or `readlink -f {RUNTIME_PATH}`) to get the true absolute path
 
    **"No such file or directory" for plugin**:
    - Plugin might not be installed: `ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/`


### PR DESCRIPTION
## Summary
- require Node.js for Windows setup instead of falling back to Bun
- generate a direct Git Bash command instead of nesting a second  wrapper
- document the Windows runtime support policy in the README files

## Why
Issue #403 is at the setup/launcher boundary, not in the HUD render loop itself. This change keeps the fix in that boundary: Windows setup now writes the most stable command shape we can support, and it stops offering the Bun path that is already documented as unstable on Windows.

## Test plan
- doc and setup-instruction change only
- manually checked the generated command examples and Windows runtime guidance for internal consistency

Closes #403
