### PR TITLE
fix(speed-tracker): scope cache per session to prevent cross-session contamination

### DIFF
--- a/src/speed-tracker.ts
+++ b/src/speed-tracker.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { createHash } from 'node:crypto';
 import type { StdinData } from './types.js';
 import { getHudPluginDir } from './claude-config-dir.js';
 
@@ -10,6 +11,9 @@ const SPEED_WINDOW_MS = 2000;
 // spurious multi-thousand tok/s readings (see #481). Require at least
 // half a second of elapsed time before reporting a speed.
 const MIN_DELTA_MS = 500;
+
+const CACHE_DIRNAME = 'speed-cache';
+const LEGACY_CACHE_FILENAME = '.speed-cache.json';
 
 interface SpeedCache {
   outputTokens: number;
@@ -26,13 +30,19 @@ const defaultDeps: SpeedTrackerDeps = {
   now: () => Date.now(),
 };
 
-function getCachePath(homeDir: string): string {
-  return path.join(getHudPluginDir(homeDir), '.speed-cache.json');
+// Scope the cache by a sha256 of the resolved transcript path so that
+// concurrent Claude Code sessions never share or overwrite each other's
+// cached output-token counters. Sharing the cache across sessions
+// produced bogus speed readings on idle terminals whenever another
+// terminal was actively streaming (see #495).
+function getCachePath(homeDir: string, transcriptPath: string): string {
+  const hash = createHash('sha256').update(path.resolve(transcriptPath)).digest('hex');
+  return path.join(getHudPluginDir(homeDir), CACHE_DIRNAME, `${hash}.json`);
 }
 
-function readCache(homeDir: string): SpeedCache | null {
+function readCache(homeDir: string, transcriptPath: string): SpeedCache | null {
   try {
-    const cachePath = getCachePath(homeDir);
+    const cachePath = getCachePath(homeDir, transcriptPath);
     if (!fs.existsSync(cachePath)) return null;
     const content = fs.readFileSync(cachePath, 'utf8');
     const parsed = JSON.parse(content) as SpeedCache;
@@ -45,9 +55,9 @@ function readCache(homeDir: string): SpeedCache | null {
   }
 }
 
-function writeCache(homeDir: string, cache: SpeedCache): void {
+function writeCache(homeDir: string, transcriptPath: string, cache: SpeedCache): void {
   try {
-    const cachePath = getCachePath(homeDir);
+    const cachePath = getCachePath(homeDir, transcriptPath);
     const cacheDir = path.dirname(cachePath);
     if (!fs.existsSync(cacheDir)) {
       fs.mkdirSync(cacheDir, { recursive: true });
@@ -58,24 +68,47 @@ function writeCache(homeDir: string, cache: SpeedCache): void {
   }
 }
 
+// Remove the pre-0.x global cache file once, if present. It has no owner
+// session so leaving it around only wastes disk.
+function removeLegacyCache(homeDir: string): void {
+  try {
+    const legacyPath = path.join(getHudPluginDir(homeDir), LEGACY_CACHE_FILENAME);
+    if (fs.existsSync(legacyPath)) {
+      fs.unlinkSync(legacyPath);
+    }
+  } catch {
+    // Ignore cleanup failures
+  }
+}
+
 export function getOutputSpeed(stdin: StdinData, overrides: Partial<SpeedTrackerDeps> = {}): number | null {
   const outputTokens = stdin.context_window?.current_usage?.output_tokens;
   if (typeof outputTokens !== 'number' || !Number.isFinite(outputTokens)) {
     return null;
   }
 
+  const transcriptPath = stdin.transcript_path?.trim();
+  if (!transcriptPath) {
+    // Without a stable session key we cannot safely isolate cache entries
+    // across concurrent Claude Code sessions, so skip speed tracking.
+    return null;
+  }
+
   const deps = { ...defaultDeps, ...overrides };
   const now = deps.now();
   const homeDir = deps.homeDir();
-  const previous = readCache(homeDir);
+
+  removeLegacyCache(homeDir);
+
+  const previous = readCache(homeDir, transcriptPath);
 
   if (!previous) {
-    writeCache(homeDir, { outputTokens, timestamp: now });
+    writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
     return null;
   }
 
   if (outputTokens < previous.outputTokens) {
-    writeCache(homeDir, { outputTokens, timestamp: now });
+    writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
     return null;
   }
 
@@ -84,12 +117,12 @@ export function getOutputSpeed(stdin: StdinData, overrides: Partial<SpeedTracker
   const deltaMs = now - previous.timestamp;
 
   if (deltaMs > SPEED_WINDOW_MS) {
-    writeCache(homeDir, { outputTokens, timestamp: now });
+    writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
     return null;
   }
 
   if (deltaTokens <= 0) {
-    writeCache(homeDir, { outputTokens, timestamp: now });
+    writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
     return null;
   }
 
@@ -99,6 +132,6 @@ export function getOutputSpeed(stdin: StdinData, overrides: Partial<SpeedTracker
 
   speed = deltaTokens / (deltaMs / 1000);
 
-  writeCache(homeDir, { outputTokens, timestamp: now });
+  writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
   return speed;
 }

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 import { render } from '../dist/render/index.js';
 import { renderSessionLine } from '../dist/render/session-line.js';
 import { renderProjectLine, renderGitFilesLine } from '../dist/render/lines/project.js';
@@ -105,7 +106,10 @@ async function withDeterministicSpeedCache(fn) {
   const tempConfigDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-render-'));
   const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
   const originalNow = Date.now;
-  const cachePath = path.join(tempConfigDir, 'plugins', 'claude-hud', '.speed-cache.json');
+  const transcriptPath = path.join(tempConfigDir, 'session.jsonl');
+  await writeFile(transcriptPath, '', 'utf8');
+  const transcriptHash = createHash('sha256').update(path.resolve(transcriptPath)).digest('hex');
+  const cachePath = path.join(tempConfigDir, 'plugins', 'claude-hud', 'speed-cache', `${transcriptHash}.json`);
 
   process.env.CLAUDE_CONFIG_DIR = tempConfigDir;
   await mkdir(path.dirname(cachePath), { recursive: true });
@@ -113,7 +117,7 @@ async function withDeterministicSpeedCache(fn) {
   Date.now = () => 2000;
 
   try {
-    await fn();
+    await fn({ transcriptPath });
   } finally {
     Date.now = originalNow;
     if (originalConfigDir === undefined) {
@@ -752,8 +756,9 @@ test('renderProjectLine omits duration when showDuration is false', () => {
 });
 
 test('renderProjectLine includes speed when showSpeed is true and speed is available', async () => {
-  await withDeterministicSpeedCache(async () => {
+  await withDeterministicSpeedCache(async ({ transcriptPath }) => {
     const ctx = baseContext();
+    ctx.stdin.transcript_path = transcriptPath;
     ctx.stdin.cwd = '/tmp/my-project';
     ctx.stdin.context_window.current_usage.output_tokens = 2000;
     ctx.config.display.showSpeed = true;
@@ -773,8 +778,9 @@ test('renderProjectLine omits speed when showSpeed is false', () => {
 });
 
 test('render expanded layout includes speed and duration on the project line', async () => {
-  await withDeterministicSpeedCache(async () => {
+  await withDeterministicSpeedCache(async ({ transcriptPath }) => {
     const ctx = baseContext();
+    ctx.stdin.transcript_path = transcriptPath;
     ctx.config.lineLayout = 'expanded';
     ctx.stdin.cwd = '/tmp/my-project';
     ctx.stdin.context_window.current_usage.output_tokens = 2000;

--- a/tests/speed-tracker.test.js
+++ b/tests/speed-tracker.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { getOutputSpeed } from '../dist/speed-tracker.js';
@@ -18,26 +18,52 @@ async function createTempHome() {
   return await mkdtemp(path.join(tmpdir(), 'claude-hud-speed-'));
 }
 
+async function createTranscript(tempHome, name = 'session.jsonl') {
+  const transcriptPath = path.join(tempHome, name);
+  await writeFile(transcriptPath, '', 'utf8');
+  return transcriptPath;
+}
+
+function stdinWith(transcriptPath, outputTokens) {
+  return {
+    transcript_path: transcriptPath,
+    context_window: { current_usage: { output_tokens: outputTokens } },
+  };
+}
+
 test('getOutputSpeed returns null when output tokens are missing', () => {
-  const speed = getOutputSpeed({ context_window: { current_usage: { input_tokens: 10 } } });
+  const speed = getOutputSpeed({
+    transcript_path: '/tmp/claude-hud-speed-missing.jsonl',
+    context_window: { current_usage: { input_tokens: 10 } },
+  });
   assert.equal(speed, null);
 });
 
-test('getOutputSpeed computes tokens per second within window', async () => {
+test('getOutputSpeed returns null when transcript_path is missing', async () => {
   const tempHome = await createTempHome();
 
   try {
     const base = { homeDir: () => tempHome };
-    const first = getOutputSpeed(
+    const speed = getOutputSpeed(
       { context_window: { current_usage: { output_tokens: 10 } } },
       { ...base, now: () => 1000 }
     );
+    assert.equal(speed, null);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('getOutputSpeed computes tokens per second within window', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = await createTranscript(tempHome);
+
+  try {
+    const base = { homeDir: () => tempHome };
+    const first = getOutputSpeed(stdinWith(transcriptPath, 10), { ...base, now: () => 1000 });
     assert.equal(first, null);
 
-    const second = getOutputSpeed(
-      { context_window: { current_usage: { output_tokens: 20 } } },
-      { ...base, now: () => 1500 }
-    );
+    const second = getOutputSpeed(stdinWith(transcriptPath, 20), { ...base, now: () => 1500 });
     assert.ok(second !== null);
     assert.ok(Math.abs(second - 20) < 0.01);
   } finally {
@@ -47,20 +73,15 @@ test('getOutputSpeed computes tokens per second within window', async () => {
 
 test('getOutputSpeed ignores sub-window bursts to avoid inflated rates', async () => {
   const tempHome = await createTempHome();
+  const transcriptPath = await createTranscript(tempHome);
 
   try {
     const base = { homeDir: () => tempHome };
-    getOutputSpeed(
-      { context_window: { current_usage: { output_tokens: 10 } } },
-      { ...base, now: () => 1000 }
-    );
+    getOutputSpeed(stdinWith(transcriptPath, 10), { ...base, now: () => 1000 });
 
     // Status line re-renders ~50ms later with 60 more tokens. A naive rate
     // calculation would report 1200 tok/s; we expect null instead (#481).
-    const speed = getOutputSpeed(
-      { context_window: { current_usage: { output_tokens: 70 } } },
-      { ...base, now: () => 1050 }
-    );
+    const speed = getOutputSpeed(stdinWith(transcriptPath, 70), { ...base, now: () => 1050 });
     assert.equal(speed, null);
   } finally {
     await rm(tempHome, { recursive: true, force: true });
@@ -69,30 +90,19 @@ test('getOutputSpeed ignores sub-window bursts to avoid inflated rates', async (
 
 test('getOutputSpeed accumulates repeated short windows until the sample matures', async () => {
   const tempHome = await createTempHome();
+  const transcriptPath = await createTranscript(tempHome);
 
   try {
     const base = { homeDir: () => tempHome };
-    getOutputSpeed(
-      { context_window: { current_usage: { output_tokens: 10 } } },
-      { ...base, now: () => 1000 }
-    );
+    getOutputSpeed(stdinWith(transcriptPath, 10), { ...base, now: () => 1000 });
 
-    const firstBurst = getOutputSpeed(
-      { context_window: { current_usage: { output_tokens: 40 } } },
-      { ...base, now: () => 1200 }
-    );
+    const firstBurst = getOutputSpeed(stdinWith(transcriptPath, 40), { ...base, now: () => 1200 });
     assert.equal(firstBurst, null);
 
-    const secondBurst = getOutputSpeed(
-      { context_window: { current_usage: { output_tokens: 70 } } },
-      { ...base, now: () => 1400 }
-    );
+    const secondBurst = getOutputSpeed(stdinWith(transcriptPath, 70), { ...base, now: () => 1400 });
     assert.equal(secondBurst, null);
 
-    const matured = getOutputSpeed(
-      { context_window: { current_usage: { output_tokens: 100 } } },
-      { ...base, now: () => 1600 }
-    );
+    const matured = getOutputSpeed(stdinWith(transcriptPath, 100), { ...base, now: () => 1600 });
     assert.ok(matured !== null);
     assert.ok(Math.abs(matured - 150) < 0.01);
   } finally {
@@ -102,19 +112,43 @@ test('getOutputSpeed accumulates repeated short windows until the sample matures
 
 test('getOutputSpeed ignores stale windows', async () => {
   const tempHome = await createTempHome();
+  const transcriptPath = await createTranscript(tempHome);
 
   try {
     const base = { homeDir: () => tempHome };
-    getOutputSpeed(
-      { context_window: { current_usage: { output_tokens: 10 } } },
-      { ...base, now: () => 1000 }
-    );
+    getOutputSpeed(stdinWith(transcriptPath, 10), { ...base, now: () => 1000 });
 
-    const speed = getOutputSpeed(
-      { context_window: { current_usage: { output_tokens: 30 } } },
-      { ...base, now: () => 8000 }
-    );
+    const speed = getOutputSpeed(stdinWith(transcriptPath, 30), { ...base, now: () => 8000 });
     assert.equal(speed, null);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('getOutputSpeed isolates cache across concurrent sessions', async () => {
+  const tempHome = await createTempHome();
+  const sessionA = await createTranscript(tempHome, 'session-a.jsonl');
+  const sessionB = await createTranscript(tempHome, 'session-b.jsonl');
+
+  try {
+    const base = { homeDir: () => tempHome };
+
+    // Session A streams: seeds its cache, then reports a speed on the next tick.
+    getOutputSpeed(stdinWith(sessionA, 100), { ...base, now: () => 1000 });
+    const aSpeed = getOutputSpeed(stdinWith(sessionA, 200), { ...base, now: () => 1500 });
+    assert.ok(aSpeed !== null);
+
+    // Session B is idle with a much smaller counter. Before the fix, B would
+    // read A's cache entry as its `previous`, compute a bogus speed, or reset
+    // A's cache to B's value and poison subsequent A readings. With per-session
+    // caches the first B tick must seed a fresh cache and return null.
+    const bFirst = getOutputSpeed(stdinWith(sessionB, 5), { ...base, now: () => 1600 });
+    assert.equal(bFirst, null);
+
+    // Session A's cache must survive B's tick and keep producing stable speeds.
+    const aContinued = getOutputSpeed(stdinWith(sessionA, 300), { ...base, now: () => 2000 });
+    assert.ok(aContinued !== null);
+    assert.ok(Math.abs(aContinued - 200) < 0.01);
   } finally {
     await rm(tempHome, { recursive: true, force: true });
   }
@@ -129,22 +163,17 @@ test('getOutputSpeed writes cache under CLAUDE_CONFIG_DIR by default', async () 
   process.env.CLAUDE_CONFIG_DIR = customConfigDir;
 
   try {
-    const first = getOutputSpeed(
-      { context_window: { current_usage: { output_tokens: 10 } } },
-      { now: () => 1000 }
-    );
+    const transcriptPath = await createTranscript(tempHome);
+    const first = getOutputSpeed(stdinWith(transcriptPath, 10), { now: () => 1000 });
     assert.equal(first, null);
 
-    const second = getOutputSpeed(
-      { context_window: { current_usage: { output_tokens: 20 } } },
-      { now: () => 1500 }
-    );
+    const second = getOutputSpeed(stdinWith(transcriptPath, 20), { now: () => 1500 });
     assert.ok(second !== null);
 
-    const customCachePath = path.join(customConfigDir, 'plugins', 'claude-hud', '.speed-cache.json');
-    const defaultCachePath = path.join(tempHome, '.claude', 'plugins', 'claude-hud', '.speed-cache.json');
-    assert.equal(existsSync(customCachePath), true);
-    assert.equal(existsSync(defaultCachePath), false);
+    const customCacheDir = path.join(customConfigDir, 'plugins', 'claude-hud', 'speed-cache');
+    const defaultCacheDir = path.join(tempHome, '.claude', 'plugins', 'claude-hud', 'speed-cache');
+    assert.equal(existsSync(customCacheDir), true);
+    assert.equal(existsSync(defaultCacheDir), false);
   } finally {
     restoreEnvVar('HOME', originalHome);
     restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);


### PR DESCRIPTION
Fixes #495

## Problem

`src/speed-tracker.ts` stored its cache in a single global file (`<plugin-dir>/.speed-cache.json`). Every concurrent Claude Code session shared that file. Because `output_tokens` in `stdin.context_window.current_usage` is a session-local counter, comparing the current frame against a previous value written by a different session produced:

- bogus `tok/s` readings on idle terminals whenever another terminal was actively streaming, and
- a poisoned cache for the streaming terminal as soon as the idle session reset the file to its own smaller value.

Every other cache in the project already isolates by a hash of the transcript path (see `context-cache.ts` and the transcript cache) — the speed cache was the only outlier.

## Fix

- Key the speed cache by `sha256(path.resolve(transcript_path))`, matching the `context-cache.ts` approach. Cache lives at `<plugin-dir>/speed-cache/<hash>.json`.
- Thread `transcript_path` through `getOutputSpeed`. When it is missing we cannot safely isolate cache entries, so we skip speed tracking rather than fall back to a cross-session file.
- Opportunistically remove the legacy global `.speed-cache.json` once on first call, so upgraded installs don't leave a dead file behind.

## Tests

- Added `getOutputSpeed returns null when transcript_path is missing`.
- Added `getOutputSpeed isolates cache across concurrent sessions`, which reproduces the original bug by interleaving two sessions and asserting the idle session's first tick seeds a fresh cache while the active session continues to report stable speeds.
- Updated existing tests and the `withDeterministicSpeedCache` render helper to seed the new per-session cache path and thread the transcript path through `stdin`.
- \`npm ci && npm run build && npm test\` → 506 passing, 0 failing, 1 skipped (pre-existing).

## Notes

- Only \`src/\` and \`tests/\` are modified per \`CONTRIBUTING.md\`; \`dist/\` is left for CI.
- The cache layout change means the legacy file is abandoned — the cleanup step removes it so it doesn't linger on disk.