### PR TITLE
fix(setup): use POSIX [[:space:]] to avoid GNU grep \t issue on Linux/macOS

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -112,7 +112,7 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
 1. Get plugin path (sorted by dotted numeric version, not modification time):
    ```bash
-   ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '{ print $(NF-1) "\t" $(0) }' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\t' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-
+   ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '{ print $(NF-1) "\t" $(0) }' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+[[:space:]]' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-
    ```
    If empty, the plugin is not installed. Go back to Step 0 to check for ghost installation or EXDEV issues. If Step 0 was clean, ask the user to install via `/plugin install claude-hud` first.
 
@@ -156,14 +156,26 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
    terminal. The `- 4` accounts for Claude Code's input area padding
    (2 columns on each side).
 
+   The grep pattern uses `[[:space:]]` rather than `\t` to match the tab
+   separator emitted by awk. GNU grep (BRE/ERE) does **not** interpret
+   `\t` as a tab character — it emits `warning: stray \ before t` and
+   treats the pattern as literal `t`, so the regex never matches the awk
+   output and `plugin_dir` resolves to an empty string. The runtime then
+   exits with `Module not found "src/index.ts"` and no HUD appears.
+   Setup verification can hide this because some shells alias `grep` to
+   alternatives (e.g. `ugrep`) that *do* expand `\t`, while the actual
+   `statusLine` subprocess invokes `/usr/bin/grep`. `[[:space:]]` is a
+   POSIX character class supported by both BSD grep (macOS default) and
+   GNU grep (Linux default).
+
    **When runtime is bun** - add `--env-file /dev/null` to prevent Bun from auto-loading project `.env` files:
    ```
-   bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | grep -E '"'"'^[0-9]+\.[0-9]+\.[0-9]+\t'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
+   bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | grep -E '"'"'^[0-9]+\.[0-9]+\.[0-9]+[[:space:]]'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
    ```
 
    **When runtime is node**:
    ```
-   bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | grep -E '"'"'^[0-9]+\.[0-9]+\.[0-9]+\t'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
+   bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | grep -E '"'"'^[0-9]+\.[0-9]+\.[0-9]+[[:space:]]'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
    ```
 
 **Windows + Git Bash** (Platform: `win32`, Shell: `bash`):


### PR DESCRIPTION
## Summary

Fixes the Linux/macOS `statusLine` command in `commands/setup.md` so it works with stock GNU grep on Linux and BSD grep on macOS. Minimum-change fix: keeps the awk + grep + numeric sort pipeline, just swaps the broken `\t` in the grep regex for the POSIX class `[[:space:]]`.

Closes #503.

## Problem

The macOS/Linux generated command piped tab-separated awk output through:

```
grep -E '^[0-9]+\.[0-9]+\.[0-9]+\t'
```

GNU grep does **not** interpret `\t` as a tab character in BRE/ERE. It emits `grep: warning: stray \ before t` and treats the pattern as literal `t`. The regex never matches the awk output, `plugin_dir` resolves to an empty string, and the runtime exits with `Module not found "src/index.ts"` — no HUD appears.

Reproduction with stock GNU grep 3.12:

```
$ printf '0.1.0\t/some/path\n' | /usr/bin/grep -E '^[0-9]+\.[0-9]+\.[0-9]+\t'
/usr/bin/grep: warning: stray \ before t
(no match)
```

## Why setup verification hides this

Many Linux/macOS users have `grep` shimmed in their interactive shell. In my case Claude Code wraps `grep` to invoke `ugrep`, which **does** expand `\t`. So when the setup skill tests the pipeline interactively, it matches and setup looks successful. But the statusLine command runs via `bash -c '...'` as a Claude Code subprocess, which resolves `grep` from `PATH` to `/usr/bin/grep` — and there it fails. The user restarts Claude Code, sees no HUD, and the issue is hard to attribute.

## Fix

Replace `\t` in the grep pattern with `[[:space:]]`:

```diff
- grep -E '^[0-9]+\.[0-9]+\.[0-9]+\t'
+ grep -E '^[0-9]+\.[0-9]+\.[0-9]+[[:space:]]'
```

`[[:space:]]` is a POSIX character class supported by both BSD grep (macOS default) and GNU grep (Linux default), so the same expression works everywhere the rest of the pipeline already runs.

I also added a short paragraph in `setup.md` documenting the failure mode so future maintainers do not regress it back to `\t`.

## Why this approach

I considered switching to `sort -V` (the same approach the Windows + Git Bash branch already uses, which avoids the awk/grep stage entirely). I initially pushed that fix but reverted it: **macOS ships BSD `sort`, which does not support `-V`**, so it would actively break setup on default macOS installs. Git for Windows bundles GNU sort, which is why `sort -V` is fine on the Windows + Git Bash branch.

The `[[:space:]]` change is the smallest portable diff and does not touch the Windows + Git Bash branch.

## Verification

Tested locally on Manjaro Linux (kernel 6.12, `grep (GNU grep) 3.12-modified`, bun 1.x). Before the fix the HUD did not render after restart; after applying the new command to `~/.claude/settings.json` and restarting Claude Code, the HUD appears as expected.

Manual smoke test:

```
$ echo '{"session_id":"test","model":{"display_name":"Opus"},"workspace":{"current_dir":"."}}' | bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | grep -E '"'"'^[0-9]+\.[0-9]+\.[0-9]+[[:space:]]'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "/home/sum/.bun/bin/bun" --env-file /dev/null "${plugin_dir}src/index.ts"'
[Opus]
Context ░░░░░░░░░░ 0%
1 CLAUDE.md | 4 MCPs | 1 hooks
```

## Test plan

- [x] Verified failing pipeline with stock GNU grep
- [x] Verified `[[:space:]]` pipeline matches awk's tab-separated output and resolves plugin_dir
- [x] Verified bun runtime renders HUD output with the new command on Linux
- [ ] Maintainer to confirm on macOS (BSD grep also supports `[[:space:]]` per POSIX, so this should just work)