### PR TITLE
feat(git): add wrapped branch overflow mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `gitStatus.pushWarningThreshold` | number | 0 | Color the ahead count with the warning color at or above this unpushed-commit count (`0` disables it) |
 | `gitStatus.pushCriticalThreshold` | number | 0 | Color the ahead count with the critical color at or above this unpushed-commit count (`0` disables it) |
 | `gitStatus.showFileStats` | boolean | false | Show file change counts `!M +A ✘D ?U` |
+| `gitStatus.branchOverflow` | `truncate` \| `wrap` | `truncate` | Keep current truncation behavior or let the git block wrap onto its own line boundary when possible |
 | `display.showModel` | boolean | true | Show model name `[Opus]` |
 | `display.showContextBar` | boolean | true | Show visual context bar `████░░░░░░` |
 | `display.contextValue` | `percent` \| `tokens` \| `remaining` \| `both` | `percent` | Context display format (`45%`, `45k/200k`, `55%` remaining, or `45% (45k/200k)`) |

--- a/README.zh.md
+++ b/README.zh.md
@@ -161,6 +161,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `gitStatus.pushWarningThreshold` | number | 0 | 当未推送提交数达到此值时，用警告色显示 ahead 计数（`0` 表示禁用） |
 | `gitStatus.pushCriticalThreshold` | number | 0 | 当未推送提交数达到此值时，用严重色显示 ahead 计数（`0` 表示禁用） |
 | `gitStatus.showFileStats` | boolean | false | 显示文件变更数量 `!M +A ✘D ?U` |
+| `gitStatus.branchOverflow` | `truncate` \| `wrap` | `truncate` | 保持当前截断行为，或在可能时让 git 块以自己的换行边界单独换到下一行 |
 | `display.showModel` | boolean | true | 显示模型名称 `[Opus]` |
 | `display.showContextBar` | boolean | true | 显示可视化上下文进度条 `████░░░░░░` |
 | `display.contextValue` | `percent` \| `tokens` \| `remaining` \| `both` | `percent` | 上下文显示格式（`45%`、`45k/200k`、剩余 `55%` 或 `45% (45k/200k)`） |

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export type LineLayoutType = 'compact' | 'expanded';
 
 export type AutocompactBufferMode = 'enabled' | 'disabled';
 export type ContextValueMode = 'percent' | 'tokens' | 'remaining' | 'both';
+export type GitBranchOverflowMode = 'truncate' | 'wrap';
 
 /**
  * Controls how the model name is displayed in the HUD badge.
@@ -71,6 +72,7 @@ export interface HudConfig {
     showDirty: boolean;
     showAheadBehind: boolean;
     showFileStats: boolean;
+    branchOverflow: GitBranchOverflowMode;
     pushWarningThreshold: number;
     pushCriticalThreshold: number;
   };
@@ -121,6 +123,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showDirty: true,
     showAheadBehind: false,
     showFileStats: false,
+    branchOverflow: 'truncate',
     pushWarningThreshold: 0,
     pushCriticalThreshold: 0,
   },
@@ -186,6 +189,10 @@ function validateLineLayout(value: unknown): value is LineLayoutType {
 
 function validateAutocompactBuffer(value: unknown): value is AutocompactBufferMode {
   return value === 'enabled' || value === 'disabled';
+}
+
+function validateGitBranchOverflow(value: unknown): value is GitBranchOverflowMode {
+  return value === 'truncate' || value === 'wrap';
 }
 
 function validateContextValue(value: unknown): value is ContextValueMode {
@@ -329,6 +336,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showFileStats: typeof migrated.gitStatus?.showFileStats === 'boolean'
       ? migrated.gitStatus.showFileStats
       : DEFAULT_CONFIG.gitStatus.showFileStats,
+    branchOverflow: validateGitBranchOverflow(migrated.gitStatus?.branchOverflow)
+      ? migrated.gitStatus.branchOverflow
+      : DEFAULT_CONFIG.gitStatus.branchOverflow,
     pushWarningThreshold: validateCountThreshold(migrated.gitStatus?.pushWarningThreshold),
     pushCriticalThreshold: validateCountThreshold(migrated.gitStatus?.pushCriticalThreshold),
   };

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -43,6 +43,7 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   let gitPart = '';
   const gitConfig = ctx.config?.gitStatus;
   const showGit = gitConfig?.enabled ?? true;
+  const branchOverflow = gitConfig?.branchOverflow ?? 'truncate';
 
   if (showGit && ctx.gitStatus) {
     const branchText = ctx.gitStatus.branch + ((gitConfig?.showDirty ?? true) && ctx.gitStatus.isDirty ? '*' : '');
@@ -71,7 +72,12 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   }
 
   if (projectPart && gitPart) {
-    parts.push(`${projectPart} ${gitPart}`);
+    if (branchOverflow === 'wrap') {
+      parts.push(projectPart);
+      parts.push(gitPart);
+    } else {
+      parts.push(`${projectPart} ${gitPart}`);
+    }
   } else if (projectPart) {
     parts.push(projectPart);
   } else if (gitPart) {

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -74,6 +74,7 @@ export function renderSessionLine(ctx: RenderContext): string {
   let gitPart = '';
   const gitConfig = ctx.config?.gitStatus;
   const showGit = gitConfig?.enabled ?? true;
+  const branchOverflow = gitConfig?.branchOverflow ?? 'truncate';
 
   if (showGit && ctx.gitStatus) {
     const gitParts: string[] = [ctx.gitStatus.branch];
@@ -110,7 +111,12 @@ export function renderSessionLine(ctx: RenderContext): string {
   }
 
   if (projectPart && gitPart) {
-    parts.push(`${projectPart} ${gitPart}`);
+    if (branchOverflow === 'wrap') {
+      parts.push(projectPart);
+      parts.push(gitPart);
+    } else {
+      parts.push(`${projectPart} ${gitPart}`);
+    }
   } else if (projectPart) {
     parts.push(projectPart);
   } else if (gitPart) {

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -42,6 +42,7 @@ test('loadConfig returns valid config structure', async () => {
   assert.equal(typeof config.gitStatus.enabled, 'boolean');
   assert.equal(typeof config.gitStatus.showDirty, 'boolean');
   assert.equal(typeof config.gitStatus.showAheadBehind, 'boolean');
+  assert.ok(['truncate', 'wrap'].includes(config.gitStatus.branchOverflow), 'branchOverflow should be valid');
   assert.equal(typeof config.gitStatus.pushWarningThreshold, 'number');
   assert.equal(typeof config.gitStatus.pushCriticalThreshold, 'number');
 
@@ -131,6 +132,7 @@ test('mergeConfig preserves explicit showCost=true', () => {
 
 test('mergeConfig defaults git push thresholds to disabled', () => {
   const config = mergeConfig({});
+  assert.equal(config.gitStatus.branchOverflow, 'truncate');
   assert.equal(config.gitStatus.pushWarningThreshold, 0);
   assert.equal(config.gitStatus.pushCriticalThreshold, 0);
 });
@@ -141,6 +143,16 @@ test('mergeConfig preserves explicit git push thresholds', () => {
   });
   assert.equal(config.gitStatus.pushWarningThreshold, 15);
   assert.equal(config.gitStatus.pushCriticalThreshold, 30);
+});
+
+test('mergeConfig preserves valid git branch overflow modes', () => {
+  assert.equal(mergeConfig({ gitStatus: { branchOverflow: 'wrap' } }).gitStatus.branchOverflow, 'wrap');
+  assert.equal(mergeConfig({ gitStatus: { branchOverflow: 'truncate' } }).gitStatus.branchOverflow, 'truncate');
+});
+
+test('mergeConfig falls back to truncate for invalid git branch overflow values', () => {
+  assert.equal(mergeConfig({ gitStatus: { branchOverflow: 'full' } }).gitStatus.branchOverflow, 'truncate');
+  assert.equal(mergeConfig({ gitStatus: { branchOverflow: null } }).gitStatus.branchOverflow, 'truncate');
 });
 
 test('mergeConfig defaults showOutputStyle to false', () => {

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -28,7 +28,7 @@ function baseContext() {
       lineLayout: 'compact',
       showSeparators: false,
       pathLevels: 1,
-      gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false },
+      gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, branchOverflow: 'truncate' },
       display: {
         showModel: true,
         showContextBar: true,
@@ -164,6 +164,26 @@ test('render wraps long lines to terminal width and keeps all activity lines vis
   assert.equal(countContaining(lines, 'plan-c'), 1, 'third agent line should remain visible');
   assert.equal(countContaining(lines, 'todo-marker'), 1, 'todo line should remain visible');
   assert.ok(lines.every(line => displayWidth(line) <= 20), 'all lines should fit terminal width');
+});
+
+test('render can wrap git to its own line without truncating the branch name', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/project-with-a-long-name';
+  ctx.gitStatus = {
+    branch: 'feature/this-is-a-very-long-branch-name',
+    isDirty: true,
+    ahead: 0,
+    behind: 0,
+  };
+  ctx.config.gitStatus.branchOverflow = 'wrap';
+
+  let lines = [];
+  withTerminal(55, () => {
+    lines = captureRender(ctx);
+  });
+
+  assert.ok(lines.every(line => displayWidth(line) <= 55), 'all lines should fit terminal width');
+  assert.ok(lines.some(line => line.includes('git:(feature/this-is-a-very-long-branch-name*)')), 'git branch should remain intact on its own line');
 });
 
 test('render falls back to COLUMNS env when stdout.columns is unavailable', () => {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -19,7 +19,9 @@ import { setLanguage } from '../dist/i18n/index.js';
 
 function stripAnsi(str) {
   // eslint-disable-next-line no-control-regex
-  return str.replace(/\x1b\[[0-9;]*m/g, '');
+  return str
+    .replace(/\x1b\[[0-9;]*m/g, '')
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
 }
 
 function baseContext() {
@@ -49,7 +51,7 @@ function baseContext() {
       showSeparators: false,
       pathLevels: 1,
       elementOrder: ['project', 'context', 'usage', 'memory', 'environment', 'tools', 'agents', 'todos'],
-      gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, pushWarningThreshold: 0, pushCriticalThreshold: 0 },
+      gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, branchOverflow: 'truncate', pushWarningThreshold: 0, pushCriticalThreshold: 0 },
       display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showResetLabel: true, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showOutputStyle: false, autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
       colors: {
         context: 'green',
@@ -746,6 +748,24 @@ test('renderSessionLine displays branch with slashes', () => {
   const line = renderSessionLine(ctx);
   assert.ok(line.includes('git:('));
   assert.ok(line.includes('feature/add-auth'));
+});
+
+test('renderSessionLine can give git its own segment for wrapping', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.gitStatus = { branch: 'feature/add-auth', isDirty: false, ahead: 0, behind: 0 };
+  ctx.config.gitStatus.branchOverflow = 'wrap';
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('my-project | git:(feature/add-auth)'), 'git should render as a separate segment');
+});
+
+test('renderProjectLine can give git its own segment for wrapping', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.gitStatus = { branch: 'feature/add-auth', isDirty: false, ahead: 0, behind: 0 };
+  ctx.config.gitStatus.branchOverflow = 'wrap';
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(line.includes('my-project │ git:(feature/add-auth)'), 'git should render as a separate segment');
 });
 
 test('renderToolsLine renders running and completed tools', () => {


### PR DESCRIPTION
## Summary
- add `gitStatus.branchOverflow` with `truncate` and `wrap` modes
- keep the default truncation behavior unchanged
- let the git block render as its own segment when wrapping is enabled

## Testing
- npm test

Closes #467