### PR TITLE
Feat/kaomoji status

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showConfigCounts` | boolean | false | Show CLAUDE.md, rules, MCPs, hooks counts |
 | `display.showCost` | boolean | false | Show session cost using Claude Code's native `cost.total_cost_usd` when available, with a local estimate fallback for direct Anthropic sessions |
 | `display.showOutputStyle` | boolean | false | Show the active Claude Code `outputStyle` from settings files as `style: <name>` |
+| `display.showKaomoji` | boolean | false | Show an animated kaomoji at the start of line 1 that reflects session state (context health, tool activity, agent status, errors, todos) |
 | `display.showDuration` | boolean | false | Show session duration `⏱️ 5m` |
 | `display.showSpeed` | boolean | false | Show output token speed `out: 42.1 tok/s` |
 | `display.showUsage` | boolean | true | Show Claude subscriber usage limits when available |

--- a/README.zh.md
+++ b/README.zh.md
@@ -170,6 +170,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `display.showConfigCounts` | boolean | false | 显示 CLAUDE.md、rules、MCPs、hooks 数量 |
 | `display.showCost` | boolean | false | 使用 Claude Code 原生提供的 `cost.total_cost_usd` 显示会话费用（可用时），并附带本地估算回退方案 |
 | `display.showOutputStyle` | boolean | false | 从配置文件显示当前 Claude Code `outputStyle`，格式为 `style: <名称>` |
+| `display.showKaomoji` | boolean | false | 在第 1 行开头显示动态颜文字，反映当前会话状态（上下文健康度、工具活动、Agent 状态、错误、待办进度） |
 | `display.showDuration` | boolean | false | 显示会话时长 `⏱️ 5m` |
 | `display.showSpeed` | boolean | false | 显示输出 Token 速度 `out: 42.1 tok/s` |
 | `display.showUsage` | boolean | true | 显示 Claude 订阅用户的使用率限制（可用时） |

--- a/src/config.ts
+++ b/src/config.ts
@@ -106,6 +106,7 @@ export interface HudConfig {
     promptCacheTtlSeconds: number;
     showSessionTokens: boolean;
     showOutputStyle: boolean;
+    showKaomoji: boolean;
     mergeGroups: HudElement[][];
     autocompactBuffer: AutocompactBufferMode;
     usageThreshold: number;
@@ -160,6 +161,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     promptCacheTtlSeconds: 300,
     showSessionTokens: false,
     showOutputStyle: false,
+    showKaomoji: false,
     mergeGroups: DEFAULT_MERGE_GROUPS.map(group => [...group]),
     autocompactBuffer: 'enabled',
     usageThreshold: 0,
@@ -484,6 +486,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showOutputStyle: typeof migrated.display?.showOutputStyle === 'boolean'
       ? migrated.display.showOutputStyle
       : DEFAULT_CONFIG.display.showOutputStyle,
+    showKaomoji: typeof migrated.display?.showKaomoji === 'boolean'
+      ? migrated.display.showKaomoji
+      : DEFAULT_CONFIG.display.showKaomoji,
     mergeGroups: validateMergeGroups(migrated.display?.mergeGroups),
     autocompactBuffer: validateAutocompactBuffer(migrated.display?.autocompactBuffer)
       ? migrated.display.autocompactBuffer

--- a/src/kaomoji.ts
+++ b/src/kaomoji.ts
@@ -1,0 +1,69 @@
+import type { RenderContext } from './types.js';
+import { getContextPercent } from './stdin.js';
+import { isLimitReached } from './types.js';
+
+const CONTEXT_LOW_THRESHOLD = 5;
+const CONTEXT_WARNING_THRESHOLD = 70;
+const CONTEXT_CRITICAL_THRESHOLD = 85;
+
+function frame(frames: string[], intervalMs: number): string {
+  const index = Math.floor(Date.now() / intervalMs) % frames.length;
+  return frames[index];
+}
+
+export function getKaomoji(ctx: RenderContext): string {
+  // Rate limit hit — sad cry
+  if (ctx.usageData && isLimitReached(ctx.usageData)) {
+    return frame(['(T_T)', '(;_;)', '(T_T)', '(TOT)'], 800);
+  }
+
+  const contextPercent = getContextPercent(ctx.stdin);
+
+  // Context critical — fast panic
+  if (contextPercent > CONTEXT_CRITICAL_THRESHOLD) {
+    return frame(['(；ﾟдﾟ)', '(；°Д°)', '(；ﾟдﾟ)', '(ﾟдﾟ；)'], 400);
+  }
+
+  // Tool error — embarrassed
+  const hasToolError = ctx.transcript.tools.some(t => t.status === 'error');
+  if (hasToolError) {
+    return frame(['(*/ω＼*)', '(*/_＼*)', '(*/ω＼*)'], 700);
+  }
+
+  // Context warning — worried
+  if (contextPercent >= CONTEXT_WARNING_THRESHOLD) {
+    return frame(['(´･_･`)', '(´-_-`)', '(´･_･`)'], 700);
+  }
+
+  const runningTools = ctx.transcript.tools.filter(t => t.status === 'running');
+  const runningAgents = ctx.transcript.agents.filter(a => a.status === 'running');
+
+  // Many tools at once — overwhelmed
+  if (runningTools.length > 2) {
+    return frame(['(ﾉ°ω°)ﾉ', '(ﾉ°Д°)ﾉ', '(ﾉ>ω<)ﾉ'], 400);
+  }
+
+  // Agent delegating — excited/commanding
+  if (runningAgents.length > 0) {
+    return frame(['(ﾟ∀ﾟ)', '( ﾟ∀ﾟ)', '(ﾟ∀ﾟ )', '(ﾟ∀ﾟ)'], 500);
+  }
+
+  // Tools running — focused
+  if (runningTools.length > 0) {
+    return frame(['(￣ω￣)', '(￣－￣)', '(￣ー￣)', '(￣ω￣)'], 600);
+  }
+
+  // All todos done — celebrate
+  const todos = ctx.transcript.todos;
+  if (todos.length > 0 && todos.every(t => t.status === 'completed')) {
+    return frame(['(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧', '✧ﾟ･:(ﾉ◕ヮ◕)ﾉ', '(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧'], 600);
+  }
+
+  // Context just cleared — relieved
+  if (contextPercent < CONTEXT_LOW_THRESHOLD && contextPercent > 0) {
+    return frame(['(￣▽￣)ノ', '( ￣▽￣)ノ', '(￣▽￣)ノ'], 700);
+  }
+
+  // Normal — slow happy blink
+  return frame(['(◕‿◕)', '(◕‿◕)', '(◕‿◕)', '(-‿-)'], 600);
+}

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -6,6 +6,7 @@ import { getOutputSpeed } from '../../speed-tracker.js';
 import { git as gitColor, gitBranch as gitBranchColor, warning as warningColor, critical as criticalColor, label, model as modelColor, project as projectColor, red, green, yellow, dim, custom as customColor } from '../colors.js';
 import { t } from '../../i18n/index.js';
 import { renderCostEstimate } from './cost.js';
+import { getKaomoji } from '../../kaomoji.js';
 
 function hyperlink(uri: string, text: string): string {
   const esc = '\x1b';
@@ -17,6 +18,10 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   const display = ctx.config?.display;
   const colors = ctx.config?.colors;
   const parts: string[] = [];
+
+  if (display?.showKaomoji) {
+    parts.push(getKaomoji(ctx));
+  }
 
   if (display?.showModel !== false) {
     const model = formatModelName(getModelName(ctx.stdin), ctx.config?.display?.modelFormat, ctx.config?.display?.modelOverride);


### PR DESCRIPTION
Add an opt-in animated kaomoji indicator to line 1 of the HUD that reflects the current session state in real time. Disabled by default — enable via display.showKaomoji: true in config.

Summary

- New src/kaomoji.ts module: selects and animates kaomoji based on session state with priority ordering
- config.ts: add display.showKaomoji (default false)
- render/lines/project.ts: render kaomoji at the start of line 1 when enabled
- README.md / README.zh.md: document the new option

State → kaomoji mapping (highest priority first):

## State → Kaomoji Mapping (highest priority first)
| State               | Kaomoji                  |
| ------------------- | ------------------------ |
| Rate limit reached  | (T_T) / (;;) / (TOT)     |
| Context >85%        | (；ﾟдﾟ) / (；°Д°)       |
| Tool error          | (/ω＼)                   |
| Context 70–85%      | (´･･)/(´-_-)             |
| 3+ tools running    | (ﾉ°ω°)ﾉ / (ﾉ°Д°)ﾉ       |
| Agent running       | (ﾟ∀ﾟ)                    |
| Tools running       | (￣ω￣) / (￣ー￣)        |
| All todos done      | (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧            |
| Context <5%        | (￣▽￣)ノ                |
| Normal              | (◕‿◕) / (-‿-)            |

Animation cycles through frames using Date.now() % intervalMs, leveraging the existing ~300ms HUD refresh rate. Each state has its own speed — panic is fast (400ms), normal blink is slow (600ms).

Enable via:
{ "display": { "showKaomoji": true } }

## Testing

- [x] `npm test`
- [x] `npm run test:coverage`

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed