### PR TITLE
Require a 500ms minimum window for output speed

### DIFF
--- a/src/speed-tracker.ts
+++ b/src/speed-tracker.ts
@@ -5,6 +5,11 @@ import type { StdinData } from './types.js';
 import { getHudPluginDir } from './claude-config-dir.js';
 
 const SPEED_WINDOW_MS = 2000;
+// Status lines can re-render many times per second while tokens stream.
+// Computing a rate from sub-500ms windows amplifies noise and produces
+// spurious multi-thousand tok/s readings (see #481). Require at least
+// half a second of elapsed time before reporting a speed.
+const MIN_DELTA_MS = 500;
 
 interface SpeedCache {
   outputTokens: number;
@@ -68,7 +73,7 @@ export function getOutputSpeed(stdin: StdinData, overrides: Partial<SpeedTracker
   if (previous && outputTokens >= previous.outputTokens) {
     const deltaTokens = outputTokens - previous.outputTokens;
     const deltaMs = now - previous.timestamp;
-    if (deltaTokens > 0 && deltaMs > 0 && deltaMs <= SPEED_WINDOW_MS) {
+    if (deltaTokens > 0 && deltaMs >= MIN_DELTA_MS && deltaMs <= SPEED_WINDOW_MS) {
       speed = deltaTokens / (deltaMs / 1000);
     }
   }

--- a/tests/speed-tracker.test.js
+++ b/tests/speed-tracker.test.js
@@ -45,6 +45,28 @@ test('getOutputSpeed computes tokens per second within window', async () => {
   }
 });
 
+test('getOutputSpeed ignores sub-window bursts to avoid inflated rates', async () => {
+  const tempHome = await createTempHome();
+
+  try {
+    const base = { homeDir: () => tempHome };
+    getOutputSpeed(
+      { context_window: { current_usage: { output_tokens: 10 } } },
+      { ...base, now: () => 1000 }
+    );
+
+    // Status line re-renders ~50ms later with 60 more tokens. A naive rate
+    // calculation would report 1200 tok/s; we expect null instead (#481).
+    const speed = getOutputSpeed(
+      { context_window: { current_usage: { output_tokens: 70 } } },
+      { ...base, now: () => 1050 }
+    );
+    assert.equal(speed, null);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
 test('getOutputSpeed ignores stale windows', async () => {
   const tempHome = await createTempHome();
 


### PR DESCRIPTION
Closes #481.

The status line re-renders many times per second while tokens are streaming, so consecutive `getOutputSpeed` calls routinely land within tens of milliseconds of each other. The existing guard only caps the upper end of the window (`deltaMs <= SPEED_WINDOW_MS`) and lets any positive `deltaMs` through, so a small token delta over a very short window produces a huge tok/s value. The screenshot on #481 shows `out: 6291.9 tok/s` from what was actually ~60 tok/s of real output.

This adds a `MIN_DELTA_MS = 500` floor. If the window is shorter than that, the cache still updates but the function returns `null`, so the caller falls back to its no-speed rendering until a meaningful sample is available. 500ms matches the existing computation test's window, which continues to pass at the boundary. A new test exercises a 50ms rapid-render path and asserts the returned speed is `null` instead of 1200 tok/s.

`npm run build` clean, `node --test tests/speed-tracker.test.js` passes all five cases.