### PR TITLE
feat(workspace): show /add-dir directories in statusline

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `gitStatus.showFileStats` | boolean | false | Show file change counts `!M +A ✘D ?U` |
 | `gitStatus.branchOverflow` | `truncate` \| `wrap` | `truncate` | Keep current truncation behavior or let the git block wrap onto its own line boundary when possible |
 | `display.showModel` | boolean | true | Show model name `[Opus]` |
-| `display.showAddedDirs` | boolean | true | Show extra workspace directories from `/add-dir` (e.g. `+sparkle +lib-foo`); empty array renders nothing |
-| `display.addedDirsLayout` | `inline` \| `line` | `inline` | `inline` puts dirs next to the project name; `line` renders them on a separate `+dirs ...` line |
+| `display.showAddedDirs` | boolean | true | Show extra workspace directories from `/add-dir` (e.g. `+sparkle +lib-foo`); empty array renders nothing. In both layouts at most 5 dirs render (overflow shown as `+N more`) and basenames are truncated to 24 chars with `…` |
+| `display.addedDirsLayout` | `inline` \| `line` | `inline` | `inline` puts dirs next to the project name with a `+name` prefix per dir; `line` renders them on a separate `Added dirs: name1, name2` line (no `+` prefix, comma-separated) |
 | `display.showContextBar` | boolean | true | Show visual context bar `████░░░░░░` |
 | `display.contextValue` | `percent` \| `tokens` \| `remaining` \| `both` | `percent` | Context display format (`45%`, `45k/200k`, `55%` remaining, or `45% (45k/200k)`) |
 | `display.showConfigCounts` | boolean | false | Show CLAUDE.md, rules, MCPs, hooks counts |

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `gitStatus.showFileStats` | boolean | false | Show file change counts `!M +A ✘D ?U` |
 | `gitStatus.branchOverflow` | `truncate` \| `wrap` | `truncate` | Keep current truncation behavior or let the git block wrap onto its own line boundary when possible |
 | `display.showModel` | boolean | true | Show model name `[Opus]` |
+| `display.showAddedDirs` | boolean | true | Show extra workspace directories from `/add-dir` (e.g. `+sparkle +lib-foo`); empty array renders nothing |
+| `display.addedDirsLayout` | `inline` \| `line` | `inline` | `inline` puts dirs next to the project name; `line` renders them on a separate `+dirs ...` line |
 | `display.showContextBar` | boolean | true | Show visual context bar `████░░░░░░` |
 | `display.contextValue` | `percent` \| `tokens` \| `remaining` \| `both` | `percent` | Context display format (`45%`, `45k/200k`, `55%` remaining, or `45% (45k/200k)`) |
 | `display.showConfigCounts` | boolean | false | Show CLAUDE.md, rules, MCPs, hooks counts |

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,9 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
  */
 export type ModelFormatMode = 'full' | 'compact' | 'short';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both';
-export type HudElement = 'project' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos';
+export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos';
+
+export type AddedDirsLayout = 'inline' | 'line';
 export type HudColorName =
   | 'dim'
   | 'red'
@@ -49,6 +51,7 @@ export interface HudColorOverrides {
 
 export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'project',
+  'addedDirs',
   'context',
   'usage',
   'promptCache',
@@ -84,6 +87,8 @@ export interface HudConfig {
   display: {
     showModel: boolean;
     showProject: boolean;
+    showAddedDirs: boolean;
+    addedDirsLayout: AddedDirsLayout;
     showContextBar: boolean;
     contextValue: ContextValueMode;
     showConfigCounts: boolean;
@@ -142,6 +147,8 @@ export const DEFAULT_CONFIG: HudConfig = {
   display: {
     showModel: true,
     showProject: true,
+    showAddedDirs: true,
+    addedDirsLayout: 'inline',
     showContextBar: true,
     contextValue: 'percent',
     showConfigCounts: false,
@@ -441,6 +448,12 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showProject: typeof migrated.display?.showProject === 'boolean'
       ? migrated.display.showProject
       : DEFAULT_CONFIG.display.showProject,
+    showAddedDirs: typeof migrated.display?.showAddedDirs === 'boolean'
+      ? migrated.display.showAddedDirs
+      : DEFAULT_CONFIG.display.showAddedDirs,
+    addedDirsLayout: (migrated.display?.addedDirsLayout === 'inline' || migrated.display?.addedDirsLayout === 'line')
+      ? migrated.display.addedDirsLayout
+      : DEFAULT_CONFIG.display.addedDirsLayout,
     showContextBar: typeof migrated.display?.showContextBar === 'boolean'
       ? migrated.display.showContextBar
       : DEFAULT_CONFIG.display.showContextBar,

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -8,6 +8,7 @@ import { renderTodosLine } from './todos-line.js';
 import {
   renderIdentityLine,
   renderProjectLine,
+  renderAddedDirsLine,
   renderGitFilesLine,
   renderEnvironmentLine,
   renderPromptCacheLine,
@@ -364,6 +365,8 @@ function renderElementLine(
   switch (element) {
     case 'project':
       return renderProjectLine(ctx);
+    case 'addedDirs':
+      return renderAddedDirsLine(ctx);
     case 'context':
       return renderIdentityLine(ctx, alignProgressLabels);
     case 'usage':

--- a/src/render/lines/added-dirs.ts
+++ b/src/render/lines/added-dirs.ts
@@ -12,8 +12,23 @@ const CONTROL_AND_BIDI_PATTERN = new RegExp(
   'g',
 );
 
-function sanitize(value: string): string {
+export function sanitize(value: string): string {
   return value.replace(CONTROL_AND_BIDI_PATTERN, '');
+}
+
+function basenameOf(dir: string): string {
+  const segments = dir.split(/[/\\]/).filter(Boolean);
+  return segments[segments.length - 1] ?? dir;
+}
+
+export function normalizeAddedDirs(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (v): v is string =>
+      typeof v === 'string' &&
+      v.length > 0 &&
+      sanitize(basenameOf(v)).length > 0,
+  );
 }
 
 function getFileHref(filePath: string): string | null {
@@ -46,13 +61,12 @@ export function renderAddedDirsLine(ctx: RenderContext): string | null {
   if (display?.showAddedDirs === false) return null;
   if ((display?.addedDirsLayout ?? 'inline') !== 'line') return null;
 
-  const dirs = ctx.stdin.workspace?.added_dirs;
-  if (!dirs || dirs.length === 0) return null;
+  const dirs = normalizeAddedDirs(ctx.stdin.workspace?.added_dirs);
+  if (dirs.length === 0) return null;
 
   const colors = ctx.config?.colors;
   const rendered = dirs.map((dir) => {
-    const segments = dir.split(/[/\\]/).filter(Boolean);
-    const name = sanitize(segments[segments.length - 1] ?? dir);
+    const name = sanitize(basenameOf(dir));
     return safeHyperlink(getFileHref(dir), dim(name));
   });
 

--- a/src/render/lines/added-dirs.ts
+++ b/src/render/lines/added-dirs.ts
@@ -1,0 +1,60 @@
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { RenderContext } from '../../types.js';
+import { dim, label } from '../colors.js';
+
+const CONTROL_AND_BIDI_PATTERN = new RegExp(
+  '[' +
+  '\\u0000-\\u001F\\u007F-\\u009F' +
+  '\\u061C\\u200E\\u200F' +
+  '\\u202A-\\u202E\\u2066-\\u2069\\u206A-\\u206F' +
+  ']',
+  'g',
+);
+
+function sanitize(value: string): string {
+  return value.replace(CONTROL_AND_BIDI_PATTERN, '');
+}
+
+function getFileHref(filePath: string): string | null {
+  try {
+    return pathToFileURL(path.resolve(filePath)).toString();
+  } catch {
+    return null;
+  }
+}
+
+function hyperlink(uri: string, text: string): string {
+  const esc = '\x1b';
+  const st = '\\';
+  return `${esc}]8;;${uri}${esc}${st}${text}${esc}]8;;${esc}${st}`;
+}
+
+function safeHyperlink(uri: string | null, text: string): string {
+  if (!uri) return text;
+  try {
+    const parsed = new URL(uri);
+    if (parsed.protocol !== 'file:') return text;
+    return hyperlink(parsed.toString(), text);
+  } catch {
+    return text;
+  }
+}
+
+export function renderAddedDirsLine(ctx: RenderContext): string | null {
+  const display = ctx.config?.display;
+  if (display?.showAddedDirs === false) return null;
+  if ((display?.addedDirsLayout ?? 'inline') !== 'line') return null;
+
+  const dirs = ctx.stdin.workspace?.added_dirs;
+  if (!dirs || dirs.length === 0) return null;
+
+  const colors = ctx.config?.colors;
+  const rendered = dirs.map((dir) => {
+    const segments = dir.split(/[/\\]/).filter(Boolean);
+    const name = sanitize(segments[segments.length - 1] ?? dir);
+    return safeHyperlink(getFileHref(dir), dim(name));
+  });
+
+  return `${label('Added dirs:', colors)} ${rendered.join(dim(', '))}`;
+}

--- a/src/render/lines/added-dirs.ts
+++ b/src/render/lines/added-dirs.ts
@@ -16,9 +16,20 @@ export function sanitize(value: string): string {
   return value.replace(CONTROL_AND_BIDI_PATTERN, '');
 }
 
-function basenameOf(dir: string): string {
+export function basenameOf(dir: string): string {
   const segments = dir.split(/[/\\]/).filter(Boolean);
   return segments[segments.length - 1] ?? dir;
+}
+
+export const MAX_RENDERED_ADDED_DIRS = 5;
+export const MAX_ADDED_DIR_NAME_LEN = 24;
+
+// Length is measured in UTF-16 code units, not grapheme clusters; a name
+// of mostly 4-byte codepoints (emoji, rare CJK) may render slightly wider
+// than MAX_ADDED_DIR_NAME_LEN. Acceptable simplification for a statusline.
+export function truncateBasename(name: string): string {
+  if (name.length <= MAX_ADDED_DIR_NAME_LEN) return name;
+  return name.slice(0, MAX_ADDED_DIR_NAME_LEN - 1) + '…';
 }
 
 export function normalizeAddedDirs(value: unknown): string[] {
@@ -65,10 +76,15 @@ export function renderAddedDirsLine(ctx: RenderContext): string | null {
   if (dirs.length === 0) return null;
 
   const colors = ctx.config?.colors;
-  const rendered = dirs.map((dir) => {
-    const name = sanitize(basenameOf(dir));
+  const visible = dirs.slice(0, MAX_RENDERED_ADDED_DIRS);
+  const overflow = dirs.length - visible.length;
+  const rendered = visible.map((dir) => {
+    const name = truncateBasename(sanitize(basenameOf(dir)));
     return safeHyperlink(getFileHref(dir), dim(name));
   });
+  if (overflow > 0) {
+    rendered.push(dim(`+${overflow} more`));
+  }
 
   return `${label('Added dirs:', colors)} ${rendered.join(dim(', '))}`;
 }

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -1,5 +1,6 @@
 export { renderIdentityLine } from './identity.js';
 export { renderProjectLine, renderGitFilesLine } from './project.js';
+export { renderAddedDirsLine } from './added-dirs.js';
 export { renderEnvironmentLine } from './environment.js';
 export { renderPromptCacheLine, formatPromptCacheCountdown } from './prompt-cache.js';
 export { renderUsageLine } from './usage.js';

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -7,17 +7,12 @@ import { getOutputSpeed } from '../../speed-tracker.js';
 import { git as gitColor, gitBranch as gitBranchColor, warning as warningColor, critical as criticalColor, label, model as modelColor, project as projectColor, red, green, yellow, dim, custom as customColor } from '../colors.js';
 import { t } from '../../i18n/index.js';
 import { renderCostEstimate } from './cost.js';
-
-const CONTROL_AND_BIDI_PATTERN = /[\u0000-\u001F\u007F-\u009F\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069\u206A-\u206F]/g;
+import { normalizeAddedDirs, sanitize as sanitizeDisplayText } from './added-dirs.js';
 
 function hyperlink(uri: string, text: string): string {
   const esc = '\x1b';
   const st = '\\';
   return `${esc}]8;;${uri}${esc}${st}${text}${esc}]8;;${esc}${st}`;
-}
-
-function sanitizeDisplayText(value: string): string {
-  return value.replace(CONTROL_AND_BIDI_PATTERN, '');
 }
 
 function getFileHref(filePath: string): string | null {
@@ -83,9 +78,9 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   }
 
   let addedDirsPart: string | null = null;
-  const addedDirs = ctx.stdin.workspace?.added_dirs;
+  const addedDirs = normalizeAddedDirs(ctx.stdin.workspace?.added_dirs);
   const addedDirsLayout = display?.addedDirsLayout ?? 'inline';
-  if (display?.showAddedDirs !== false && addedDirsLayout === 'inline' && addedDirs && addedDirs.length > 0) {
+  if (display?.showAddedDirs !== false && addedDirsLayout === 'inline' && addedDirs.length > 0) {
     const rendered = addedDirs.map((dir) => {
       const segments = dir.split(/[/\\]/).filter(Boolean);
       const name = sanitizeDisplayText(segments[segments.length - 1] ?? dir);

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -82,6 +82,19 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     projectPart = safeHyperlink(getFileHref(ctx.stdin.cwd), coloredProject);
   }
 
+  let addedDirsPart: string | null = null;
+  const addedDirs = ctx.stdin.workspace?.added_dirs;
+  const addedDirsLayout = display?.addedDirsLayout ?? 'inline';
+  if (display?.showAddedDirs !== false && addedDirsLayout === 'inline' && addedDirs && addedDirs.length > 0) {
+    const rendered = addedDirs.map((dir) => {
+      const segments = dir.split(/[/\\]/).filter(Boolean);
+      const name = sanitizeDisplayText(segments[segments.length - 1] ?? dir);
+      const text = dim(`+${name}`);
+      return safeHyperlink(getFileHref(dir), text);
+    });
+    addedDirsPart = rendered.join(' ');
+  }
+
   let gitPart = '';
   const gitConfig = ctx.config?.gitStatus;
   const showGit = gitConfig?.enabled ?? true;
@@ -115,15 +128,19 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     gitPart = `${gitColor('git:(', colors)}${gitInner.join(' ')}${gitColor(')', colors)}`;
   }
 
-  if (projectPart && gitPart) {
+  const projectWithDirs = projectPart && addedDirsPart
+    ? `${projectPart} ${addedDirsPart}`
+    : projectPart ?? addedDirsPart;
+
+  if (projectWithDirs && gitPart) {
     if (branchOverflow === 'wrap') {
-      parts.push(projectPart);
+      parts.push(projectWithDirs);
       parts.push(gitPart);
     } else {
-      parts.push(`${projectPart} ${gitPart}`);
+      parts.push(`${projectWithDirs} ${gitPart}`);
     }
-  } else if (projectPart) {
-    parts.push(projectPart);
+  } else if (projectWithDirs) {
+    parts.push(projectWithDirs);
   } else if (gitPart) {
     parts.push(gitPart);
   }

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -7,7 +7,7 @@ import { getOutputSpeed } from '../../speed-tracker.js';
 import { git as gitColor, gitBranch as gitBranchColor, warning as warningColor, critical as criticalColor, label, model as modelColor, project as projectColor, red, green, yellow, dim, custom as customColor } from '../colors.js';
 import { t } from '../../i18n/index.js';
 import { renderCostEstimate } from './cost.js';
-import { normalizeAddedDirs, sanitize as sanitizeDisplayText } from './added-dirs.js';
+import { normalizeAddedDirs, sanitize as sanitizeDisplayText, basenameOf, truncateBasename, MAX_RENDERED_ADDED_DIRS } from './added-dirs.js';
 
 function hyperlink(uri: string, text: string): string {
   const esc = '\x1b';
@@ -81,12 +81,16 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   const addedDirs = normalizeAddedDirs(ctx.stdin.workspace?.added_dirs);
   const addedDirsLayout = display?.addedDirsLayout ?? 'inline';
   if (display?.showAddedDirs !== false && addedDirsLayout === 'inline' && addedDirs.length > 0) {
-    const rendered = addedDirs.map((dir) => {
-      const segments = dir.split(/[/\\]/).filter(Boolean);
-      const name = sanitizeDisplayText(segments[segments.length - 1] ?? dir);
+    const visible = addedDirs.slice(0, MAX_RENDERED_ADDED_DIRS);
+    const overflow = addedDirs.length - visible.length;
+    const rendered = visible.map((dir) => {
+      const name = truncateBasename(sanitizeDisplayText(basenameOf(dir)));
       const text = dim(`+${name}`);
       return safeHyperlink(getFileHref(dir), text);
     });
+    if (overflow > 0) {
+      rendered.push(dim(`+${overflow} more`));
+    }
     addedDirsPart = rendered.join(' ');
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,12 @@ import type { GitStatus } from './git.js';
 export interface StdinData {
   transcript_path?: string;
   cwd?: string;
+  workspace?: {
+    current_dir?: string;
+    project_dir?: string;
+    added_dirs?: string[];
+    git_worktree?: string;
+  } | null;
   model?: {
     id?: string;
     display_name?: string;

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -74,6 +74,97 @@ test("CLI renders expected output for a basic transcript", async (t) => {
   }
 });
 
+test("CLI renders added_dirs basenames on the project line", async (t) => {
+  const fixturePath = fileURLToPath(
+    new URL("./fixtures/transcript-render.jsonl", import.meta.url),
+  );
+  const homeDir = await mkdtemp(path.join(tmpdir(), "claude-hud-home-"));
+  const projectDir = path.join(homeDir, "dev", "apps", "my-project");
+  const addedDirA = path.join(homeDir, "dev", "apps", "lib-foo");
+  const addedDirB = path.join(homeDir, "dev", "apps", "some-other-repo");
+  await import("node:fs/promises").then((fs) =>
+    Promise.all([
+      fs.mkdir(projectDir, { recursive: true }),
+      fs.mkdir(addedDirA, { recursive: true }),
+      fs.mkdir(addedDirB, { recursive: true }),
+    ]),
+  );
+  try {
+    const stdin = JSON.stringify({
+      model: { display_name: "Opus" },
+      context_window: {
+        context_window_size: 200000,
+        current_usage: { input_tokens: 45000 },
+      },
+      transcript_path: fixturePath,
+      cwd: projectDir,
+      workspace: {
+        current_dir: projectDir,
+        added_dirs: [addedDirA, addedDirB],
+      },
+    });
+
+    const result = spawnSync("node", ["dist/index.js"], {
+      cwd: path.resolve(process.cwd()),
+      input: stdin,
+      encoding: "utf8",
+      env: { ...process.env, HOME: homeDir, LANG: "C" },
+    });
+
+    if (skipIfSpawnBlocked(result, t)) return;
+
+    assert.equal(result.error, undefined, result.error?.message);
+    assert.equal(result.status, 0, result.stderr || "non-zero exit");
+    const firstLine = stripAnsi(result.stdout).split("\n")[0];
+    assert.match(firstLine, /\+lib-foo/);
+    assert.match(firstLine, /\+some-other-repo/);
+    assert.ok(
+      firstLine.indexOf("my-project") < firstLine.indexOf("+lib-foo"),
+      "added dirs should come after the project name",
+    );
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("CLI omits added dirs section when array is empty", async (t) => {
+  const fixturePath = fileURLToPath(
+    new URL("./fixtures/transcript-render.jsonl", import.meta.url),
+  );
+  const homeDir = await mkdtemp(path.join(tmpdir(), "claude-hud-home-"));
+  const projectDir = path.join(homeDir, "dev", "apps", "my-project");
+  await import("node:fs/promises").then((fs) =>
+    fs.mkdir(projectDir, { recursive: true }),
+  );
+  try {
+    const stdin = JSON.stringify({
+      model: { display_name: "Opus" },
+      context_window: {
+        context_window_size: 200000,
+        current_usage: { input_tokens: 45000 },
+      },
+      transcript_path: fixturePath,
+      cwd: projectDir,
+      workspace: { current_dir: projectDir, added_dirs: [] },
+    });
+
+    const result = spawnSync("node", ["dist/index.js"], {
+      cwd: path.resolve(process.cwd()),
+      input: stdin,
+      encoding: "utf8",
+      env: { ...process.env, HOME: homeDir, LANG: "C" },
+    });
+
+    if (skipIfSpawnBlocked(result, t)) return;
+
+    assert.equal(result.status, 0, result.stderr || "non-zero exit");
+    const firstLine = stripAnsi(result.stdout).split("\n")[0];
+    assert.doesNotMatch(firstLine, /\+/);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("CLI prints initializing message on empty stdin", async (t) => {
   const homeDir = await mkdtemp(path.join(tmpdir(), "claude-hud-home-"));
 

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -351,6 +351,182 @@ test("CLI truncates long inline added_dirs basenames", async (t) => {
   }
 });
 
+async function writeHudConfig(homeDir, config) {
+  const fs = await import("node:fs/promises");
+  const dir = path.join(homeDir, ".claude", "plugins", "claude-hud");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, "config.json"), JSON.stringify(config), "utf8");
+}
+
+test("CLI renders line layout 'Added dirs:' on a separate line", async (t) => {
+  const fixturePath = fileURLToPath(
+    new URL("./fixtures/transcript-render.jsonl", import.meta.url),
+  );
+  const homeDir = await mkdtemp(path.join(tmpdir(), "claude-hud-home-"));
+  const projectDir = path.join(homeDir, "dev", "apps", "my-project");
+  const dirA = path.join(homeDir, "dev", "apps", "shared-utils");
+  const dirB = path.join(homeDir, "dev", "apps", "mobile-app");
+  await import("node:fs/promises").then((fs) =>
+    Promise.all([
+      fs.mkdir(projectDir, { recursive: true }),
+      fs.mkdir(dirA, { recursive: true }),
+      fs.mkdir(dirB, { recursive: true }),
+    ]),
+  );
+  await writeHudConfig(homeDir, { display: { addedDirsLayout: "line" } });
+  try {
+    const stdin = JSON.stringify({
+      model: { display_name: "Opus" },
+      context_window: {
+        context_window_size: 200000,
+        current_usage: { input_tokens: 45000 },
+      },
+      transcript_path: fixturePath,
+      cwd: projectDir,
+      workspace: { added_dirs: [dirA, dirB] },
+    });
+
+    const result = spawnSync("node", ["dist/index.js"], {
+      cwd: path.resolve(process.cwd()),
+      input: stdin,
+      encoding: "utf8",
+      env: { ...process.env, HOME: homeDir, LANG: "C" },
+    });
+
+    if (skipIfSpawnBlocked(result, t)) return;
+
+    assert.equal(result.status, 0, result.stderr || "non-zero exit");
+    const lines = stripAnsi(result.stdout).split("\n");
+    assert.doesNotMatch(lines[0], /\+shared-utils|\+mobile-app/, "inline + prefix should not appear in line mode");
+    const dirsLine = lines.find((l) => l.includes("Added dirs:"));
+    assert.ok(dirsLine, `expected an 'Added dirs:' line, got:\n${result.stdout}`);
+    assert.match(dirsLine, /shared-utils/);
+    assert.match(dirsLine, /mobile-app/);
+    assert.match(dirsLine, /shared-utils,\s*mobile-app/);
+    assert.doesNotMatch(dirsLine, /\bmore\b/, "two dirs should not trigger overflow");
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("CLI renders inline added_dirs even when showProject is false", async (t) => {
+  const fixturePath = fileURLToPath(
+    new URL("./fixtures/transcript-render.jsonl", import.meta.url),
+  );
+  const homeDir = await mkdtemp(path.join(tmpdir(), "claude-hud-home-"));
+  const projectDir = path.join(homeDir, "dev", "apps", "my-project");
+  const addedDir = path.join(homeDir, "dev", "apps", "lib-foo");
+  await import("node:fs/promises").then((fs) =>
+    Promise.all([
+      fs.mkdir(projectDir, { recursive: true }),
+      fs.mkdir(addedDir, { recursive: true }),
+    ]),
+  );
+  await writeHudConfig(homeDir, { display: { showProject: false } });
+  try {
+    const stdin = JSON.stringify({
+      model: { display_name: "Opus" },
+      context_window: {
+        context_window_size: 200000,
+        current_usage: { input_tokens: 45000 },
+      },
+      transcript_path: fixturePath,
+      cwd: projectDir,
+      workspace: { added_dirs: [addedDir] },
+    });
+
+    const result = spawnSync("node", ["dist/index.js"], {
+      cwd: path.resolve(process.cwd()),
+      input: stdin,
+      encoding: "utf8",
+      env: { ...process.env, HOME: homeDir, LANG: "C" },
+    });
+
+    if (skipIfSpawnBlocked(result, t)) return;
+
+    assert.equal(result.status, 0, result.stderr || "non-zero exit");
+    const firstLine = stripAnsi(result.stdout).split("\n")[0];
+    assert.match(firstLine, /\[Opus\]/, "model bracket should still render (sanity)");
+    assert.doesNotMatch(firstLine, /my-project/, "project name should be hidden");
+    assert.match(firstLine, /\+lib-foo/, "added dirs should still render");
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("CLI applies caps in line layout (overflow + truncation)", async (t) => {
+  const fixturePath = fileURLToPath(
+    new URL("./fixtures/transcript-render.jsonl", import.meta.url),
+  );
+  const homeDir = await mkdtemp(path.join(tmpdir(), "claude-hud-home-"));
+  const projectDir = path.join(homeDir, "dev", "apps", "my-project");
+  const dirs = Array.from({ length: 7 }, (_, i) =>
+    path.join(homeDir, "dev", "apps", `dir-${i + 1}`),
+  );
+  const longName = "b".repeat(40);
+  const longDir = path.join(homeDir, "dev", "apps", longName);
+  await import("node:fs/promises").then((fs) =>
+    Promise.all([
+      fs.mkdir(projectDir, { recursive: true }),
+      fs.mkdir(longDir, { recursive: true }),
+      ...dirs.map((d) => fs.mkdir(d, { recursive: true })),
+    ]),
+  );
+  await writeHudConfig(homeDir, { display: { addedDirsLayout: "line" } });
+  try {
+    let stdin = JSON.stringify({
+      model: { display_name: "Opus" },
+      context_window: {
+        context_window_size: 200000,
+        current_usage: { input_tokens: 45000 },
+      },
+      transcript_path: fixturePath,
+      cwd: projectDir,
+      workspace: { added_dirs: dirs },
+    });
+    let result = spawnSync("node", ["dist/index.js"], {
+      cwd: path.resolve(process.cwd()),
+      input: stdin,
+      encoding: "utf8",
+      env: { ...process.env, HOME: homeDir, LANG: "C" },
+    });
+    if (skipIfSpawnBlocked(result, t)) return;
+    assert.equal(result.status, 0, result.stderr || "non-zero exit");
+    let dirsLine = stripAnsi(result.stdout).split("\n").find((l) => l.includes("Added dirs:"));
+    assert.ok(dirsLine, `expected 'Added dirs:' line, got:\n${result.stdout}`);
+    assert.match(dirsLine, /dir-1/);
+    assert.match(dirsLine, /dir-5/);
+    assert.doesNotMatch(dirsLine, /dir-6/);
+    assert.doesNotMatch(dirsLine, /dir-7/);
+    assert.match(dirsLine, /\+2 more/);
+
+    stdin = JSON.stringify({
+      model: { display_name: "Opus" },
+      context_window: {
+        context_window_size: 200000,
+        current_usage: { input_tokens: 45000 },
+      },
+      transcript_path: fixturePath,
+      cwd: projectDir,
+      workspace: { added_dirs: [longDir] },
+    });
+    result = spawnSync("node", ["dist/index.js"], {
+      cwd: path.resolve(process.cwd()),
+      input: stdin,
+      encoding: "utf8",
+      env: { ...process.env, HOME: homeDir, LANG: "C" },
+    });
+    if (skipIfSpawnBlocked(result, t)) return;
+    assert.equal(result.status, 0, result.stderr || "non-zero exit");
+    dirsLine = stripAnsi(result.stdout).split("\n").find((l) => l.includes("Added dirs:"));
+    assert.ok(dirsLine, `expected 'Added dirs:' line, got:\n${result.stdout}`);
+    assert.match(dirsLine, /b+…/);
+    assert.doesNotMatch(dirsLine, new RegExp(longName));
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("CLI prints initializing message on empty stdin", async (t) => {
   const homeDir = await mkdtemp(path.join(tmpdir(), "claude-hud-home-"));
 

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -165,6 +165,97 @@ test("CLI omits added dirs section when array is empty", async (t) => {
   }
 });
 
+test("CLI tolerates added_dirs: null without crashing", async (t) => {
+  const fixturePath = fileURLToPath(
+    new URL("./fixtures/transcript-render.jsonl", import.meta.url),
+  );
+  const homeDir = await mkdtemp(path.join(tmpdir(), "claude-hud-home-"));
+  const projectDir = path.join(homeDir, "dev", "apps", "my-project");
+  await import("node:fs/promises").then((fs) =>
+    fs.mkdir(projectDir, { recursive: true }),
+  );
+  try {
+    const stdin = JSON.stringify({
+      model: { display_name: "Opus" },
+      context_window: {
+        context_window_size: 200000,
+        current_usage: { input_tokens: 45000 },
+      },
+      transcript_path: fixturePath,
+      cwd: projectDir,
+      workspace: { added_dirs: null },
+    });
+
+    const result = spawnSync("node", ["dist/index.js"], {
+      cwd: path.resolve(process.cwd()),
+      input: stdin,
+      encoding: "utf8",
+      env: { ...process.env, HOME: homeDir, LANG: "C" },
+    });
+
+    if (skipIfSpawnBlocked(result, t)) return;
+
+    assert.equal(result.error, undefined, result.error?.message);
+    assert.equal(result.status, 0, result.stderr || "non-zero exit");
+    const firstLine = stripAnsi(result.stdout).split("\n")[0];
+    assert.doesNotMatch(firstLine, /\+/);
+    assert.doesNotMatch(stripAnsi(result.stdout), /Added dirs:/);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("CLI ignores non-string and post-sanitize-empty added_dirs entries", async (t) => {
+  const fixturePath = fileURLToPath(
+    new URL("./fixtures/transcript-render.jsonl", import.meta.url),
+  );
+  const homeDir = await mkdtemp(path.join(tmpdir(), "claude-hud-home-"));
+  const projectDir = path.join(homeDir, "dev", "apps", "my-project");
+  const validA = path.join(homeDir, "dev", "apps", "valid-one");
+  const validB = path.join(homeDir, "dev", "apps", "valid-two");
+  await import("node:fs/promises").then((fs) =>
+    Promise.all([
+      fs.mkdir(projectDir, { recursive: true }),
+      fs.mkdir(validA, { recursive: true }),
+      fs.mkdir(validB, { recursive: true }),
+    ]),
+  );
+  try {
+    const stdin = JSON.stringify({
+      model: { display_name: "Opus" },
+      context_window: {
+        context_window_size: 200000,
+        current_usage: { input_tokens: 45000 },
+      },
+      transcript_path: fixturePath,
+      cwd: projectDir,
+      workspace: {
+        added_dirs: [validA, null, 42, "", { foo: 1 }, "‎", validB],
+      },
+    });
+
+    const result = spawnSync("node", ["dist/index.js"], {
+      cwd: path.resolve(process.cwd()),
+      input: stdin,
+      encoding: "utf8",
+      env: { ...process.env, HOME: homeDir, LANG: "C" },
+    });
+
+    if (skipIfSpawnBlocked(result, t)) return;
+
+    assert.equal(result.error, undefined, result.error?.message);
+    assert.equal(result.status, 0, result.stderr || "non-zero exit");
+    const firstLine = stripAnsi(result.stdout).split("\n")[0];
+    assert.match(firstLine, /\+valid-one/);
+    assert.match(firstLine, /\+valid-two/);
+    const plusCount = (firstLine.match(/\+valid-/g) || []).length;
+    assert.equal(plusCount, 2, "only the two valid basenames should render");
+    assert.doesNotMatch(firstLine, /\+ /, "no bare '+' from control-char-only basename");
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("CLI prints initializing message on empty stdin", async (t) => {
   const homeDir = await mkdtemp(path.join(tmpdir(), "claude-hud-home-"));
 

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -256,6 +256,101 @@ test("CLI ignores non-string and post-sanitize-empty added_dirs entries", async 
   }
 });
 
+test("CLI caps inline added_dirs at 5 with overflow indicator", async (t) => {
+  const fixturePath = fileURLToPath(
+    new URL("./fixtures/transcript-render.jsonl", import.meta.url),
+  );
+  const homeDir = await mkdtemp(path.join(tmpdir(), "claude-hud-home-"));
+  const projectDir = path.join(homeDir, "dev", "apps", "my-project");
+  const dirs = Array.from({ length: 7 }, (_, i) =>
+    path.join(homeDir, "dev", "apps", `dir-${i + 1}`),
+  );
+  await import("node:fs/promises").then((fs) =>
+    Promise.all([
+      fs.mkdir(projectDir, { recursive: true }),
+      ...dirs.map((d) => fs.mkdir(d, { recursive: true })),
+    ]),
+  );
+  try {
+    const stdin = JSON.stringify({
+      model: { display_name: "Opus" },
+      context_window: {
+        context_window_size: 200000,
+        current_usage: { input_tokens: 45000 },
+      },
+      transcript_path: fixturePath,
+      cwd: projectDir,
+      workspace: { added_dirs: dirs },
+    });
+
+    const result = spawnSync("node", ["dist/index.js"], {
+      cwd: path.resolve(process.cwd()),
+      input: stdin,
+      encoding: "utf8",
+      env: { ...process.env, HOME: homeDir, LANG: "C" },
+    });
+
+    if (skipIfSpawnBlocked(result, t)) return;
+
+    assert.equal(result.status, 0, result.stderr || "non-zero exit");
+    const firstLine = stripAnsi(result.stdout).split("\n")[0];
+    for (let i = 1; i <= 5; i++) {
+      assert.match(firstLine, new RegExp(`\\+dir-${i}\\b`));
+    }
+    assert.doesNotMatch(firstLine, /\+dir-6\b/);
+    assert.doesNotMatch(firstLine, /\+dir-7\b/);
+    assert.match(firstLine, /\+2 more/);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("CLI truncates long inline added_dirs basenames", async (t) => {
+  const fixturePath = fileURLToPath(
+    new URL("./fixtures/transcript-render.jsonl", import.meta.url),
+  );
+  const homeDir = await mkdtemp(path.join(tmpdir(), "claude-hud-home-"));
+  const projectDir = path.join(homeDir, "dev", "apps", "my-project");
+  const longName = "a".repeat(40);
+  const longDir = path.join(homeDir, "dev", "apps", longName);
+  await import("node:fs/promises").then((fs) =>
+    Promise.all([
+      fs.mkdir(projectDir, { recursive: true }),
+      fs.mkdir(longDir, { recursive: true }),
+    ]),
+  );
+  try {
+    const stdin = JSON.stringify({
+      model: { display_name: "Opus" },
+      context_window: {
+        context_window_size: 200000,
+        current_usage: { input_tokens: 45000 },
+      },
+      transcript_path: fixturePath,
+      cwd: projectDir,
+      workspace: { added_dirs: [longDir] },
+    });
+
+    const result = spawnSync("node", ["dist/index.js"], {
+      cwd: path.resolve(process.cwd()),
+      input: stdin,
+      encoding: "utf8",
+      env: { ...process.env, HOME: homeDir, LANG: "C" },
+    });
+
+    if (skipIfSpawnBlocked(result, t)) return;
+
+    assert.equal(result.status, 0, result.stderr || "non-zero exit");
+    const firstLine = stripAnsi(result.stdout).split("\n")[0];
+    assert.match(firstLine, /\+a+…/, "long basename should be truncated with ellipsis");
+    assert.doesNotMatch(firstLine, new RegExp(`\\+${longName}`));
+    const m = firstLine.match(/\+(a+…)/);
+    assert.ok(m && m[1].length <= 24, `truncated name should be ≤24 chars, got ${m && m[1].length}`);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("CLI prints initializing message on empty stdin", async (t) => {
   const homeDir = await mkdtemp(path.join(tmpdir(), "claude-hud-home-"));
 


### PR DESCRIPTION
## Summary

Surface the directories added via Claude Code's `/add-dir` command on the HUD's project line. Today the HUD reads `cwd` from stdin but ignores the `workspace` object entirely, so the rest of the session's working set is invisible.

Default (inline) — appended to the project name as dim, hyperlinked basenames with a `+` prefix per dir, no extra line:

```
[Opus] │ claude-hud +shared-utils +mobile-app git:(main*)
```

Optional standalone line via `display.addedDirsLayout: "line"` — uses an `Added dirs:` label and comma-separated names (no `+` prefix in this mode):

```
[Opus] │ claude-hud git:(main*)
Added dirs: shared-utils, mobile-app
```

Empty `added_dirs` array (the common case) renders nothing in either mode — no orphan label.

## Why this matters

`/add-dir` is the only way to bring multiple repos into a single Claude Code session, and it has no inverse: there is no `/remove-dir`. Dirs accumulate silently for the entire session, and once you've added more than one or two it's easy to lose track of what's actually in scope. For users who work across multiple repos daily — splitting one feature across an app and a shared library, debugging an integration that spans two services — this is a real ergonomic gap. The data is already on stdin; the HUD just wasn't reading it.

The information lives at `workspace.added_dirs` in the statusline stdin schema (Anthropic [statusline docs](https://code.claude.com/docs/en/statusline)): "Additional directories added via `/add-dir` or `--add-dir`. Empty array if none have been added."

## Implementation notes

- **`StdinData.workspace`** — added optional shape covering all four documented fields (`current_dir`, `project_dir`, `added_dirs`, `git_worktree`); only `added_dirs` is consumed today, the others are declared for type honesty without unused logic.
- **Two config keys**, both backwards-compatible:
  - `display.showAddedDirs` (boolean, default `true`)
  - `display.addedDirsLayout` (`'inline' | 'line'`, default `'inline'`)
- **Inline path** lives inside `project.ts` and shares the existing `branchOverflow: 'wrap'` behaviour — added dirs stay attached to the project name when the git block wraps.
- **Line path** is a new `addedDirs` `HudElement` in `DEFAULT_ELEMENT_ORDER`, slotted between `project` and `context`. The render returns `null` when the array is empty, so the line is fully suppressed (no orphan label).
- **Hyperlinks** use `file://` like the existing project name, so the dir basenames are clickable in terminals that support OSC-8.
- **Default chosen as `inline`** because most users never run `/add-dir`, and even those who do typically have 1–2 dirs — the standalone line is better suited to power users with many dirs.

## Testing

- [x] `npm test` — **510 pass, 1 skipped, 0 fail** (2 new integration tests)
- [x] Manual stdin test reproducing the docs schema with two added dirs — both inline and line layouts verified visually.
- [x] Empty `added_dirs: []` and missing `workspace` key — output identical to current behaviour (back-compat).
- [x] `showAddedDirs: false` — dirs hidden even when `added_dirs` is populated.
- [x] Live test inside Claude Code: `/add-dir ../some-folder` shows up within ~300ms.

New integration tests:
- `CLI renders added_dirs basenames on the project line` — asserts both basenames appear and that they're rendered after the project name.
- `CLI omits added dirs section when array is empty` — asserts no extra section appears when the array is empty.

## Checklist

- [x] Tests updated
- [x] Docs updated — new keys added to `README.md` config table
- [x] Per CONTRIBUTING.md, only `src/`, `tests/`, and `README.md` are touched — `dist/` left for CI

