### PR TITLE
feat(context): make colour thresholds configurable

### DIFF
--- a/commands/configure.md
+++ b/commands/configure.md
@@ -16,7 +16,8 @@ These are always enabled and NOT configurable:
 - Context bar `████░░░░░░ 45%`
 
 Advanced settings such as `colors.*`, `pathLevels`, `display.timeFormat`,
-`display.usageThreshold`, and `display.environmentThreshold` are preserved when saving but are not
+`display.usageThreshold`, `display.environmentThreshold`, `display.contextWarningThreshold`,
+and `display.contextCriticalThreshold` are preserved when saving but are not
 edited by this guided flow.
 
 ---

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ export type HudColorName =
   | 'brightBlue'
   | 'brightMagenta';
 
-/** A color value: named preset, 256-color index (0-255), or hex string (#rrggbb). */
+/** A colour value: named preset, 256-colour index (0-255), or hex string (#rrggbb). */
 export type HudColorValue = HudColorName | number | string;
 
 export interface HudColorOverrides {
@@ -108,6 +108,8 @@ export interface HudConfig {
     showOutputStyle: boolean;
     mergeGroups: HudElement[][];
     autocompactBuffer: AutocompactBufferMode;
+    contextWarningThreshold: number;
+    contextCriticalThreshold: number;
     usageThreshold: number;
     sevenDayThreshold: number;
     environmentThreshold: number;
@@ -164,6 +166,8 @@ export const DEFAULT_CONFIG: HudConfig = {
     showOutputStyle: false,
     mergeGroups: DEFAULT_MERGE_GROUPS.map(group => [...group]),
     autocompactBuffer: 'enabled',
+    contextWarningThreshold: 70,
+    contextCriticalThreshold: 85,
     usageThreshold: 0,
     sevenDayThreshold: 80,
     environmentThreshold: 0,
@@ -355,6 +359,11 @@ function validateThreshold(value: unknown, max = 100): number {
   return Math.max(0, Math.min(max, value));
 }
 
+function validateContextThreshold(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.min(100, value));
+}
+
 function validateCountThreshold(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return 0;
@@ -503,6 +512,14 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     autocompactBuffer: validateAutocompactBuffer(migrated.display?.autocompactBuffer)
       ? migrated.display.autocompactBuffer
       : DEFAULT_CONFIG.display.autocompactBuffer,
+    contextWarningThreshold: validateContextThreshold(
+      migrated.display?.contextWarningThreshold,
+      DEFAULT_CONFIG.display.contextWarningThreshold,
+    ),
+    contextCriticalThreshold: validateContextThreshold(
+      migrated.display?.contextCriticalThreshold,
+      DEFAULT_CONFIG.display.contextCriticalThreshold,
+    ),
     usageThreshold: validateThreshold(migrated.display?.usageThreshold, 100),
     sevenDayThreshold: validateThreshold(migrated.display?.sevenDayThreshold, 100),
     environmentThreshold: validateThreshold(migrated.display?.environmentThreshold, 100),

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ export type HudColorName =
   | 'brightBlue'
   | 'brightMagenta';
 
-/** A colour value: named preset, 256-colour index (0-255), or hex string (#rrggbb). */
+/** A color value: named preset, 256-color index (0-255), or hex string (#rrggbb). */
 export type HudColorValue = HudColorName | number | string;
 
 export interface HudColorOverrides {

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -23,7 +23,7 @@ const ANSI_BY_NAME: Record<HudColorName, string> = {
   brightMagenta: BRIGHT_MAGENTA,
 };
 
-/** Convert a hex color string (#rrggbb) to a truecolor ANSI escape sequence. */
+/** Convert a hex colour string (#rrggbb) to a truecolor ANSI escape sequence. */
 function hexToAnsi(hex: string): string {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);
@@ -32,8 +32,8 @@ function hexToAnsi(hex: string): string {
 }
 
 /**
- * Resolve a color value to an ANSI escape sequence.
- * Accepts named presets, 256-color indices (0-255), or hex strings (#rrggbb).
+ * Resolve a colour value to an ANSI escape sequence.
+ * Accepts named presets, 256-colour indices (0-255), or hex strings (#rrggbb).
  */
 function resolveAnsi(value: HudColorValue | undefined, fallback: string): string {
   if (value === undefined || value === null) {
@@ -116,9 +116,20 @@ export function critical(text: string, colors?: Partial<HudColorOverrides>): str
   return colorize(text, resolveAnsi(colors?.critical, RED));
 }
 
-export function getContextColor(percent: number, colors?: Partial<HudColorOverrides>): string {
-  if (percent >= 85) return resolveAnsi(colors?.critical, RED);
-  if (percent >= 70) return resolveAnsi(colors?.warning, YELLOW);
+export interface ContextThresholds {
+  warning?: number;
+  critical?: number;
+}
+
+export function getContextColor(
+  percent: number,
+  colors?: Partial<HudColorOverrides>,
+  thresholds?: ContextThresholds,
+): string {
+  const critical = thresholds?.critical ?? 85;
+  const warning = thresholds?.warning ?? 70;
+  if (percent >= critical) return resolveAnsi(colors?.critical, RED);
+  if (percent >= warning) return resolveAnsi(colors?.warning, YELLOW);
   return resolveAnsi(colors?.context, GREEN);
 }
 
@@ -137,11 +148,16 @@ export function quotaBar(percent: number, width: number = 10, colors?: Partial<H
   return `${color}${'█'.repeat(filled)}${DIM}${'░'.repeat(empty)}${RESET}`;
 }
 
-export function coloredBar(percent: number, width: number = 10, colors?: Partial<HudColorOverrides>): string {
+export function coloredBar(
+  percent: number,
+  width: number = 10,
+  colors?: Partial<HudColorOverrides>,
+  thresholds?: ContextThresholds,
+): string {
   const safeWidth = Number.isFinite(width) ? Math.max(0, Math.round(width)) : 0;
   const safePercent = Number.isFinite(percent) ? Math.min(100, Math.max(0, percent)) : 0;
   const filled = Math.round((safePercent / 100) * safeWidth);
   const empty = safeWidth - filled;
-  const color = getContextColor(safePercent, colors);
+  const color = getContextColor(safePercent, colors, thresholds);
   return `${color}${'█'.repeat(filled)}${DIM}${'░'.repeat(empty)}${RESET}`;
 }

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -23,7 +23,7 @@ const ANSI_BY_NAME: Record<HudColorName, string> = {
   brightMagenta: BRIGHT_MAGENTA,
 };
 
-/** Convert a hex colour string (#rrggbb) to a truecolor ANSI escape sequence. */
+/** Convert a hex color string (#rrggbb) to a truecolor ANSI escape sequence. */
 function hexToAnsi(hex: string): string {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);
@@ -32,8 +32,8 @@ function hexToAnsi(hex: string): string {
 }
 
 /**
- * Resolve a colour value to an ANSI escape sequence.
- * Accepts named presets, 256-colour indices (0-255), or hex strings (#rrggbb).
+ * Resolve a color value to an ANSI escape sequence.
+ * Accepts named presets, 256-color indices (0-255), or hex strings (#rrggbb).
  */
 function resolveAnsi(value: HudColorValue | undefined, fallback: string): string {
   if (value === undefined || value === null) {

--- a/src/render/lines/identity.ts
+++ b/src/render/lines/identity.ts
@@ -29,13 +29,17 @@ export function renderIdentityLine(
   }
 
   const display = ctx.config?.display;
+  const contextThresholds = {
+    warning: display?.contextWarningThreshold,
+    critical: display?.contextCriticalThreshold,
+  };
   const contextValueMode = display?.contextValue ?? "percent";
   const contextValue = formatContextValue(ctx, percent, contextValueMode);
-  const contextValueDisplay = `${getContextColor(percent, colors)}${contextValue}${RESET}`;
+  const contextValueDisplay = `${getContextColor(percent, colors, contextThresholds)}${contextValue}${RESET}`;
 
   let line =
     display?.showContextBar !== false
-      ? `${progressLabel("label.context", colors, alignLabels)} ${coloredBar(percent, getAdaptiveBarWidth(), colors)} ${contextValueDisplay}`
+      ? `${progressLabel("label.context", colors, alignLabels)} ${coloredBar(percent, getAdaptiveBarWidth(), colors, contextThresholds)} ${contextValueDisplay}`
       : `${progressLabel("label.context", colors, alignLabels)} ${contextValueDisplay}`;
 
   if (display?.showTokenBreakdown !== false && percent >= 85) {

--- a/src/render/lines/identity.ts
+++ b/src/render/lines/identity.ts
@@ -42,7 +42,7 @@ export function renderIdentityLine(
       ? `${progressLabel("label.context", colors, alignLabels)} ${coloredBar(percent, getAdaptiveBarWidth(), colors, contextThresholds)} ${contextValueDisplay}`
       : `${progressLabel("label.context", colors, alignLabels)} ${contextValueDisplay}`;
 
-  if (display?.showTokenBreakdown !== false && percent >= 85) {
+  if (display?.showTokenBreakdown !== false && percent >= (display?.contextCriticalThreshold ?? 85)) {
     const usage = ctx.stdin.context_window?.current_usage;
     if (usage) {
       const input = formatTokens(usage.input_tokens ?? 0);

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -296,7 +296,7 @@ export function renderSessionLine(ctx: RenderContext): string {
   let line = parts.join(' | ');
 
   // Token breakdown at high context
-  if (display?.showTokenBreakdown !== false && percent >= 85) {
+  if (display?.showTokenBreakdown !== false && percent >= (display?.contextCriticalThreshold ?? 85)) {
     const usage = ctx.stdin.context_window?.current_usage;
     if (usage) {
       const input = formatTokens(usage.input_tokens ?? 0);

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -29,16 +29,20 @@ export function renderSessionLine(ctx: RenderContext): string {
   }
 
   const colors = ctx.config?.colors;
+  const display = ctx.config?.display;
+  const contextThresholds = {
+    warning: display?.contextWarningThreshold,
+    critical: display?.contextCriticalThreshold,
+  };
   const barWidth = getAdaptiveBarWidth();
-  const bar = coloredBar(percent, barWidth, colors);
+  const bar = coloredBar(percent, barWidth, colors, contextThresholds);
 
   const parts: string[] = [];
-  const display = ctx.config?.display;
   const timeFormat: TimeFormatMode = display?.timeFormat ?? 'relative';
   const resetsKey = timeFormat === 'absolute' ? 'format.resets' : 'format.resetsIn';
   const contextValueMode = display?.contextValue ?? 'percent';
   const contextValue = formatContextValue(ctx, percent, contextValueMode);
-  const contextValueDisplay = `${getContextColor(percent, colors)}${contextValue}${RESET}`;
+  const contextValueDisplay = `${getContextColor(percent, colors, contextThresholds)}${contextValue}${RESET}`;
 
   // Model and context bar (FIRST)
   const providerLabel = getProviderLabel(ctx.stdin);

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -178,6 +178,36 @@ test('mergeConfig preserves explicit git push thresholds', () => {
   assert.equal(config.gitStatus.pushCriticalThreshold, 30);
 });
 
+test('mergeConfig defaults context thresholds to 70/85', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.contextWarningThreshold, 70);
+  assert.equal(config.display.contextCriticalThreshold, 85);
+});
+
+test('mergeConfig preserves explicit context thresholds', () => {
+  const config = mergeConfig({
+    display: { contextWarningThreshold: 30, contextCriticalThreshold: 50 },
+  });
+  assert.equal(config.display.contextWarningThreshold, 30);
+  assert.equal(config.display.contextCriticalThreshold, 50);
+});
+
+test('mergeConfig clamps context thresholds to 0-100', () => {
+  const config = mergeConfig({
+    display: { contextWarningThreshold: -10, contextCriticalThreshold: 150 },
+  });
+  assert.equal(config.display.contextWarningThreshold, 0);
+  assert.equal(config.display.contextCriticalThreshold, 100);
+});
+
+test('mergeConfig falls back to defaults for invalid context thresholds', () => {
+  const config = mergeConfig({
+    display: { contextWarningThreshold: 'high', contextCriticalThreshold: null },
+  });
+  assert.equal(config.display.contextWarningThreshold, 70);
+  assert.equal(config.display.contextCriticalThreshold, 85);
+});
+
 test('mergeConfig preserves valid git branch overflow modes', () => {
   assert.equal(mergeConfig({ gitStatus: { branchOverflow: 'wrap' } }).gitStatus.branchOverflow, 'wrap');
   assert.equal(mergeConfig({ gitStatus: { branchOverflow: 'truncate' } }).gitStatus.branchOverflow, 'truncate');
@@ -522,7 +552,7 @@ test('mergeConfig accepts valid color overrides and filters invalid values', () 
   assert.equal(config.colors.custom, '#ff6600');
 });
 
-// --- Custom color value tests (256-color and hex) ---
+// --- Custom colour value tests (256-colour and hex) ---
 
 test('mergeConfig accepts 256-color index values', () => {
   const config = mergeConfig({

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -175,6 +175,28 @@ test('getContextColor returns yellow for warning threshold', () => {
   assert.equal(getContextColor(70), '\x1b[33m');
 });
 
+test('getContextColor respects custom thresholds', () => {
+  const thresholds = { warning: 30, critical: 50 };
+  assert.equal(getContextColor(10, undefined, thresholds), '\x1b[32m'); // green
+  assert.equal(getContextColor(30, undefined, thresholds), '\x1b[33m'); // yellow
+  assert.equal(getContextColor(49, undefined, thresholds), '\x1b[33m'); // still yellow
+  assert.equal(getContextColor(50, undefined, thresholds), '\x1b[31m'); // red
+  assert.equal(getContextColor(90, undefined, thresholds), '\x1b[31m'); // red
+});
+
+test('getContextColor falls back to defaults when thresholds undefined', () => {
+  assert.equal(getContextColor(69, undefined, {}), '\x1b[32m');
+  assert.equal(getContextColor(70, undefined, {}), '\x1b[33m');
+  assert.equal(getContextColor(85, undefined, {}), '\x1b[31m');
+});
+
+test('getContextColor honours partial threshold overrides', () => {
+  // Only warning overridden — critical stays at default 85
+  assert.equal(getContextColor(30, undefined, { warning: 30 }), '\x1b[33m');
+  assert.equal(getContextColor(84, undefined, { warning: 30 }), '\x1b[33m');
+  assert.equal(getContextColor(85, undefined, { warning: 30 }), '\x1b[31m');
+});
+
 test('getContextColor and getQuotaColor respect custom semantic overrides', () => {
   const colors = {
     context: 'cyan',

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -134,6 +134,42 @@ test('renderSessionLine adds token breakdown when context is high', () => {
   assert.ok(line.includes('cache:'), 'expected cache breakdown');
 });
 
+test('renderSessionLine token breakdown honours contextCriticalThreshold', () => {
+  const ctx = baseContext();
+  ctx.config.display.contextCriticalThreshold = 50;
+  // For 55%: (tokens + 33000) / 200000 = 0.55 → tokens = 77000
+  ctx.stdin.context_window.current_usage.input_tokens = 77000;
+  const line = renderSessionLine(ctx);
+  assert.ok(line.includes('in:'), 'expected token breakdown at 55% when critical threshold is 50');
+});
+
+test('renderSessionLine suppresses token breakdown below raised contextCriticalThreshold', () => {
+  const ctx = baseContext();
+  ctx.config.display.contextCriticalThreshold = 95;
+  // For 90%: (tokens + 33000) / 200000 = 0.9 → tokens = 147000
+  ctx.stdin.context_window.current_usage.input_tokens = 147000;
+  const line = renderSessionLine(ctx);
+  assert.ok(!line.includes('in:'), 'expected no token breakdown at 90% when critical threshold is 95');
+});
+
+test('renderIdentityLine token breakdown honours contextCriticalThreshold', () => {
+  const ctx = baseContext();
+  ctx.config.display.contextCriticalThreshold = 50;
+  // For 55%: (tokens + 33000) / 200000 = 0.55 → tokens = 77000
+  ctx.stdin.context_window.current_usage.input_tokens = 77000;
+  const line = renderIdentityLine(ctx);
+  assert.ok(line.includes('in:'), 'expected token breakdown at 55% when critical threshold is 50');
+});
+
+test('renderIdentityLine suppresses token breakdown below raised contextCriticalThreshold', () => {
+  const ctx = baseContext();
+  ctx.config.display.contextCriticalThreshold = 95;
+  // For 90%: (tokens + 33000) / 200000 = 0.9 → tokens = 147000
+  ctx.stdin.context_window.current_usage.input_tokens = 147000;
+  const line = renderIdentityLine(ctx);
+  assert.ok(!line.includes('in:'), 'expected no token breakdown at 90% when critical threshold is 95');
+});
+
 test('renderSessionLine includes duration and formats large tokens', () => {
   const ctx = baseContext();
   ctx.sessionDuration = '1m';


### PR DESCRIPTION
## Summary

The context bar's warning (yellow) and critical (red) colours switch at hard-coded 70% and 85%, and the token-breakdown detail (`in: Nk, cache: Nk`) triggers at a hard-coded `percent >= 85`. This PR makes all three configurable via two new config keys, defaulting to current values so existing installs see zero behaviour change:

```json
{
  "display": {
    "contextWarningThreshold": 70,
    "contextCriticalThreshold": 85
  }
}
```

Mirrors the existing `gitStatus.pushWarningThreshold` / `pushCriticalThreshold` pattern. `contextCriticalThreshold` governs **both** the red-colour threshold AND the token-breakdown detail trigger — one "critical" concept, one number.

## Why this matters

**Auto-compact defaults are too late for many use cases.** Claude Code's built-in auto-compact fires at ~83.5% ([bswen docs](https://docs.bswen.com/blog/2026-03-21-claude-code-auto-compact-settings/), [claudefa.st](https://claudefa.st/blog/guide/mechanics/context-buffer-management)) — the current 85% critical threshold is effectively "same as auto-compact," giving the user no heads-up before the system intervenes.

**Empirical context-rot research suggests users should compact far earlier than 85%:**
- Chroma's 2025 [Context Rot research](https://www.trychroma.com/research/context-rot) tested 18 frontier models; all showed ≥30% accuracy drop in mid-window positions, with degradation starting well before the nominal limit.
- Community guidance recommends **manual compact at 60%**, with 40–70% as the practical working range ([mindstudio](https://www.mindstudio.ai/blog/claude-code-compact-command-context-management), [howdoiuseai](https://www.howdoiuseai.com/blog/2026-04-16-what-does-compact-do-in-claude-code-context-management)).
- Liu et al.'s U-shaped attention curve: models attend to the start and end of context, poorly to the middle.

**Workflows with an externally-triggered wrap-up step** (a pre-compaction hook that itself consumes tokens) have a hard requirement for earlier warning — the wrap-up needs headroom to run. Today the HUD can't signal any of this: the bar stays green until 70%, and by then the model may already be degrading.

## Implementation notes

- New optional `ContextThresholds` parameter on `getContextColor` and `coloredBar`. Existing callers without it fall through to 70/85. No breaking change.
- Values are clamped to `0-100`; non-numeric / non-finite values fall back to defaults (new `validateContextThreshold` helper — `validateThreshold` returns `0` on invalid input, which would mean "everything is critical", so a dedicated validator returning the default is cleaner).
- **No ordering invariant** is enforced. If `warning >= critical` the warning branch simply never fires. Keeps the behaviour transparent; no silent reordering.
- `prompt-cache.ts` calls `getContextColor(0, ...)` to force the "healthy" colour — unaffected by thresholds and unchanged.
- Token-breakdown detail (`identity.ts:45`, `session-line.ts:299`) now uses `display?.contextCriticalThreshold ?? 85` instead of the hard-coded `85`.

## Testing

- [x] `npm test` — **480 pass, 1 skipped, 0 fail** (11 new tests added)
- [x] `npm run test:coverage` — passes

New tests:
- `config.test.js` — defaults to 70/85, preserves explicit values, clamps out-of-range, falls back on invalid types
- `render.test.js` — `getContextColor` respects custom thresholds, falls back on empty object, honours partial overrides
- `render.test.js` — token breakdown honours `contextCriticalThreshold` (shown at 55% when threshold=50, suppressed at 90% when threshold=95), mirrored for both `renderSessionLine` and `renderIdentityLine`

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed — new keys added to `commands/configure.md`'s "advanced settings preserved when saving but not edited by this guided flow" list
- [x] Per CONTRIBUTING.md, only `src/`, `tests/`, and `commands/` are touched — `dist/` left untouched for CI

## Use cases enabled

- **Pre-compaction hook / skill / slash command** that consumes tokens — can set critical to e.g. 50 so the colour flips before the hook starts, leaving headroom.
- **Context-rot-aware workflow** — set warning to 40–50 (mid-window degradation zone per Chroma research) to see yellow before quality drops, rather than the current green-until-70.
- **Long-context-aggressive users** — raise thresholds to 90/95 to push the HUD's attention to the very end of usable context.
