### PR TITLE
docs: remove stray `<<<<<<< HEAD` conflict markers in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `lineLayout` | string | `expanded` | Layout: `expanded` (multi-line) or `compact` (single line) |
 | `pathLevels` | 1-3 | 1 | Directory levels to show in project path |
 | `maxWidth` | number \| `null` | `null` | Optional fallback width used only when terminal width detection fails completely |
-<<<<<<< HEAD
 | `elementOrder` | string[] | `["project","context","usage","promptCache","memory","environment","tools","agents","todos"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. |
 | `display.mergeGroups` | string[][] | `[["context","usage"]]` | Expanded-mode groups that should share a line when adjacent. Set `[]` to disable merged lines. |
 | `gitStatus.enabled` | boolean | true | Show git branch in HUD |

--- a/README.zh.md
+++ b/README.zh.md
@@ -154,7 +154,6 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `language` | `en` \| `zh` | `en` | HUD 标签语言。默认为英文；设为 `zh` 启用中文标签 |
 | `lineLayout` | string | `expanded` | 布局：`expanded`（多行）或 `compact`（单行） |
 | `pathLevels` | 1-3 | 1 | 项目路径显示的目录层级数 |
-<<<<<<< HEAD
 | `elementOrder` | string[] | `["project","context","usage","promptCache","memory","environment","tools","agents","todos"]` | 展开模式下元素的顺序。省略的条目在展开模式下隐藏 |
 | `display.mergeGroups` | string[][] | `[["context","usage"]]` | 展开模式下相邻时应共享一行的元素分组。设为 `[]` 可禁用合并行 |
 | `gitStatus.enabled` | boolean | true | 在 HUD 中显示 git 分支 |


### PR DESCRIPTION
## Summary
- Both `README.md` (line 163) and `README.zh.md` (line 157) contain a stray `<<<<<<< HEAD` line with no matching `=======` / `>>>>>>>` markers — likely a leftover from an incomplete merge conflict resolution.
- The stray line breaks the options table on GitHub's rendered view and inside editors.
- This PR deletes the two stray lines. No other content changes.

## Test plan
- [x] `grep -n "<<<<<<<\|>>>>>>>\|^=======$" README.md README.zh.md` returns nothing
- [x] Options tables in both READMEs render as a single continuous table