### PR TITLE
fix(speed): accumulate short windows before sampling

### DIFF
--- a/src/speed-tracker.ts
+++ b/src/speed-tracker.ts
@@ -69,14 +69,35 @@ export function getOutputSpeed(stdin: StdinData, overrides: Partial<SpeedTracker
   const homeDir = deps.homeDir();
   const previous = readCache(homeDir);
 
-  let speed: number | null = null;
-  if (previous && outputTokens >= previous.outputTokens) {
-    const deltaTokens = outputTokens - previous.outputTokens;
-    const deltaMs = now - previous.timestamp;
-    if (deltaTokens > 0 && deltaMs >= MIN_DELTA_MS && deltaMs <= SPEED_WINDOW_MS) {
-      speed = deltaTokens / (deltaMs / 1000);
-    }
+  if (!previous) {
+    writeCache(homeDir, { outputTokens, timestamp: now });
+    return null;
   }
+
+  if (outputTokens < previous.outputTokens) {
+    writeCache(homeDir, { outputTokens, timestamp: now });
+    return null;
+  }
+
+  let speed: number | null = null;
+  const deltaTokens = outputTokens - previous.outputTokens;
+  const deltaMs = now - previous.timestamp;
+
+  if (deltaMs > SPEED_WINDOW_MS) {
+    writeCache(homeDir, { outputTokens, timestamp: now });
+    return null;
+  }
+
+  if (deltaTokens <= 0) {
+    writeCache(homeDir, { outputTokens, timestamp: now });
+    return null;
+  }
+
+  if (deltaMs < MIN_DELTA_MS) {
+    return null;
+  }
+
+  speed = deltaTokens / (deltaMs / 1000);
 
   writeCache(homeDir, { outputTokens, timestamp: now });
   return speed;

--- a/tests/speed-tracker.test.js
+++ b/tests/speed-tracker.test.js
@@ -67,6 +67,39 @@ test('getOutputSpeed ignores sub-window bursts to avoid inflated rates', async (
   }
 });
 
+test('getOutputSpeed accumulates repeated short windows until the sample matures', async () => {
+  const tempHome = await createTempHome();
+
+  try {
+    const base = { homeDir: () => tempHome };
+    getOutputSpeed(
+      { context_window: { current_usage: { output_tokens: 10 } } },
+      { ...base, now: () => 1000 }
+    );
+
+    const firstBurst = getOutputSpeed(
+      { context_window: { current_usage: { output_tokens: 40 } } },
+      { ...base, now: () => 1200 }
+    );
+    assert.equal(firstBurst, null);
+
+    const secondBurst = getOutputSpeed(
+      { context_window: { current_usage: { output_tokens: 70 } } },
+      { ...base, now: () => 1400 }
+    );
+    assert.equal(secondBurst, null);
+
+    const matured = getOutputSpeed(
+      { context_window: { current_usage: { output_tokens: 100 } } },
+      { ...base, now: () => 1600 }
+    );
+    assert.ok(matured !== null);
+    assert.ok(Math.abs(matured - 150) < 0.01);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
 test('getOutputSpeed ignores stale windows', async () => {
   const tempHome = await createTempHome();
 


### PR DESCRIPTION
## Summary
- keep short output-speed windows open until they reach the minimum sampling interval
- avoid resetting the baseline on every fast rerender
- add a regression test that repeated sub-500ms updates eventually produce a sane speed

## Testing
- [x] npm test
- [x] npm test -- tests/speed-tracker.test.js

Fixes the regression introduced after #484 merged and restores the intended resolution for #481.