### PR TITLE
fix(security): harden links and Windows version lookup

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ Security fixes are applied to the latest release series only.
 
 ## Reporting a Vulnerability
 
-Please report security issues to: jarrodwttsyt@gmail.com
+Please report security issues through GitHub's private advisory flow:
+https://github.com/jarrodwatts/claude-hud/security/advisories/new
 
 Include a clear description, reproduction steps, and any relevant logs or screenshots.
 We will acknowledge receipt within 5 business days and provide a timeline for a fix if applicable.

--- a/src/git.ts
+++ b/src/git.ts
@@ -129,7 +129,7 @@ export async function getGitStatus(cwd?: string): Promise<GitStatus | null> {
         .replace(/^git@([^:]+):/, 'https://$1/')
         .replace(/\.git$/, '');
       if (httpsBase.startsWith('https://')) {
-        branchUrl = `${httpsBase}/tree/${branch}`;
+        branchUrl = `${httpsBase}/tree/${encodeURIComponent(branch)}`;
       }
     } catch {
       // No remote or not GitHub

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { RenderContext } from '../../types.js';
 import { getModelName, formatModelName, getProviderLabel } from '../../stdin.js';
 import { getOutputSpeed } from '../../speed-tracker.js';
@@ -7,10 +8,51 @@ import { git as gitColor, gitBranch as gitBranchColor, warning as warningColor, 
 import { t } from '../../i18n/index.js';
 import { renderCostEstimate } from './cost.js';
 
+const CONTROL_AND_BIDI_PATTERN = /[\u0000-\u001F\u007F-\u009F\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069\u206A-\u206F]/g;
+
 function hyperlink(uri: string, text: string): string {
   const esc = '\x1b';
   const st = '\\';
   return `${esc}]8;;${uri}${esc}${st}${text}${esc}]8;;${esc}${st}`;
+}
+
+function sanitizeDisplayText(value: string): string {
+  return value.replace(CONTROL_AND_BIDI_PATTERN, '');
+}
+
+function getFileHref(filePath: string): string | null {
+  try {
+    return pathToFileURL(path.resolve(filePath)).toString();
+  } catch {
+    return null;
+  }
+}
+
+function resolvePathWithinCwd(cwd: string, candidatePath: string): string | null {
+  const resolvedCwd = path.resolve(cwd);
+  const resolvedPath = path.resolve(cwd, candidatePath);
+  const relative = path.relative(resolvedCwd, resolvedPath);
+  if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+    return resolvedPath;
+  }
+  return null;
+}
+
+function safeHyperlink(uri: string | undefined | null, text: string): string {
+  if (!uri) {
+    return text;
+  }
+
+  const sanitizedUri = sanitizeDisplayText(uri);
+  try {
+    const parsed = new URL(sanitizedUri);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'file:') {
+      return text;
+    }
+    return hyperlink(parsed.toString(), text);
+  } catch {
+    return text;
+  }
 }
 
 export function renderProjectLine(ctx: RenderContext): string | null {
@@ -35,9 +77,9 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   if (display?.showProject !== false && ctx.stdin.cwd) {
     const segments = ctx.stdin.cwd.split(/[/\\]/).filter(Boolean);
     const pathLevels = ctx.config?.pathLevels ?? 1;
-    const projectPath = segments.length > 0 ? segments.slice(-pathLevels).join('/') : '/';
+    const projectPath = sanitizeDisplayText(segments.length > 0 ? segments.slice(-pathLevels).join('/') : '/');
     const coloredProject = projectColor(projectPath, colors);
-    projectPart = hyperlink(`file://${ctx.stdin.cwd}`, coloredProject);
+    projectPart = safeHyperlink(getFileHref(ctx.stdin.cwd), coloredProject);
   }
 
   let gitPart = '';
@@ -46,9 +88,11 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   const branchOverflow = gitConfig?.branchOverflow ?? 'truncate';
 
   if (showGit && ctx.gitStatus) {
-    const branchText = ctx.gitStatus.branch + ((gitConfig?.showDirty ?? true) && ctx.gitStatus.isDirty ? '*' : '');
+    const branchText = sanitizeDisplayText(
+      ctx.gitStatus.branch + ((gitConfig?.showDirty ?? true) && ctx.gitStatus.isDirty ? '*' : '')
+    );
     const coloredBranch = gitBranchColor(branchText, colors);
-    const linkedBranch = ctx.gitStatus.branchUrl ? hyperlink(ctx.gitStatus.branchUrl, coloredBranch) : coloredBranch;
+    const linkedBranch = safeHyperlink(ctx.gitStatus.branchUrl, coloredBranch);
     const gitInner: string[] = [linkedBranch];
 
     if (gitConfig?.showAheadBehind) {
@@ -156,8 +200,10 @@ export function renderGitFilesLine(ctx: RenderContext, terminalWidth: number | n
   const cwd = ctx.stdin.cwd;
   const sorted = [...trackedFiles].sort((a, b) => {
     try {
-      const aMtime = cwd ? fs.statSync(path.join(cwd, a.fullPath)).mtimeMs : 0;
-      const bMtime = cwd ? fs.statSync(path.join(cwd, b.fullPath)).mtimeMs : 0;
+      const aPath = cwd ? resolvePathWithinCwd(cwd, a.fullPath) : null;
+      const bPath = cwd ? resolvePathWithinCwd(cwd, b.fullPath) : null;
+      const aMtime = aPath ? fs.statSync(aPath).mtimeMs : 0;
+      const bMtime = bPath ? fs.statSync(bPath).mtimeMs : 0;
       return bMtime - aMtime;
     } catch {
       return 0;
@@ -170,12 +216,14 @@ export function renderGitFilesLine(ctx: RenderContext, terminalWidth: number | n
 
   for (const trackedFile of shown) {
     const prefix = trackedFile.type === 'added' ? green('+') : trackedFile.type === 'deleted' ? red('-') : yellow('~');
+    const safeBasename = sanitizeDisplayText(trackedFile.basename);
     const coloredName = trackedFile.type === 'added'
-      ? green(trackedFile.basename)
+      ? green(safeBasename)
       : trackedFile.type === 'deleted'
-        ? red(trackedFile.basename)
-        : yellow(trackedFile.basename);
-    const linkedName = cwd ? hyperlink(`file://${path.join(cwd, trackedFile.fullPath)}`, coloredName) : coloredName;
+        ? red(safeBasename)
+        : yellow(safeBasename);
+    const resolvedPath = cwd ? resolvePathWithinCwd(cwd, trackedFile.fullPath) : null;
+    const linkedName = resolvedPath ? safeHyperlink(getFileHref(resolvedPath), coloredName) : coloredName;
     let entry = `${prefix}${linkedName}`;
 
     if (trackedFile.lineDiff) {

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -94,6 +94,14 @@ function getTranscriptCachePath(transcriptPath: string, homeDir: string): string
   return path.join(getHudPluginDir(homeDir), 'transcript-cache', `${hash}.json`);
 }
 
+function canonicalizeTranscriptPath(transcriptPath: string): string | null {
+  try {
+    return fs.realpathSync(transcriptPath);
+  } catch {
+    return null;
+  }
+}
+
 function readTranscriptFileState(transcriptPath: string): TranscriptFileState | null {
   try {
     const stat = fs.statSync(transcriptPath);
@@ -181,7 +189,7 @@ function writeTranscriptCache(transcriptPath: string, state: TranscriptFileState
       transcriptState: state,
       data: serializeTranscriptData(data),
     };
-    fs.writeFileSync(cachePath, JSON.stringify(payload), 'utf8');
+    fs.writeFileSync(cachePath, JSON.stringify(payload), { encoding: 'utf8', mode: 0o600 });
   } catch {
     // Cache failures are non-fatal; fall back to fresh parsing next time.
   }
@@ -198,12 +206,17 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
     return result;
   }
 
-  const transcriptState = readTranscriptFileState(transcriptPath);
+  const canonicalTranscriptPath = canonicalizeTranscriptPath(transcriptPath);
+  if (!canonicalTranscriptPath) {
+    return result;
+  }
+
+  const transcriptState = readTranscriptFileState(canonicalTranscriptPath);
   if (!transcriptState) {
     return result;
   }
 
-  const cached = readTranscriptCache(transcriptPath, transcriptState);
+  const cached = readTranscriptCache(canonicalTranscriptPath, transcriptState);
   if (cached) {
     return cached;
   }
@@ -224,7 +237,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   let parsedCleanly = false;
 
   try {
-    const fileStream = createReadStreamImpl(transcriptPath);
+    const fileStream = createReadStreamImpl(canonicalTranscriptPath);
     const rl = readline.createInterface({
       input: fileStream,
       crlfDelay: Infinity,
@@ -265,7 +278,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   result.sessionName = customTitle ?? latestSlug;
   result.sessionTokens = sessionTokens;
   if (parsedCleanly) {
-    writeTranscriptCache(transcriptPath, transcriptState, result);
+    writeTranscriptCache(canonicalTranscriptPath, transcriptState, result);
   }
 
   return result;

--- a/src/version.ts
+++ b/src/version.ts
@@ -41,7 +41,7 @@ const defaultExecFile: ExecFileImpl = promisify(execFile) as ExecFileImpl;
 let execFileImpl: ExecFileImpl = defaultExecFile;
 let resolveClaudeBinaryImpl: () => ClaudeBinaryInfo | null = resolveClaudeBinaryFromPath;
 let platformImpl: () => NodeJS.Platform = () => process.platform;
-let comspecImpl: () => string | undefined = () => process.env.COMSPEC;
+let windowsCmdImpl: () => string = () => 'C:\\Windows\\System32\\cmd.exe';
 let cachedBinaryKey: string | undefined;
 let cachedVersion: string | undefined;
 let hasResolved = false;
@@ -199,13 +199,13 @@ export function _parseClaudeCodeVersion(output: string): string | undefined {
 export function _getClaudeVersionInvocation(
   binaryPath: string,
   platform: NodeJS.Platform = platformImpl(),
-  comspec: string | undefined = comspecImpl()
+  windowsCmd: string = windowsCmdImpl()
 ): ClaudeVersionInvocation {
   const ext = path.extname(binaryPath).toLowerCase();
   if (platform === 'win32' && (ext === '.cmd' || ext === '.bat')) {
     const command = [quoteForCmd(binaryPath), '--version'].join(' ');
     return {
-      file: comspec || 'cmd.exe',
+      file: windowsCmd,
       args: ['/d', '/s', '/c', `"${command}"`],
     };
   }
@@ -297,8 +297,8 @@ export function _setResolveClaudeBinaryForTests(impl: (() => ClaudeBinaryInfo | 
 
 export function _setVersionInvocationEnvForTests(
   platformGetter: (() => NodeJS.Platform) | null,
-  comspecGetter: (() => string | undefined) | null
+  windowsCmdGetter: (() => string) | null
 ): void {
   platformImpl = platformGetter ?? (() => process.platform);
-  comspecImpl = comspecGetter ?? (() => process.env.COMSPEC);
+  windowsCmdImpl = windowsCmdGetter ?? (() => 'C:\\Windows\\System32\\cmd.exe');
 }

--- a/tests/git.test.js
+++ b/tests/git.test.js
@@ -237,7 +237,7 @@ test('getGitStatus builds branchUrl from HTTPS origin remotes', async () => {
     execFileSync('git', ['remote', 'add', 'origin', 'https://github.com/example/claude-hud.git'], { cwd: dir, stdio: 'ignore' });
 
     const result = await getGitStatus(dir);
-    assert.equal(result?.branchUrl, 'https://github.com/example/claude-hud/tree/feature/test-branch');
+    assert.equal(result?.branchUrl, 'https://github.com/example/claude-hud/tree/feature%2Ftest-branch');
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -254,7 +254,7 @@ test('getGitStatus builds branchUrl from SSH origin remotes', async () => {
     execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:example/claude-hud.git'], { cwd: dir, stdio: 'ignore' });
 
     const result = await getGitStatus(dir);
-    assert.equal(result?.branchUrl, 'https://github.com/example/claude-hud/tree/feature/test-branch');
+    assert.equal(result?.branchUrl, 'https://github.com/example/claude-hud/tree/feature%2Ftest-branch');
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1706,6 +1706,25 @@ test('renderProjectLine colors ahead count at critical threshold', () => {
   assert.ok(line?.includes('\x1b[31m↑25\x1b[0m'), 'ahead count should use critical color');
 });
 
+test('renderProjectLine strips control characters from project and branch links', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-\u0007project';
+  ctx.gitStatus = {
+    branch: 'feat/\u0007name',
+    isDirty: false,
+    ahead: 0,
+    behind: 0,
+    branchUrl: 'https://github.com/example/claude-hud/tree/feat%2Fname\u0007',
+  };
+
+  const line = renderProjectLine(ctx) ?? '';
+  const visible = stripAnsi(line);
+
+  assert.ok(visible.includes('my-project'));
+  assert.ok(visible.includes('feat/name'));
+  assert.ok(!line.includes('\u0007'));
+});
+
 test('renderGitFilesLine renders tracked files with per-file line diffs', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = '/tmp/my-project';
@@ -1734,6 +1753,34 @@ test('renderGitFilesLine renders tracked files with per-file line diffs', () => 
   assert.ok(line?.includes('+4'));
   assert.ok(line?.includes('-2'));
   assert.ok(line?.includes('?2'));
+});
+
+test('renderGitFilesLine strips control characters and skips links outside cwd', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.config.gitStatus.showFileStats = true;
+  ctx.gitStatus = {
+    branch: 'main',
+    isDirty: true,
+    ahead: 0,
+    behind: 0,
+    lineDiff: { added: 1, deleted: 0 },
+    fileStats: {
+      modified: 1,
+      added: 0,
+      deleted: 0,
+      untracked: 0,
+      trackedFiles: [
+        { basename: 'app\u0007.ts', fullPath: '../outside.ts', type: 'modified', lineDiff: { added: 1, deleted: 0 } },
+      ],
+    },
+  };
+
+  const line = renderGitFilesLine(ctx, 120) ?? '';
+  const visible = stripAnsi(line);
+
+  assert.ok(visible.includes('app.ts'));
+  assert.ok(!line.includes('\u0007'));
 });
 
 test('renderGitFilesLine hides on narrow terminals', () => {

--- a/tests/version.test.js
+++ b/tests/version.test.js
@@ -44,7 +44,7 @@ test('_getClaudeVersionInvocation executes binaries directly on non-Windows', ()
   });
 });
 
-test('_getClaudeVersionInvocation wraps .cmd launches through COMSPEC on Windows', () => {
+test('_getClaudeVersionInvocation wraps .cmd launches through a fixed Windows cmd path', () => {
   const invocation = _getClaudeVersionInvocation(
     'C:\\Program Files\\Claude\\claude.cmd',
     'win32',
@@ -54,6 +54,21 @@ test('_getClaudeVersionInvocation wraps .cmd launches through COMSPEC on Windows
     file: 'C:\\Windows\\System32\\cmd.exe',
     args: ['/d', '/s', '/c', '"\"C:\\Program Files\\Claude\\claude.cmd\" --version"'],
   });
+});
+
+test('_getClaudeVersionInvocation ignores COMSPEC on Windows', () => {
+  const originalComspec = process.env.COMSPEC;
+  process.env.COMSPEC = 'C:\\malicious\\cmd.exe';
+
+  try {
+    const invocation = _getClaudeVersionInvocation(
+      'C:\\Program Files\\Claude\\claude.cmd',
+      'win32'
+    );
+    assert.equal(invocation.file, 'C:\\Windows\\System32\\cmd.exe');
+  } finally {
+    restoreEnvVar('COMSPEC', originalComspec);
+  }
 });
 
 test('_getClaudeVersionInvocation executes .exe paths directly on Windows', () => {


### PR DESCRIPTION
## Summary
- sanitize project and git hyperlink rendering to strip control characters and use safe file URLs
- encode remote branch URLs and avoid linking tracked paths outside the workspace root
- stop honoring COMSPEC for Windows Claude version checks and switch SECURITY.md to GitHub private advisories
- canonicalize transcript cache paths and write transcript cache files with restrictive permissions

## Testing
- [x] npm test
- [x] npm test -- tests/render.test.js tests/git.test.js tests/version.test.js tests/core.test.js

Addresses the validated portions of #485 on current main.