### PR TITLE
fix(effort): tolerate object schema from Claude Code 2.1.115+

### DIFF
--- a/src/effort.ts
+++ b/src/effort.ts
@@ -31,11 +31,12 @@ export type StdinEffortInput = string | StdinEffort | null | undefined;
 /**
  * Resolve the current session's effort level.
  *
- * Priority:
- * 1. stdin.effort as object `{ level: string }` — Claude Code 2.1.115+
- * 2. stdin.effort as bare string — original PR #471 future-proofed path
- * 3. Parent process CLI args — `--effort` flag captured from ppid
- * 4. null
+ * Resolution order (matches `extractEffortString` below):
+ * 1. stdin.effort as non-empty string — original PR #471 future-proofed path.
+ * 2. stdin.effort as object with string `level` — Claude Code 2.1.115+ schema
+ *    (e.g., `{ "level": "max" }`).
+ * 3. Parent process CLI args — `--effort` flag captured from ppid.
+ * 4. null.
  *
  * Non-matching inputs (numbers, booleans, arrays, objects without a string
  * `level`) fall through to step 3 rather than crashing.

--- a/src/effort.ts
+++ b/src/effort.ts
@@ -14,17 +14,38 @@ const KNOWN_SYMBOLS: Record<string, string> = {
 };
 
 /**
+ * Shape of the effort field in Claude Code stdin JSON.
+ *
+ * Historically absent; Claude Code 2.1.115+ sends an object with a string
+ * `level` field (verified capture: `{ "level": "max" }`). The index signature
+ * keeps the type permissive so future additions (e.g., a budget field) do not
+ * require another breaking change here.
+ */
+export interface StdinEffort {
+  level?: string | null;
+  [key: string]: unknown;
+}
+
+export type StdinEffortInput = string | StdinEffort | null | undefined;
+
+/**
  * Resolve the current session's effort level.
  *
  * Priority:
- * 1. stdin.effort (future — when Claude Code exposes it in statusline JSON)
- * 2. Parent process CLI args (reflects --effort flag at session start)
+ * 1. stdin.effort as object `{ level: string }` — Claude Code 2.1.115+
+ * 2. stdin.effort as bare string — original PR #471 future-proofed path
+ * 3. Parent process CLI args — `--effort` flag captured from ppid
+ * 4. null
  *
- * Returns null if effort cannot be determined.
+ * Non-matching inputs (numbers, booleans, arrays, objects without a string
+ * `level`) fall through to step 3 rather than crashing.
  */
-export function resolveEffortLevel(stdinEffort?: string | null): EffortInfo | null {
-  if (stdinEffort) {
-    return formatEffort(stdinEffort);
+export function resolveEffortLevel(
+  stdinEffort?: StdinEffortInput
+): EffortInfo | null {
+  const fromStdin = extractEffortString(stdinEffort);
+  if (fromStdin) {
+    return formatEffort(fromStdin);
   }
 
   const cliEffort = readParentProcessEffort();
@@ -32,6 +53,19 @@ export function resolveEffortLevel(stdinEffort?: string | null): EffortInfo | nu
     return formatEffort(cliEffort);
   }
 
+  return null;
+}
+
+function extractEffortString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    return value.length > 0 ? value : null;
+  }
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const level = (value as { level?: unknown }).level;
+    if (typeof level === 'string' && level.length > 0) {
+      return level;
+    }
+  }
   return null;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,8 +38,11 @@ export interface StdinData {
       resets_at?: number | null;
     } | null;
   } | null;
-  // Future: Claude Code may expose effort level directly in stdin JSON
-  effort?: string | null;
+  // Claude Code 2.1.115+ exposes effort as an object: { level: "max" }.
+  // Earlier versions (≤2.1.114) did not send this field at all. The bare-string
+  // shape is kept for backwards compatibility with the original PR #471 design
+  // that future-proofed a string form before Anthropic had committed a schema.
+  effort?: string | { level?: string | null; [key: string]: unknown } | null;
 }
 
 export interface ToolEntry {

--- a/tests/effort.test.js
+++ b/tests/effort.test.js
@@ -51,4 +51,59 @@ describe('resolveEffortLevel', () => {
       assert.strictEqual(result?.level, 'low');
     });
   });
+
+  describe('stdin effort as object (Claude Code 2.1.115+ schema)', () => {
+    it('extracts level from object { level: "max" }', () => {
+      const result = resolveEffortLevel({ level: 'max' });
+      assert.deepStrictEqual(result, { level: 'max', symbol: '●' });
+    });
+
+    it('extracts and normalizes uppercase level from object', () => {
+      const result = resolveEffortLevel({ level: 'HIGH' });
+      assert.deepStrictEqual(result, { level: 'high', symbol: '◑' });
+    });
+
+    it('handles all known levels when wrapped in object', () => {
+      assert.deepStrictEqual(resolveEffortLevel({ level: 'low' }), { level: 'low', symbol: '○' });
+      assert.deepStrictEqual(resolveEffortLevel({ level: 'medium' }), { level: 'medium', symbol: '◔' });
+      assert.deepStrictEqual(resolveEffortLevel({ level: 'xhigh' }), { level: 'xhigh', symbol: '◕' });
+    });
+
+    it('tolerates extra fields in effort object (forward-compat)', () => {
+      const result = resolveEffortLevel({ level: 'max', budget: 32000, extra: 'ignored' });
+      assert.deepStrictEqual(result, { level: 'max', symbol: '●' });
+    });
+
+    it('falls through when object has no level field', () => {
+      const result = resolveEffortLevel({});
+      assert.ok(result === null || typeof result.level === 'string');
+    });
+
+    it('falls through when object.level is null', () => {
+      const result = resolveEffortLevel({ level: null });
+      assert.ok(result === null || typeof result.level === 'string');
+    });
+
+    it('falls through when object.level is not a string', () => {
+      const result = resolveEffortLevel({ level: 42 });
+      assert.ok(result === null || typeof result.level === 'string');
+    });
+  });
+
+  describe('defensive handling of unexpected types (no crash)', () => {
+    it('does not crash on numeric effort value', () => {
+      const result = resolveEffortLevel(42);
+      assert.ok(result === null || typeof result.level === 'string');
+    });
+
+    it('does not crash on boolean effort value', () => {
+      const result = resolveEffortLevel(true);
+      assert.ok(result === null || typeof result.level === 'string');
+    });
+
+    it('does not crash on array effort value', () => {
+      const result = resolveEffortLevel(['max']);
+      assert.ok(result === null || typeof result.level === 'string');
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Since Claude Code 2.1.115+, the statusline crashes on every tick with:

```
[claude-hud] Error: level.toLowerCase is not a function
```

when a user has `display.showEffortLevel: true` in their config. The crash
only appears after upgrading Claude Code from 2.1.114 (or earlier) to
2.1.115+.

## Root cause

The original effort support (#471) was future-proofed for the case where
Claude Code would eventually expose the effort level via stdin JSON — but
because no schema existed yet, the type was guessed as a bare string:

```ts
effort?: string | null;
```

Claude Code 2.1.115+ actually added the field, but as an object:

```json
"effort": { "level": "max" },
"thinking": { "enabled": true },
"fast_mode": false
```

`resolveEffortLevel` then passes the whole object into `formatEffort`, which
invokes `level.toLowerCase()` on what is actually a `{ level: "max" }`
object — instant `TypeError`.

Evidence — live stdin dump from Claude Code 2.1.119 on macOS, Opus 4.7:

```json
{
  "session_id": "…",
  "version": "2.1.119",
  "model": { "id": "claude-opus-4-7", "display_name": "Opus 4.7" },
  "effort": { "level": "max" },
  "thinking": { "enabled": true },
  "fast_mode": false,
  …
}
```

## Fix

Accept both shapes (object with `level` string, or bare string) through a
tiny `extractEffortString` helper, and let any other truthy input fall
through to the existing `--effort` parent-process fallback rather than
throwing.

```ts
export type StdinEffortInput = string | StdinEffort | null | undefined;

export interface StdinEffort {
  level?: string | null;
  [key: string]: unknown;  // tolerate future additions like `budget`
}
```

The index signature keeps the type permissive — if Claude Code later adds
`effort.budget` or similar, no more breaking changes here.

## Tests

Added 10 tests in `tests/effort.test.js`:

- **Object schema (Claude Code 2.1.115+ shape)**
  - extracts `{ level: "max" }` → renders `●`
  - normalises uppercase level
  - handles all known levels inside objects
  - tolerates extra fields for forward-compat
  - falls through on missing / null / non-string `level`
- **Defensive handling (no crash)**
  - numeric / boolean / array inputs fall through rather than throwing

Result:

```
baseline: 486 pass, 0 fail
after   : 496 pass, 0 fail  (no regressions)
```

End-to-end verified by feeding the captured stdin payload to a locally-built
`dist/index.js`:

```
$ cat /tmp/hud-stdin-dump.json | node dist/index.js
[Opus 4.7 ●max] ██░░░░░░░░ 15% | zane | …
```

Exit code 0, effort bracket renders correctly.

## Notes

- `src/` only per CONTRIBUTING.md (CI rebuilds `dist/` on merge).
- Preserves backwards compatibility with the original PR #471 string shape
  in case any older Claude Code version still sends it or a user injects
  effort via another path.
- The `--effort` parent-process fallback path is unchanged and still acts
  as a safety net when stdin gives us nothing usable.