### PR TITLE
feat: show Skill tool targets

### DIFF
--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -467,6 +467,10 @@ function extractTarget(toolName: string, input?: Record<string, unknown>): strin
       return input.pattern as string;
     case 'Grep':
       return input.pattern as string;
+    case 'Skill':
+      return typeof input.skill === 'string' && input.skill.trim().length > 0
+        ? input.skill
+        : undefined;
     case 'Bash':
       const cmd = input.command as string;
       return cmd?.slice(0, 30) + (cmd?.length > 30 ? '...' : '');

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -881,6 +881,57 @@ test('parseTranscript extracts tool targets for common tools', async () => {
   }
 });
 
+test('parseTranscript extracts Skill tool target from non-empty input.skill', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-'));
+  const filePath = path.join(dir, 'skill-target.jsonl');
+  const lines = [
+    JSON.stringify({
+      message: {
+        content: [
+          { type: 'tool_use', id: 'tool-1', name: 'Skill', input: { skill: 'prd-development' } },
+        ],
+      },
+    }),
+  ];
+
+  await writeFile(filePath, lines.join('\n'), 'utf8');
+
+  try {
+    const result = await parseTranscript(filePath);
+    assert.equal(result.tools.length, 1);
+    assert.equal(result.tools[0].name, 'Skill');
+    assert.equal(result.tools[0].target, 'prd-development');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('parseTranscript leaves Skill target empty when input.skill is missing or invalid', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-'));
+  const filePath = path.join(dir, 'skill-target-invalid.jsonl');
+  const lines = [
+    JSON.stringify({
+      message: {
+        content: [
+          { type: 'tool_use', id: 'tool-1', name: 'Skill', input: {} },
+          { type: 'tool_use', id: 'tool-2', name: 'Skill', input: { skill: 123 } },
+          { type: 'tool_use', id: 'tool-3', name: 'Skill', input: { skill: '   ' } },
+        ],
+      },
+    }),
+  ];
+
+  await writeFile(filePath, lines.join('\n'), 'utf8');
+
+  try {
+    const result = await parseTranscript(filePath);
+    assert.equal(result.tools.length, 3);
+    assert.deepEqual(result.tools.map((tool) => tool.target), [undefined, undefined, undefined]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('parseTranscript truncates long bash commands in targets', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-'));
   const filePath = path.join(dir, 'bash.jsonl');


### PR DESCRIPTION
## Summary

- Render `Skill` tool targets from `tool_use.input.skill` when it is a non-empty string
- Preserve completed-tool grouping by keeping the tool name as `Skill`
- Add focused transcript tests for valid, missing, non-string, and whitespace-only skill metadata

Closes #493.

## Security review

- Source/test-only change; no dependency, script, network, filesystem write, config-loading, serialization, markdown, terminal escape, or generated artifact changes
- Reads only a string field already present in parsed transcript tool input
- Whitespace-only skill names are ignored to avoid noisy blank targets

## Tests

- `npm test` passes locally: 508 passing, 1 skipped
