### PR TITLE
feat: add forceMaxWidth config override

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `lineLayout` | string | `expanded` | Layout: `expanded` (multi-line) or `compact` (single line) |
 | `pathLevels` | 1-3 | 1 | Directory levels to show in project path |
 | `maxWidth` | number \| `null` | `null` | Optional fallback width used only when terminal width detection fails completely |
+| `forceMaxWidth` | boolean | false | Always use `maxWidth` when it is set, even if terminal width detection returns a smaller value |
 | `elementOrder` | string[] | `["project","context","usage","promptCache","memory","environment","tools","agents","todos"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. |
 | `display.mergeGroups` | string[][] | `[["context","usage"]]` | Expanded-mode groups that should share a line when adjacent. Set `[]` to disable merged lines. |
 | `gitStatus.enabled` | boolean | true | Show git branch in HUD |

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,7 @@ export interface HudConfig {
   showSeparators: boolean;
   pathLevels: 1 | 2 | 3;
   maxWidth: number | null;
+  forceMaxWidth: boolean;
   elementOrder: HudElement[];
   gitStatus: {
     enabled: boolean;
@@ -129,6 +130,7 @@ export const DEFAULT_CONFIG: HudConfig = {
   showSeparators: false,
   pathLevels: 1,
   maxWidth: null,
+  forceMaxWidth: false,
   elementOrder: [...DEFAULT_ELEMENT_ORDER],
   gitStatus: {
     enabled: true,
@@ -413,6 +415,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     : null;
 
   const elementOrder = validateElementOrder(migrated.elementOrder);
+  const forceMaxWidth = typeof (migrated as Record<string, unknown>).forceMaxWidth === 'boolean'
+    ? (migrated as Record<string, unknown>).forceMaxWidth as boolean
+    : DEFAULT_CONFIG.forceMaxWidth;
 
   const gitStatus = {
     enabled: typeof migrated.gitStatus?.enabled === 'boolean'
@@ -575,7 +580,7 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
       : DEFAULT_CONFIG.colors.custom,
   };
 
-  return { language, lineLayout, showSeparators, pathLevels, maxWidth, elementOrder, gitStatus, display, colors };
+  return { language, lineLayout, showSeparators, pathLevels, maxWidth, forceMaxWidth, elementOrder, gitStatus, display, colors };
 }
 
 export async function loadConfig(): Promise<HudConfig> {

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -478,7 +478,10 @@ export function render(ctx: RenderContext): void {
   const lineLayout = ctx.config?.lineLayout ?? 'expanded';
   const showSeparators = ctx.config?.showSeparators ?? false;
   const detectedWidth = getTerminalWidth({ preferEnv: true, fallback: UNKNOWN_TERMINAL_WIDTH });
-  const terminalWidth = detectedWidth ?? ctx.config?.maxWidth ?? UNKNOWN_TERMINAL_WIDTH;
+  const configuredMaxWidth = ctx.config?.maxWidth ?? UNKNOWN_TERMINAL_WIDTH;
+  const terminalWidth = ctx.config?.forceMaxWidth && configuredMaxWidth !== UNKNOWN_TERMINAL_WIDTH
+    ? configuredMaxWidth
+    : (detectedWidth ?? configuredMaxWidth ?? UNKNOWN_TERMINAL_WIDTH);
 
   let lines: string[];
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -91,6 +91,12 @@ test('getConfigPath returns correct path', () => {
   }
 });
 
+test('mergeConfig defaults showSessionName to false', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.showSessionName, false);
+  assert.equal(DEFAULT_CONFIG.display.showSessionName, false);
+});
+
 test('mergeConfig defaults forceMaxWidth to false', () => {
   const config = mergeConfig({});
   assert.equal(config.forceMaxWidth, false);

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -91,11 +91,22 @@ test('getConfigPath returns correct path', () => {
   }
 });
 
-test('mergeConfig defaults showSessionName to false', () => {
+test('mergeConfig defaults forceMaxWidth to false', () => {
   const config = mergeConfig({});
-  assert.equal(config.display.showSessionName, false);
-  assert.equal(DEFAULT_CONFIG.display.showSessionName, false);
+  assert.equal(config.forceMaxWidth, false);
+  assert.equal(DEFAULT_CONFIG.forceMaxWidth, false);
 });
+
+test('mergeConfig preserves explicit forceMaxWidth=true', () => {
+  const config = mergeConfig({ forceMaxWidth: true });
+  assert.equal(config.forceMaxWidth, true);
+});
+
+test('mergeConfig falls back to false for invalid forceMaxWidth values', () => {
+  assert.equal(mergeConfig({ forceMaxWidth: 'yes' }).forceMaxWidth, false);
+  assert.equal(mergeConfig({ forceMaxWidth: 1 }).forceMaxWidth, false);
+});
+
 
 test('mergeConfig preserves explicit showSessionName=true', () => {
   const config = mergeConfig({ display: { showSessionName: true } });

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { render } from '../dist/render/index.js';
+import { mergeConfig } from '../dist/config.js';
 import { setLanguage } from '../dist/i18n/index.js';
 
 function baseContext() {
@@ -212,6 +213,31 @@ test('render falls back to COLUMNS env when stdout.columns is unavailable', () =
 });
 
 
+test('render falls back to stderr.columns when stdout.columns and COLUMNS are unavailable', () => {
+  const ctx = baseContext();
+  const originalEnvColumns = process.env.COLUMNS;
+
+  let lines = [];
+  withColumns(process.stdout, undefined, () => {
+    withColumns(process.stderr, 12, () => {
+      delete process.env.COLUMNS;
+      try {
+        lines = captureRender(ctx);
+      } finally {
+        if (originalEnvColumns === undefined) {
+          delete process.env.COLUMNS;
+        } else {
+          process.env.COLUMNS = originalEnvColumns;
+        }
+      }
+    });
+  });
+
+  assert.ok(lines.length > 0, 'should still render output lines');
+  assert.ok(lines.every(line => displayWidth(line) <= 12), 'stderr width should be honored');
+  assert.ok(lines.some(line => displayWidth(line) > 10), 'stderr width should be used when no env override exists');
+});
+
 test('render does not use maxWidth over a detected 80-column width unless forceMaxWidth is enabled', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = '/tmp/project';
@@ -224,6 +250,39 @@ test('render does not use maxWidth over a detected 80-column width unless forceM
   });
 
   assert.ok(lines.length > 1, 'should still wrap when only detected width is 80 and forceMaxWidth is disabled');
+});
+
+test('render ignores forceMaxWidth when maxWidth is null', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/project';
+  ctx.config.forceMaxWidth = true;
+  ctx.extraLabel = 'x'.repeat(120);
+
+  let lines = [];
+  withTerminal(80, () => {
+    lines = captureRender(ctx);
+  });
+
+  assert.ok(lines.length > 1, 'should keep using detected width when forceMaxWidth is enabled without maxWidth');
+});
+
+test('render ignores forceMaxWidth when maxWidth is invalid in user config', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/project';
+  ctx.config = {
+    ...ctx.config,
+    ...mergeConfig({ maxWidth: 'wide', forceMaxWidth: true }),
+    display: ctx.config.display,
+    gitStatus: ctx.config.gitStatus,
+  };
+  ctx.extraLabel = 'x'.repeat(120);
+
+  let lines = [];
+  withTerminal(80, () => {
+    lines = captureRender(ctx);
+  });
+
+  assert.ok(lines.length > 1, 'should keep using detected width when invalid maxWidth is normalized away');
 });
 
 test('render uses maxWidth over a detected 80-column width when forceMaxWidth is enabled', () => {

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -211,29 +211,36 @@ test('render falls back to COLUMNS env when stdout.columns is unavailable', () =
   assert.ok(lines.every(line => displayWidth(line) <= 10), 'all lines should fit COLUMNS width');
 });
 
-test('render falls back to stderr.columns when stdout.columns and COLUMNS are unavailable', () => {
+
+test('render does not use maxWidth over a detected 80-column width unless forceMaxWidth is enabled', () => {
   const ctx = baseContext();
-  const originalEnvColumns = process.env.COLUMNS;
+  ctx.stdin.cwd = '/tmp/project';
+  ctx.config.maxWidth = 300;
+  ctx.extraLabel = 'x'.repeat(120);
 
   let lines = [];
-  withColumns(process.stdout, undefined, () => {
-    withColumns(process.stderr, 12, () => {
-      delete process.env.COLUMNS;
-      try {
-        lines = captureRender(ctx);
-      } finally {
-        if (originalEnvColumns === undefined) {
-          delete process.env.COLUMNS;
-        } else {
-          process.env.COLUMNS = originalEnvColumns;
-        }
-      }
-    });
+  withTerminal(80, () => {
+    lines = captureRender(ctx);
   });
 
-  assert.ok(lines.length > 0, 'should still render output lines');
-  assert.ok(lines.every(line => displayWidth(line) <= 12), 'stderr width should be honored');
-  assert.ok(lines.some(line => displayWidth(line) > 10), 'stderr width should be used when no env override exists');
+  assert.ok(lines.length > 1, 'should still wrap when only detected width is 80 and forceMaxWidth is disabled');
+});
+
+test('render uses maxWidth over a detected 80-column width when forceMaxWidth is enabled', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/project';
+  ctx.config.maxWidth = 300;
+  ctx.config.forceMaxWidth = true;
+  ctx.extraLabel = 'x'.repeat(120);
+
+  let lines = [];
+  withTerminal(80, () => {
+    lines = captureRender(ctx);
+  });
+
+  assert.equal(lines.length, 1, 'should keep the line intact when forceMaxWidth overrides a detected 80-column width');
+  assert.ok(lines[0].includes('x'.repeat(120)), 'should not truncate the long label when forceMaxWidth is enabled');
+  assert.ok(!lines[0].includes('...'), 'should avoid ellipsis truncation');
 });
 
 test('render ignores OSC 8 hyperlink sequences when measuring line width', () => {
@@ -257,6 +264,7 @@ test('render ignores OSC 8 hyperlink sequences when measuring line width', () =>
   assert.ok(lines[0].includes('1m'), 'later elements should not be wrapped off the line');
   assert.ok(displayWidth(lines[0]) <= 47, 'visible width should respect terminal width');
 });
+
 
 test('render ignores BEL-terminated OSC 8 hyperlink sequences when measuring line width', () => {
   const ctx = baseContext();


### PR DESCRIPTION
## Summary

Add an explicit `forceMaxWidth` config option so users can tell claude-hud to use `maxWidth` even when a terminal width is detected.

This fixes a real issue I hit on Linux when running claude-hud inside the Claude Code statusline environment: the HUD process saw a much smaller width than the actual visible terminal width, so long lines were unnecessarily truncated with `...`.

With this change:

- default behavior is unchanged
- `maxWidth` still works as a fallback by default
- users can opt in to `forceMaxWidth: true` when width detection is inaccurate

## Problem

On my Linux setup, Claude Code itself was displayed in a wide terminal, but the claude-hud subprocess only detected a narrow width. As a result, fields like:

- long branch names
- session token lines

were truncated even though there was enough visible horizontal space.

This was a width detection mismatch between the HUD subprocess and the actual terminal UI.

## Solution

Introduce:

```json
{
  "maxWidth": 300,
  "forceMaxWidth": true
}
```

When `forceMaxWidth` is enabled, claude-hud uses the configured `maxWidth` instead of the detected terminal width.

## Why this approach

- no magic-number heuristic
- no default behavior change
- fully opt-in
- easy to explain and document

## Test plan

- [x] Verify default behavior is unchanged when `forceMaxWidth` is not set
- [x] Verify detected width is still used by default
- [x] Verify `maxWidth` overrides detected width when `forceMaxWidth: true`
- [x] Verify config parsing accepts `forceMaxWidth: true`
- [x] Verify invalid `forceMaxWidth` values fall back to `false`
- [x] `npm test`

## Example

```json
{
  "lineLayout": "expanded",
  "maxWidth": 300,
  "forceMaxWidth": true
}
```

This resolved the truncation issue for me on Linux in Claude Code's statusline environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)