### PR TITLE
feat(cache): add prompt cache countdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ After choosing a preset, you can turn individual elements on or off.
 ### Manual Configuration
 
 Edit `~/.claude/plugins/claude-hud/config.json` directly for advanced settings such as `colors.*`,
-`pathLevels`, `maxWidth`, threshold overrides, and `display.timeFormat`. Running `/claude-hud:configure`
+`pathLevels`, `maxWidth`, threshold overrides, `display.timeFormat`, and `display.promptCacheTtlSeconds`. Running `/claude-hud:configure`
 preserves those manual settings while still letting you change `language`, layout, and the common
 guided toggles.
 
@@ -160,7 +160,8 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `lineLayout` | string | `expanded` | Layout: `expanded` (multi-line) or `compact` (single line) |
 | `pathLevels` | 1-3 | 1 | Directory levels to show in project path |
 | `maxWidth` | number \| `null` | `null` | Optional fallback width used only when terminal width detection fails completely |
-| `elementOrder` | string[] | `["project","context","usage","memory","environment","tools","agents","todos"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. |
+<<<<<<< HEAD
+| `elementOrder` | string[] | `["project","context","usage","promptCache","memory","environment","tools","agents","todos"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. |
 | `display.mergeGroups` | string[][] | `[["context","usage"]]` | Expanded-mode groups that should share a line when adjacent. Set `[]` to disable merged lines. |
 | `gitStatus.enabled` | boolean | true | Show git branch in HUD |
 | `gitStatus.showDirty` | boolean | true | Show `*` for uncommitted changes |
@@ -190,6 +191,8 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showSessionName` | boolean | false | Show session slug or custom title from `/rename` |
 | `display.showClaudeCodeVersion` | boolean | false | Show the installed Claude Code version, e.g. `CC v2.1.81` |
 | `display.showMemoryUsage` | boolean | false | Show an approximate system RAM usage line in expanded layout |
+| `display.showPromptCache` | boolean | false | Show a prompt cache countdown based on the last assistant response timestamp in the transcript |
+| `display.promptCacheTtlSeconds` | number | `300` | Prompt cache TTL in seconds. Keep the default for Pro, set `3600` for Max |
 | `colors.context` | color value | `green` | Base color for the context bar and context percentage |
 | `colors.usage` | color value | `brightBlue` | Base color for usage bars and percentages below warning thresholds |
 | `colors.warning` | color value | `yellow` | Warning color for context thresholds and usage warning text |
@@ -207,6 +210,8 @@ Supported color names: `dim`, `red`, `green`, `yellow`, `magenta`, `cyan`, `brig
 `display.showMemoryUsage` is fully opt-in and only renders in `expanded` layout. It reports approximate system RAM usage from the local machine, not precise memory pressure inside Claude Code or a specific process. The number may overstate actual pressure because reclaimable OS cache and buffers can still be counted as used memory.
 
 `display.showCost` is fully opt-in. ClaudeHUD prefers the native `cost.total_cost_usd` field that Claude Code provides on stdin when it is available. If that field is absent or invalid for a direct Anthropic session, ClaudeHUD falls back to the existing local transcript-based estimate so the cost line still works on older payloads. The native field is absent before the first API response in a session, so the cost display may stay hidden until then. ClaudeHUD also keeps the cost hidden for known routed providers such as Bedrock, because cloud-provider billed sessions may report `$0.00` or omit the field even though the session was not literally free.
+
+`display.showPromptCache` is fully opt-in. When enabled, ClaudeHUD looks at the timestamp of the last assistant response in the local transcript and shows a live countdown until the prompt cache expires. The default TTL is 5 minutes (`300` seconds). Set `display.promptCacheTtlSeconds` to `3600` if you want a 1-hour Max-style window. If the transcript does not have an assistant timestamp yet, the cache element stays hidden.
 
 ### Usage Limits
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -143,7 +143,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 
 ### 手动配置
 
-直接编辑 `~/.claude/plugins/claude-hud/config.json` 来配置高级选项，如 `colors.*`、`pathLevels`、阈值覆盖以及 `display.timeFormat`。运行 `/claude-hud:configure` 时会保留这些手动设置，同时你仍可更改 `language`、布局和常用引导式开关。
+直接编辑 `~/.claude/plugins/claude-hud/config.json` 来配置高级选项，如 `colors.*`、`pathLevels`、阈值覆盖、`display.timeFormat` 以及 `display.promptCacheTtlSeconds`。运行 `/claude-hud:configure` 时会保留这些手动设置，同时你仍可更改 `language`、布局和常用引导式开关。
 
 中文 HUD 标签作为显式 opt-in 选项提供。除非你在 `/claude-hud:configure` 中选择 `中文` 或在配置中设置 `language`，否则默认使用英文。
 
@@ -154,7 +154,8 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `language` | `en` \| `zh` | `en` | HUD 标签语言。默认为英文；设为 `zh` 启用中文标签 |
 | `lineLayout` | string | `expanded` | 布局：`expanded`（多行）或 `compact`（单行） |
 | `pathLevels` | 1-3 | 1 | 项目路径显示的目录层级数 |
-| `elementOrder` | string[] | `["project","context","usage","memory","environment","tools","agents","todos"]` | 展开模式下元素的顺序。省略的条目在展开模式下隐藏 |
+<<<<<<< HEAD
+| `elementOrder` | string[] | `["project","context","usage","promptCache","memory","environment","tools","agents","todos"]` | 展开模式下元素的顺序。省略的条目在展开模式下隐藏 |
 | `display.mergeGroups` | string[][] | `[["context","usage"]]` | 展开模式下相邻时应共享一行的元素分组。设为 `[]` 可禁用合并行 |
 | `gitStatus.enabled` | boolean | true | 在 HUD 中显示 git 分支 |
 | `gitStatus.showDirty` | boolean | true | 显示 `*` 表示未提交的更改 |
@@ -182,6 +183,8 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `display.showSessionName` | boolean | false | 显示会话 slug 或 `/rename` 设置的自定义标题 |
 | `display.showClaudeCodeVersion` | boolean | false | 显示已安装的 Claude Code 版本，如 `CC v2.1.81` |
 | `display.showMemoryUsage` | boolean | false | 在展开布局中显示近似系统 RAM 使用行 |
+| `display.showPromptCache` | boolean | false | 根据 transcript 中最后一次 assistant 响应时间显示 prompt cache 倒计时 |
+| `display.promptCacheTtlSeconds` | number | `300` | Prompt cache TTL 秒数。Pro 保持默认值，Max 可设为 `3600` |
 | `colors.context` | 颜色值 | `green` | 上下文进度条和百分比的基础颜色 |
 | `colors.usage` | 颜色值 | `brightBlue` | 使用率进度条和低于警告阈值时百分比的颜色 |
 | `colors.warning` | 颜色值 | `yellow` | 上下文阈值和使用率警告文本的警告颜色 |
@@ -199,6 +202,8 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 `display.showMemoryUsage` 为完全 opt-in 选项，仅在 `expanded` 布局下渲染。它报告本地机器的近似系统 RAM 使用情况，而非 Claude Code 或特定进程内的精确内存压力。由于可回收的 OS 缓存缓冲区仍可能被计入已用内存，该数字可能高估实际压力。
 
 `display.showCost` 为完全 opt-in 选项。ClaudeHUD 优先使用 Claude Code 在 stdin 上提供的原生 `cost.total_cost_usd` 字段（可用时）。如果该字段缺失或对直连 Anthropic 会话无效，ClaudeHUD 会回退到现有的基于本地转录文件的估算方案，确保费用行在旧负载下仍能工作。原生字段在会话中首个 API 响应之前为空，因此费用显示可能在响应到达前保持隐藏。对于已知的路由提供商（如 Bedrock），ClaudeHUD 也会隐藏费用显示，因为云提供商计费会话可能报告 `$0.00` 或省略该字段，即使会话并非真正免费。
+
+`display.showPromptCache` 为完全 opt-in 选项。启用后，ClaudeHUD 会读取本地 transcript 中最后一次 assistant 响应的时间戳，并显示距离 prompt cache 过期还剩多久。默认 TTL 为 5 分钟（`300` 秒）。如果你想按 1 小时的 Max 风格窗口显示，可将 `display.promptCacheTtlSeconds` 设为 `3600`。如果 transcript 里还没有 assistant 时间戳，这个元素会继续隐藏。
 
 ### 使用率限制
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
  */
 export type ModelFormatMode = 'full' | 'compact' | 'short';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both';
-export type HudElement = 'project' | 'context' | 'usage' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos';
+export type HudElement = 'project' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos';
 export type HudColorName =
   | 'dim'
   | 'red'
@@ -51,6 +51,7 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'project',
   'context',
   'usage',
+  'promptCache',
   'memory',
   'environment',
   'tools',
@@ -101,6 +102,8 @@ export interface HudConfig {
     showClaudeCodeVersion: boolean;
     showEffortLevel: boolean;
     showMemoryUsage: boolean;
+    showPromptCache: boolean;
+    promptCacheTtlSeconds: number;
     showSessionTokens: boolean;
     showOutputStyle: boolean;
     mergeGroups: HudElement[][];
@@ -153,6 +156,8 @@ export const DEFAULT_CONFIG: HudConfig = {
     showClaudeCodeVersion: false,
     showEffortLevel: false,
     showMemoryUsage: false,
+    showPromptCache: false,
+    promptCacheTtlSeconds: 300,
     showSessionTokens: false,
     showOutputStyle: false,
     mergeGroups: DEFAULT_MERGE_GROUPS.map(group => [...group]),
@@ -353,6 +358,13 @@ function validateCountThreshold(value: unknown): number {
   return Math.max(0, Math.floor(value));
 }
 
+function validateDurationSeconds(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
 export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
   const migrated = migrateConfig(userConfig);
   const language = validateLanguage(migrated.language)
@@ -459,6 +471,13 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showMemoryUsage: typeof migrated.display?.showMemoryUsage === 'boolean'
       ? migrated.display.showMemoryUsage
       : DEFAULT_CONFIG.display.showMemoryUsage,
+    showPromptCache: typeof migrated.display?.showPromptCache === 'boolean'
+      ? migrated.display.showPromptCache
+      : DEFAULT_CONFIG.display.showPromptCache,
+    promptCacheTtlSeconds: validateDurationSeconds(
+      migrated.display?.promptCacheTtlSeconds,
+      DEFAULT_CONFIG.display.promptCacheTtlSeconds,
+    ),
     showSessionTokens: typeof migrated.display?.showSessionTokens === 'boolean'
       ? migrated.display.showSessionTokens
       : DEFAULT_CONFIG.display.showSessionTokens,

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -6,6 +6,7 @@ export const en: Messages = {
   "label.usage": "Usage",
   "label.weekly": "Weekly",
   "label.approxRam": "Approx RAM",
+  "label.promptCache": "Cache",
   "label.rules": "rules",
   "label.hooks": "hooks",
   "label.estimatedCost": "Est.",
@@ -14,6 +15,7 @@ export const en: Messages = {
   // Status
   "status.limitReached": "Limit reached",
   "status.allTodosComplete": "All todos complete",
+  "status.expired": "expired",
 
   // Format
   "format.resets": "resets",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -4,6 +4,7 @@ export type MessageKey =
   | "label.usage"
   | "label.weekly"
   | "label.approxRam"
+  | "label.promptCache"
   | "label.rules"
   | "label.hooks"
   | "label.estimatedCost"
@@ -11,6 +12,7 @@ export type MessageKey =
   // Status
   | "status.limitReached"
   | "status.allTodosComplete"
+  | "status.expired"
   // Format
   | "format.resets"
   | "format.resetsIn"

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -6,6 +6,7 @@ export const zh: Messages = {
   "label.usage": "用量",
   "label.weekly": "本周",
   "label.approxRam": "内存",
+  "label.promptCache": "缓存",
   "label.rules": "规则",
   "label.hooks": "钩子",
   "label.estimatedCost": "估算",
@@ -14,6 +15,7 @@ export const zh: Messages = {
   // Status
   "status.limitReached": "已达上限",
   "status.allTodosComplete": "全部完成",
+  "status.expired": "已过期",
 
   // Format
   "format.resets": "重置于",

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -10,6 +10,7 @@ import {
   renderProjectLine,
   renderGitFilesLine,
   renderEnvironmentLine,
+  renderPromptCacheLine,
   renderUsageLine,
   renderMemoryLine,
   renderSessionTokensLine,
@@ -367,6 +368,8 @@ function renderElementLine(
       return renderIdentityLine(ctx, alignProgressLabels);
     case 'usage':
       return renderUsageLine(ctx, alignProgressLabels);
+    case 'promptCache':
+      return renderPromptCacheLine(ctx);
     case 'memory':
       return renderMemoryLine(ctx);
     case 'environment':

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -1,6 +1,7 @@
 export { renderIdentityLine } from './identity.js';
 export { renderProjectLine, renderGitFilesLine } from './project.js';
 export { renderEnvironmentLine } from './environment.js';
+export { renderPromptCacheLine, formatPromptCacheCountdown } from './prompt-cache.js';
 export { renderUsageLine } from './usage.js';
 export { renderMemoryLine } from './memory.js';
 export { renderSessionTokensLine } from './session-tokens.js';

--- a/src/render/lines/prompt-cache.ts
+++ b/src/render/lines/prompt-cache.ts
@@ -1,5 +1,6 @@
 import type { RenderContext } from '../../types.js';
 import { getContextColor, RESET, label, warning as warningColor } from '../colors.js';
+import { t } from '../../i18n/index.js';
 
 function getPromptCacheWarningSeconds(ttlSeconds: number): number {
   return Math.min(ttlSeconds, Math.max(60, Math.floor(ttlSeconds / 5)));
@@ -23,7 +24,7 @@ function colorPromptCacheValue(
 
 export function formatPromptCacheCountdown(remainingMs: number): string {
   if (remainingMs <= 0) {
-    return 'expired';
+    return t('status.expired');
   }
 
   const totalSeconds = Math.ceil(remainingMs / 1000);
@@ -64,5 +65,5 @@ export function renderPromptCacheLine(ctx: RenderContext, now: number = Date.now
       ? 'warning'
       : 'active';
 
-  return `${label('Cache', ctx.config?.colors)} ${colorPromptCacheValue(`⏱ ${formatPromptCacheCountdown(remainingMs)}`, state, ctx)}`;
+  return `${label(t('label.promptCache'), ctx.config?.colors)} ${colorPromptCacheValue(`⏱ ${formatPromptCacheCountdown(remainingMs)}`, state, ctx)}`;
 }

--- a/src/render/lines/prompt-cache.ts
+++ b/src/render/lines/prompt-cache.ts
@@ -1,0 +1,68 @@
+import type { RenderContext } from '../../types.js';
+import { getContextColor, RESET, label, warning as warningColor } from '../colors.js';
+
+function getPromptCacheWarningSeconds(ttlSeconds: number): number {
+  return Math.min(ttlSeconds, Math.max(60, Math.floor(ttlSeconds / 5)));
+}
+
+function colorPromptCacheValue(
+  value: string,
+  state: 'active' | 'warning' | 'expired',
+  ctx: RenderContext,
+): string {
+  if (state === 'expired') {
+    return label(value, ctx.config?.colors);
+  }
+
+  if (state === 'warning') {
+    return warningColor(value, ctx.config?.colors);
+  }
+
+  return `${getContextColor(0, ctx.config?.colors)}${value}${RESET}`;
+}
+
+export function formatPromptCacheCountdown(remainingMs: number): string {
+  if (remainingMs <= 0) {
+    return 'expired';
+  }
+
+  const totalSeconds = Math.ceil(remainingMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${seconds}s`;
+  }
+
+  return `${minutes}m ${seconds}s`;
+}
+
+export function renderPromptCacheLine(ctx: RenderContext, now: number = Date.now()): string | null {
+  const display = ctx.config?.display;
+  if (!display?.showPromptCache) {
+    return null;
+  }
+
+  const lastAssistantResponseAt = ctx.transcript.lastAssistantResponseAt;
+  if (!lastAssistantResponseAt || Number.isNaN(lastAssistantResponseAt.getTime())) {
+    return null;
+  }
+
+  const ttlSeconds = (
+    typeof display.promptCacheTtlSeconds === 'number'
+    && Number.isFinite(display.promptCacheTtlSeconds)
+    && display.promptCacheTtlSeconds > 0
+  )
+    ? Math.floor(display.promptCacheTtlSeconds)
+    : 300;
+
+  const remainingMs = (lastAssistantResponseAt.getTime() + ttlSeconds * 1000) - now;
+  const state = remainingMs <= 0
+    ? 'expired'
+    : remainingMs <= getPromptCacheWarningSeconds(ttlSeconds) * 1000
+      ? 'warning'
+      : 'active';
+
+  return `${label('Cache', ctx.config?.colors)} ${colorPromptCacheValue(`⏱ ${formatPromptCacheCountdown(remainingMs)}`, state, ctx)}`;
+}

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -5,6 +5,7 @@ import { getOutputSpeed } from '../speed-tracker.js';
 import { coloredBar, critical, git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, getContextColor, getQuotaColor, quotaBar, custom as customColor, RESET } from './colors.js';
 import { getAdaptiveBarWidth } from '../utils/terminal.js';
 import { renderCostEstimate } from './lines/cost.js';
+import { renderPromptCacheLine } from './lines/prompt-cache.js';
 import { t } from '../i18n/index.js';
 import type { TimeFormatMode } from '../config.js';
 import { formatResetTime } from './format-reset-time.js';
@@ -259,6 +260,11 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   if (display?.showDuration !== false && ctx.sessionDuration) {
     parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
+  }
+
+  const promptCacheLine = renderPromptCacheLine(ctx);
+  if (promptCacheLine) {
+    parts.push(promptCacheLine);
   }
 
   const costEstimate = renderCostEstimate(ctx);

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -52,6 +52,7 @@ interface SerializedTranscriptData {
   todos: TodoItem[];
   sessionStart?: string;
   sessionName?: string;
+  lastAssistantResponseAt?: string;
   sessionTokens?: SessionTokenUsage;
 }
 
@@ -120,6 +121,7 @@ function serializeTranscriptData(data: TranscriptData): SerializedTranscriptData
     todos: data.todos.map((todo) => ({ ...todo })),
     sessionStart: data.sessionStart?.toISOString(),
     sessionName: data.sessionName,
+    lastAssistantResponseAt: data.lastAssistantResponseAt?.toISOString(),
     sessionTokens: data.sessionTokens,
   };
 }
@@ -139,6 +141,7 @@ function deserializeTranscriptData(data: SerializedTranscriptData): TranscriptDa
     todos: data.todos.map((todo) => ({ ...todo })),
     sessionStart: data.sessionStart ? new Date(data.sessionStart) : undefined,
     sessionName: data.sessionName,
+    lastAssistantResponseAt: data.lastAssistantResponseAt ? new Date(data.lastAssistantResponseAt) : undefined,
     sessionTokens: normalizeSessionTokens(data.sessionTokens),
   };
 }
@@ -274,9 +277,14 @@ function processEntry(
   result: TranscriptData
 ): void {
   const timestamp = entry.timestamp ? new Date(entry.timestamp) : new Date();
+  const hasValidTimestamp = !Number.isNaN(timestamp.getTime());
 
-  if (!result.sessionStart && entry.timestamp) {
+  if (!result.sessionStart && entry.timestamp && hasValidTimestamp) {
     result.sessionStart = timestamp;
+  }
+
+  if (entry.type === 'assistant' && entry.timestamp && hasValidTimestamp) {
+    result.lastAssistantResponseAt = timestamp;
   }
 
   const content = entry.message?.content;

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -57,10 +57,13 @@ interface SerializedTranscriptData {
 }
 
 interface TranscriptCacheFile {
+  version?: number;
   transcriptPath: string;
   transcriptState: TranscriptFileState;
   data: SerializedTranscriptData;
 }
+
+const TRANSCRIPT_CACHE_VERSION = 2;
 
 let createReadStreamImpl: typeof fs.createReadStream = fs.createReadStream;
 
@@ -152,7 +155,10 @@ function readTranscriptCache(transcriptPath: string, state: TranscriptFileState)
     const raw = fs.readFileSync(cachePath, 'utf8');
     const parsed = JSON.parse(raw) as TranscriptCacheFile;
     if (
-      parsed.transcriptPath !== path.resolve(transcriptPath)
+      parsed.version !== TRANSCRIPT_CACHE_VERSION
+      || !parsed.data
+      || !parsed.transcriptPath
+      || parsed.transcriptPath !== path.resolve(transcriptPath)
       || parsed.transcriptState?.mtimeMs !== state.mtimeMs
       || parsed.transcriptState?.size !== state.size
     ) {
@@ -170,6 +176,7 @@ function writeTranscriptCache(transcriptPath: string, state: TranscriptFileState
     const cachePath = getTranscriptCachePath(transcriptPath, os.homedir());
     fs.mkdirSync(path.dirname(cachePath), { recursive: true });
     const payload: TranscriptCacheFile = {
+      version: TRANSCRIPT_CACHE_VERSION,
       transcriptPath: path.resolve(transcriptPath),
       transcriptState: state,
       data: serializeTranscriptData(data),

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,7 @@ export interface TranscriptData {
   todos: TodoItem[];
   sessionStart?: Date;
   sessionName?: string;
+  lastAssistantResponseAt?: Date;
   sessionTokens?: SessionTokenUsage;
 }
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -63,6 +63,8 @@ test('loadConfig returns valid config structure', async () => {
   assert.equal(typeof config.display.showSessionName, 'boolean');
   assert.equal(typeof config.display.showClaudeCodeVersion, 'boolean');
   assert.equal(typeof config.display.showMemoryUsage, 'boolean');
+  assert.equal(typeof config.display.showPromptCache, 'boolean');
+  assert.equal(typeof config.display.promptCacheTtlSeconds, 'number');
   assert.equal(typeof config.display.showCost, 'boolean');
   assert.equal(typeof config.display.showOutputStyle, 'boolean');
   assert.ok(['full', 'compact', 'short'].includes(config.display.modelFormat), 'modelFormat should be valid');
@@ -118,6 +120,34 @@ test('mergeConfig defaults showMemoryUsage to false', () => {
 test('mergeConfig preserves explicit showMemoryUsage=true', () => {
   const config = mergeConfig({ display: { showMemoryUsage: true } });
   assert.equal(config.display.showMemoryUsage, true);
+});
+
+test('mergeConfig defaults showPromptCache to false', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.showPromptCache, false);
+  assert.equal(DEFAULT_CONFIG.display.showPromptCache, false);
+});
+
+test('mergeConfig preserves explicit showPromptCache=true', () => {
+  const config = mergeConfig({ display: { showPromptCache: true } });
+  assert.equal(config.display.showPromptCache, true);
+});
+
+test('mergeConfig defaults promptCacheTtlSeconds to 300', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.promptCacheTtlSeconds, 300);
+  assert.equal(DEFAULT_CONFIG.display.promptCacheTtlSeconds, 300);
+});
+
+test('mergeConfig preserves valid promptCacheTtlSeconds values', () => {
+  const config = mergeConfig({ display: { promptCacheTtlSeconds: 3600 } });
+  assert.equal(config.display.promptCacheTtlSeconds, 3600);
+});
+
+test('mergeConfig falls back to default promptCacheTtlSeconds for invalid values', () => {
+  assert.equal(mergeConfig({ display: { promptCacheTtlSeconds: 0 } }).display.promptCacheTtlSeconds, 300);
+  assert.equal(mergeConfig({ display: { promptCacheTtlSeconds: -1 } }).display.promptCacheTtlSeconds, 300);
+  assert.equal(mergeConfig({ display: { promptCacheTtlSeconds: 'fast' } }).display.promptCacheTtlSeconds, 300);
 });
 
 test('mergeConfig defaults showCost to false', () => {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, readdir, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { _setCreateReadStreamForTests, parseTranscript } from '../dist/transcript.js';
@@ -992,6 +993,52 @@ test('parseTranscript falls back to a fresh parse when the transcript cache is c
     const second = await parseTranscript(transcriptPath);
     assert.equal(second.tools.length, 1);
     assert.equal(second.tools[0].target, '/tmp/original.txt');
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('parseTranscript invalidates transcript cache entries from older cache versions', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-transcript-cache-'));
+  const configDir = path.join(dir, '.claude-test');
+  const transcriptPath = path.join(dir, 'cache-version-upgrade.jsonl');
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  const line = `${JSON.stringify({
+    type: 'assistant',
+    timestamp: '2024-01-01T00:00:00.000Z',
+    message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'Read', input: { path: '/tmp/fresh.txt' } }] },
+  })}\n`;
+
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  await writeFile(transcriptPath, line, 'utf8');
+  fs.utimesSync(transcriptPath, 1710000200, 1710000200);
+
+  try {
+    const stat = fs.statSync(transcriptPath);
+    const cachePath = path.join(
+      configDir,
+      'plugins',
+      'claude-hud',
+      'transcript-cache',
+      `${createHash('sha256').update(path.resolve(transcriptPath)).digest('hex')}.json`
+    );
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await writeFile(cachePath, JSON.stringify({
+      transcriptPath: path.resolve(transcriptPath),
+      transcriptState: { mtimeMs: stat.mtimeMs, size: stat.size },
+      data: {
+        tools: [],
+        agents: [],
+        todos: [],
+        sessionName: 'stale-cache',
+      },
+    }), 'utf8');
+
+    const result = await parseTranscript(transcriptPath);
+    assert.equal(result.sessionName, undefined);
+    assert.equal(result.tools.length, 1);
+    assert.equal(result.lastAssistantResponseAt?.toISOString(), '2024-01-01T00:00:00.000Z');
   } finally {
     restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
     await rm(dir, { recursive: true, force: true });

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -527,6 +527,26 @@ test('parseTranscript accumulates session token usage from assistant messages', 
   }
 });
 
+test('parseTranscript captures the last assistant response timestamp', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-'));
+  const filePath = path.join(dir, 'assistant-timestamp.jsonl');
+  const lines = [
+    JSON.stringify({ type: 'assistant', timestamp: '2024-01-01T00:00:05.000Z' }),
+    JSON.stringify({ type: 'user', timestamp: '2024-01-01T00:00:06.000Z' }),
+    JSON.stringify({ type: 'assistant', timestamp: '2024-01-01T00:00:10.000Z' }),
+    JSON.stringify({ type: 'assistant', timestamp: 'not-a-date' }),
+  ];
+
+  await writeFile(filePath, lines.join('\n'), 'utf8');
+
+  try {
+    const result = await parseTranscript(filePath);
+    assert.equal(result.lastAssistantResponseAt?.toISOString(), '2024-01-01T00:00:10.000Z');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('parseTranscript ignores malformed session token values', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-'));
   const filePath = path.join(dir, 'session-tokens-malformed.jsonl');

--- a/tests/prompt-cache.test.js
+++ b/tests/prompt-cache.test.js
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatPromptCacheCountdown, renderPromptCacheLine } from '../dist/render/lines/prompt-cache.js';
+
+function stripAnsi(str) {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+function baseContext() {
+  return {
+    stdin: {},
+    transcript: { tools: [], agents: [], todos: [] },
+    claudeMdCount: 0,
+    rulesCount: 0,
+    mcpCount: 0,
+    hooksCount: 0,
+    sessionDuration: '',
+    gitStatus: null,
+    usageData: null,
+    memoryUsage: null,
+    config: {
+      display: {
+        showPromptCache: true,
+        promptCacheTtlSeconds: 300,
+      },
+      colors: {},
+    },
+    extraLabel: null,
+  };
+}
+
+test('formatPromptCacheCountdown formats minutes and seconds', () => {
+  assert.equal(formatPromptCacheCountdown(272_000), '4m 32s');
+});
+
+test('formatPromptCacheCountdown formats hours when needed', () => {
+  assert.equal(formatPromptCacheCountdown(3_632_000), '1h 0m 32s');
+});
+
+test('formatPromptCacheCountdown returns expired when countdown has elapsed', () => {
+  assert.equal(formatPromptCacheCountdown(0), 'expired');
+  assert.equal(formatPromptCacheCountdown(-1000), 'expired');
+});
+
+test('renderPromptCacheLine shows warning and expired states', () => {
+  const ctx = baseContext();
+  const now = Date.UTC(2024, 0, 1, 0, 5, 0);
+
+  ctx.transcript.lastAssistantResponseAt = new Date(now - 280_000);
+  assert.equal(stripAnsi(renderPromptCacheLine(ctx, now) ?? ''), 'Cache ⏱ 0m 20s');
+
+  ctx.transcript.lastAssistantResponseAt = new Date(now - 301_000);
+  assert.equal(stripAnsi(renderPromptCacheLine(ctx, now) ?? ''), 'Cache ⏱ expired');
+});

--- a/tests/prompt-cache.test.js
+++ b/tests/prompt-cache.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { formatPromptCacheCountdown, renderPromptCacheLine } from '../dist/render/lines/prompt-cache.js';
+import { setLanguage } from '../dist/i18n/index.js';
 
 function stripAnsi(str) {
   // eslint-disable-next-line no-control-regex
@@ -52,4 +53,17 @@ test('renderPromptCacheLine shows warning and expired states', () => {
 
   ctx.transcript.lastAssistantResponseAt = new Date(now - 301_000);
   assert.equal(stripAnsi(renderPromptCacheLine(ctx, now) ?? ''), 'Cache ⏱ expired');
+});
+
+test('renderPromptCacheLine localizes label and expired state', () => {
+  const ctx = baseContext();
+  const now = Date.UTC(2024, 0, 1, 0, 5, 1);
+  ctx.transcript.lastAssistantResponseAt = new Date(now - 301_000);
+
+  setLanguage('zh');
+  try {
+    assert.equal(stripAnsi(renderPromptCacheLine(ctx, now) ?? ''), '缓存 ⏱ 已过期');
+  } finally {
+    setLanguage('en');
+  }
 });

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { render } from '../dist/render/index.js';
 import { renderSessionLine } from '../dist/render/session-line.js';
 import { renderProjectLine, renderGitFilesLine } from '../dist/render/lines/project.js';
+import { renderPromptCacheLine } from '../dist/render/lines/prompt-cache.js';
 import { renderToolsLine } from '../dist/render/tools-line.js';
 import { renderAgentsLine } from '../dist/render/agents-line.js';
 import { renderTodosLine } from '../dist/render/todos-line.js';
@@ -50,9 +51,9 @@ function baseContext() {
       lineLayout: 'compact',
       showSeparators: false,
       pathLevels: 1,
-      elementOrder: ['project', 'context', 'usage', 'memory', 'environment', 'tools', 'agents', 'todos'],
+      elementOrder: ['project', 'context', 'usage', 'promptCache', 'memory', 'environment', 'tools', 'agents', 'todos'],
       gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, branchOverflow: 'truncate', pushWarningThreshold: 0, pushCriticalThreshold: 0 },
-      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showResetLabel: true, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
+      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showResetLabel: true, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showPromptCache: false, promptCacheTtlSeconds: 300, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
       colors: {
         context: 'green',
         usage: 'brightBlue',
@@ -328,6 +329,16 @@ test('render expanded layout supports combined context display', () => {
   );
 });
 
+test('render expanded layout includes prompt cache as its own opt-in element', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.config.display.showPromptCache = true;
+  ctx.transcript.lastAssistantResponseAt = new Date(Date.now() - 45_000);
+
+  const lines = captureRenderLines(ctx);
+  assert.ok(lines.some(line => line.includes('Cache ⏱ 4m 15s')), `should render prompt cache line, got: ${lines.join(' | ')}`);
+});
+
 test('renderSessionLine omits project name when cwd is undefined', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = undefined;
@@ -351,6 +362,23 @@ test('renderSessionLine includes Claude Code version when enabled', () => {
   ctx.claudeCodeVersion = '2.1.81';
   const line = stripAnsi(renderSessionLine(ctx));
   assert.ok(line.includes('CC v2.1.81'));
+});
+
+test('renderPromptCacheLine returns null when disabled or missing transcript data', () => {
+  const ctx = baseContext();
+  assert.equal(renderPromptCacheLine(ctx), null);
+
+  ctx.config.display.showPromptCache = true;
+  assert.equal(renderPromptCacheLine(ctx), null);
+});
+
+test('renderSessionLine includes prompt cache countdown when enabled', () => {
+  const ctx = baseContext();
+  ctx.config.display.showPromptCache = true;
+  ctx.transcript.lastAssistantResponseAt = new Date(Date.now() - 30_000);
+
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('Cache ⏱ 4m 30s'), `should include prompt cache countdown, got: ${line}`);
 });
 
 test('renderSessionLine hides session name by default', () => {


### PR DESCRIPTION
## Summary
- add an opt-in prompt cache countdown element with a configurable TTL
- record the last assistant response timestamp from the transcript cache path
- render the countdown in both expanded and compact layouts without changing the default HUD

## Testing
- npm test

Closes #400