### PR TITLE
feat(layout): add configurable expanded merge groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `pathLevels` | 1-3 | 1 | Directory levels to show in project path |
 | `maxWidth` | number \| `null` | `null` | Optional fallback width used only when terminal width detection fails completely |
 | `elementOrder` | string[] | `["project","context","usage","memory","environment","tools","agents","todos"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. |
+| `display.mergeGroups` | string[][] | `[["context","usage"]]` | Expanded-mode groups that should share a line when adjacent. Set `[]` to disable merged lines. |
 | `gitStatus.enabled` | boolean | true | Show git branch in HUD |
 | `gitStatus.showDirty` | boolean | true | Show `*` for uncommitted changes |
 | `gitStatus.showAheadBehind` | boolean | false | Show `↑N ↓N` for ahead/behind remote |

--- a/README.zh.md
+++ b/README.zh.md
@@ -155,6 +155,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `lineLayout` | string | `expanded` | 布局：`expanded`（多行）或 `compact`（单行） |
 | `pathLevels` | 1-3 | 1 | 项目路径显示的目录层级数 |
 | `elementOrder` | string[] | `["project","context","usage","memory","environment","tools","agents","todos"]` | 展开模式下元素的顺序。省略的条目在展开模式下隐藏 |
+| `display.mergeGroups` | string[][] | `[["context","usage"]]` | 展开模式下相邻时应共享一行的元素分组。设为 `[]` 可禁用合并行 |
 | `gitStatus.enabled` | boolean | true | 在 HUD 中显示 git 分支 |
 | `gitStatus.showDirty` | boolean | true | 显示 `*` 表示未提交的更改 |
 | `gitStatus.showAheadBehind` | boolean | false | 显示 `↑N ↓N` 表示领先/落后远程的提交数 |

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,10 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'todos',
 ];
 
+export const DEFAULT_MERGE_GROUPS: HudElement[][] = [
+  ['context', 'usage'],
+];
+
 const KNOWN_ELEMENTS = new Set<HudElement>(DEFAULT_ELEMENT_ORDER);
 
 export interface HudConfig {
@@ -99,6 +103,7 @@ export interface HudConfig {
     showMemoryUsage: boolean;
     showSessionTokens: boolean;
     showOutputStyle: boolean;
+    mergeGroups: HudElement[][];
     autocompactBuffer: AutocompactBufferMode;
     usageThreshold: number;
     sevenDayThreshold: number;
@@ -150,6 +155,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showMemoryUsage: false,
     showSessionTokens: false,
     showOutputStyle: false,
+    mergeGroups: DEFAULT_MERGE_GROUPS.map(group => [...group]),
     autocompactBuffer: 'enabled',
     usageThreshold: 0,
     sevenDayThreshold: 80,
@@ -254,6 +260,55 @@ function validateElementOrder(value: unknown): HudElement[] {
   }
 
   return elementOrder.length > 0 ? elementOrder : [...DEFAULT_ELEMENT_ORDER];
+}
+
+function validateMergeGroups(value: unknown): HudElement[][] {
+  if (!Array.isArray(value)) {
+    return DEFAULT_MERGE_GROUPS.map(group => [...group]);
+  }
+
+  if (value.length === 0) {
+    return [];
+  }
+
+  const usedElements = new Set<HudElement>();
+  const mergeGroups: HudElement[][] = [];
+
+  for (const group of value) {
+    if (!Array.isArray(group)) {
+      continue;
+    }
+
+    const seenInGroup = new Set<HudElement>();
+    const normalizedGroup: HudElement[] = [];
+    const pendingElements: HudElement[] = [];
+
+    for (const item of group) {
+      if (typeof item !== 'string' || !KNOWN_ELEMENTS.has(item as HudElement)) {
+        continue;
+      }
+
+      const element = item as HudElement;
+      if (seenInGroup.has(element) || usedElements.has(element)) {
+        continue;
+      }
+
+      seenInGroup.add(element);
+      normalizedGroup.push(element);
+      pendingElements.push(element);
+    }
+
+    if (normalizedGroup.length >= 2) {
+      for (const element of pendingElements) {
+        usedElements.add(element);
+      }
+      mergeGroups.push(normalizedGroup);
+    }
+  }
+
+  return mergeGroups.length > 0
+    ? mergeGroups
+    : DEFAULT_MERGE_GROUPS.map(group => [...group]);
 }
 
 interface LegacyConfig {
@@ -410,6 +465,7 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showOutputStyle: typeof migrated.display?.showOutputStyle === 'boolean'
       ? migrated.display.showOutputStyle
       : DEFAULT_CONFIG.display.showOutputStyle,
+    mergeGroups: validateMergeGroups(migrated.display?.mergeGroups),
     autocompactBuffer: validateAutocompactBuffer(migrated.display?.autocompactBuffer)
       ? migrated.display.autocompactBuffer
       : DEFAULT_CONFIG.display.autocompactBuffer,

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,5 +1,5 @@
 import type { HudElement } from '../config.js';
-import { DEFAULT_ELEMENT_ORDER } from '../config.js';
+import { DEFAULT_ELEMENT_ORDER, DEFAULT_MERGE_GROUPS } from '../config.js';
 import type { RenderContext } from '../types.js';
 import { renderSessionLine } from './session-line.js';
 import { renderToolsLine } from './tools-line.js';
@@ -290,6 +290,40 @@ function makeSeparator(length: number): string {
 
 const ACTIVITY_ELEMENTS = new Set<HudElement>(['tools', 'agents', 'todos']);
 
+function buildMergeGroupLookup(mergeGroups: HudElement[][]): Map<HudElement, Set<HudElement>> {
+  const lookup = new Map<HudElement, Set<HudElement>>();
+
+  for (const group of mergeGroups) {
+    const groupSet = new Set(group);
+    for (const element of group) {
+      if (!lookup.has(element)) {
+        lookup.set(element, groupSet);
+      }
+    }
+  }
+
+  return lookup;
+}
+
+function collectMergeSequence(
+  elementOrder: HudElement[],
+  startIndex: number,
+  seen: Set<HudElement>,
+  group: Set<HudElement>,
+): HudElement[] {
+  const sequence: HudElement[] = [];
+
+  for (let index = startIndex; index < elementOrder.length; index += 1) {
+    const element = elementOrder[index];
+    if (seen.has(element) || !group.has(element)) {
+      break;
+    }
+    sequence.push(element);
+  }
+
+  return sequence;
+}
+
 function collectActivityLines(ctx: RenderContext): string[] {
   const activityLines: string[] = [];
   const display = ctx.config?.display;
@@ -359,6 +393,8 @@ function renderCompact(ctx: RenderContext): string[] {
 
 function renderExpanded(ctx: RenderContext, terminalWidth: number | null = null): Array<{ line: string; isActivity: boolean }> {
   const elementOrder = ctx.config?.elementOrder ?? DEFAULT_ELEMENT_ORDER;
+  const mergeGroups = ctx.config?.display?.mergeGroups ?? DEFAULT_MERGE_GROUPS;
+  const mergeGroupLookup = buildMergeGroupLookup(mergeGroups);
   const seen = new Set<HudElement>();
   const lines: Array<{ line: string; isActivity: boolean }> = [];
 
@@ -368,41 +404,57 @@ function renderExpanded(ctx: RenderContext, terminalWidth: number | null = null)
       continue;
     }
 
-    const nextElement = elementOrder[index + 1];
-    if (
-      (element === 'context' && nextElement === 'usage' && !seen.has('usage'))
-      || (element === 'usage' && nextElement === 'context' && !seen.has('context'))
-    ) {
-      seen.add(element);
-      seen.add(nextElement);
+    const mergeGroup = mergeGroupLookup.get(element);
+    if (mergeGroup) {
+      const mergeSequence = collectMergeSequence(elementOrder, index, seen, mergeGroup);
 
-      const firstLine = renderElementLine(ctx, element);
-      const secondLine = renderElementLine(ctx, nextElement);
-
-      if (firstLine && secondLine) {
-        const combinedLine = `${firstLine} │ ${secondLine}`;
-        const widthIsReal = terminalWidth && terminalWidth !== UNKNOWN_TERMINAL_WIDTH;
-        const canCombine = !widthIsReal || visualLength(combinedLine) <= terminalWidth;
-
-        if (canCombine) {
-          lines.push({ line: combinedLine, isActivity: false });
-        } else {
-          const firstStackedLine = renderElementLine(ctx, element, {
-            alignProgressLabels: true,
-          }) ?? firstLine;
-          const secondStackedLine = renderElementLine(ctx, nextElement, {
-            alignProgressLabels: true,
-          }) ?? secondLine;
-          lines.push({ line: firstStackedLine, isActivity: false });
-          lines.push({ line: secondStackedLine, isActivity: false });
+      if (mergeSequence.length > 1) {
+        index += mergeSequence.length - 1;
+        for (const groupedElement of mergeSequence) {
+          seen.add(groupedElement);
         }
-      } else if (firstLine) {
-        lines.push({ line: firstLine, isActivity: false });
-      } else if (secondLine) {
-        lines.push({ line: secondLine, isActivity: false });
-      }
 
-      continue;
+        const renderedGroupLines = mergeSequence
+          .map(groupedElement => ({
+            element: groupedElement,
+            line: renderElementLine(ctx, groupedElement),
+          }))
+          .filter(
+            (entry): entry is { element: HudElement; line: string } =>
+              typeof entry.line === 'string' && entry.line.length > 0
+          );
+
+        if (renderedGroupLines.length > 1) {
+          const combinedLine = renderedGroupLines.map(({ line }) => line).join(' │ ');
+          const widthIsReal = terminalWidth && terminalWidth !== UNKNOWN_TERMINAL_WIDTH;
+          const canCombine = !widthIsReal || visualLength(combinedLine) <= terminalWidth;
+
+          if (canCombine) {
+            lines.push({
+              line: combinedLine,
+              isActivity: renderedGroupLines.some(({ element: groupedElement }) => ACTIVITY_ELEMENTS.has(groupedElement)),
+            });
+          } else {
+            for (const { element: groupedElement, line } of renderedGroupLines) {
+              const stackedLine = renderElementLine(ctx, groupedElement, {
+                alignProgressLabels: true,
+              }) ?? line;
+              lines.push({
+                line: stackedLine,
+                isActivity: ACTIVITY_ELEMENTS.has(groupedElement),
+              });
+            }
+          }
+        } else if (renderedGroupLines.length === 1) {
+          const [{ element: groupedElement, line }] = renderedGroupLines;
+          lines.push({
+            line,
+            isActivity: ACTIVITY_ELEMENTS.has(groupedElement),
+          });
+        }
+
+        continue;
+      }
     }
 
     seen.add(element);

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -6,6 +6,7 @@ import {
   mergeConfig,
   DEFAULT_CONFIG,
   DEFAULT_ELEMENT_ORDER,
+  DEFAULT_MERGE_GROUPS,
 } from '../dist/config.js';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -344,6 +345,46 @@ test('mergeConfig falls back to default for invalid contextValue', () => {
 test('mergeConfig defaults elementOrder to the full expanded layout', () => {
   const config = mergeConfig({});
   assert.deepEqual(config.elementOrder, DEFAULT_ELEMENT_ORDER);
+});
+
+test('mergeConfig defaults mergeGroups to context and usage', () => {
+  const config = mergeConfig({});
+  assert.deepEqual(config.display.mergeGroups, DEFAULT_MERGE_GROUPS);
+  assert.deepEqual(DEFAULT_CONFIG.display.mergeGroups, DEFAULT_MERGE_GROUPS);
+});
+
+test('mergeConfig preserves explicit empty mergeGroups to disable merged lines', () => {
+  const config = mergeConfig({
+    display: {
+      mergeGroups: [],
+    },
+  });
+  assert.deepEqual(config.display.mergeGroups, []);
+});
+
+test('mergeConfig accepts valid mergeGroups and filters invalid entries', () => {
+  const config = mergeConfig({
+    display: {
+      mergeGroups: [
+        ['project', 'context', 'usage'],
+        ['tools', 'todos', 'tools'],
+        ['memory'],
+        ['agents', 'unknown', 'environment'],
+      ],
+    },
+  });
+
+  assert.deepEqual(config.display.mergeGroups, [
+    ['project', 'context', 'usage'],
+    ['tools', 'todos'],
+    ['agents', 'environment'],
+  ]);
+});
+
+test('mergeConfig falls back to default mergeGroups when value is invalid', () => {
+  assert.deepEqual(mergeConfig({ display: { mergeGroups: 'context,usage' } }).display.mergeGroups, DEFAULT_MERGE_GROUPS);
+  assert.deepEqual(mergeConfig({ display: { mergeGroups: [['context'], ['unknown']] } }).display.mergeGroups, DEFAULT_MERGE_GROUPS);
+  assert.deepEqual(mergeConfig({ display: { mergeGroups: [null] } }).display.mergeGroups, DEFAULT_MERGE_GROUPS);
 });
 
 test('mergeConfig preserves valid custom elementOrder including activity elements', () => {

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -42,6 +42,7 @@ function baseContext() {
         showTools: true,
         showAgents: true,
         showTodos: true,
+        mergeGroups: [['context', 'usage']],
         autocompactBuffer: 'enabled',
         usageThreshold: 0,
         sevenDayThreshold: 80,
@@ -483,7 +484,7 @@ test('render truncation respects Unicode display width', () => {
   assert.ok(lines.every(line => displayWidth(line) <= 10), 'all lines should respect terminal cell width');
 });
 
-test('render keeps context and usage as separate lines when a narrow terminal cannot fit both', () => {
+test('render keeps default merge-group elements as separate lines when a narrow terminal cannot fit both', () => {
   const ctx = baseContext();
   ctx.config.lineLayout = 'expanded';
   ctx.config.display.usageBarEnabled = true;

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -52,7 +52,7 @@ function baseContext() {
       pathLevels: 1,
       elementOrder: ['project', 'context', 'usage', 'memory', 'environment', 'tools', 'agents', 'todos'],
       gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, branchOverflow: 'truncate', pushWarningThreshold: 0, pushCriticalThreshold: 0 },
-      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showResetLabel: true, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showOutputStyle: false, autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
+      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showResetLabel: true, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
       colors: {
         context: 'green',
         usage: 'brightBlue',
@@ -1826,7 +1826,7 @@ test('render expanded layout omits elements not present in elementOrder', () => 
   assert.ok(!output.includes('todo-marker'), 'todos should be omitted when excluded');
 });
 
-test('render expanded layout combines usage and context when adjacent in elementOrder', () => {
+test('render expanded layout combines default merge-group elements when adjacent in elementOrder', () => {
   const ctx = baseContext();
   ctx.config.lineLayout = 'expanded';
   ctx.usageData = {
@@ -1850,7 +1850,7 @@ test('render expanded layout combines usage and context when adjacent in element
   assert.ok(!stripped.includes('Weekly '), `combined line should not pad the weekly label: ${stripped}`);
 });
 
-test('render expanded layout keeps usage and context separate when not adjacent', () => {
+test('render expanded layout keeps merge-group elements separate when they are not adjacent', () => {
   const ctx = baseContext();
   ctx.config.lineLayout = 'expanded';
   ctx.stdin.cwd = '/tmp/my-project';
@@ -1873,7 +1873,51 @@ test('render expanded layout keeps usage and context separate when not adjacent'
   assert.equal(combinedLine, undefined, 'usage and context should not combine when separated by another element');
 });
 
-test('render expanded layout aligns progress labels only after wrapping to separate lines', () => {
+test('render expanded layout keeps default merge-group elements separate when mergeGroups is empty', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.usageData = {
+    planName: 'Team',
+    fiveHour: 30,
+    sevenDay: 10,
+    fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+    sevenDayResetAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+  };
+  ctx.config.display.mergeGroups = [];
+  ctx.config.elementOrder = ['usage', 'context'];
+
+  const lines = withTerminal(120, () => captureRenderLines(ctx));
+
+  assert.equal(lines.length, 2, 'empty mergeGroups should disable expanded merged lines');
+  assert.ok(lines.some(line => line.includes('Usage')), 'usage should stay visible');
+  assert.ok(lines.some(line => line.includes('Context')), 'context should stay visible');
+  assert.ok(!lines.some(line => line.includes('Usage') && line.includes('Context')), 'no combined line should be rendered');
+});
+
+test('render expanded layout combines custom merge groups in configured order', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.usageData = {
+    planName: 'Team',
+    fiveHour: 30,
+    sevenDay: 10,
+    fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+    sevenDayResetAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+  };
+  ctx.config.display.mergeGroups = [['project', 'usage', 'context']];
+  ctx.config.elementOrder = ['project', 'usage', 'context'];
+
+  const lines = withTerminal(160, () => captureRenderLines(ctx));
+
+  assert.equal(lines.length, 1, 'custom merge groups should combine all adjacent configured elements');
+  assert.ok(lines[0].includes('my-project'), 'combined line should include project');
+  assert.ok(lines[0].includes('Usage'), 'combined line should include usage');
+  assert.ok(lines[0].includes('Context'), 'combined line should include context');
+  assert.ok(lines[0].split('│').length - 1 >= 2, 'combined line should keep the merge separators');
+});
+
+test('render expanded layout aligns progress labels only after wrapping merged lines to separate lines', () => {
   const ctx = baseContext();
   ctx.config.lineLayout = 'expanded';
   ctx.usageData = {


### PR DESCRIPTION
## Summary
- add `display.mergeGroups` for expanded-layout line sharing
- keep `context` + `usage` as the default merged group
- allow `[]` to disable merged lines and custom groups to merge other adjacent elements

## Testing
- npm test

Closes #394