### PR TITLE
fix(context): treat nonzero token totals with zero usage as suspicious

### DIFF
--- a/src/context-cache.ts
+++ b/src/context-cache.ts
@@ -203,32 +203,25 @@ function isAllUsageZero(usage: ContextWindow["current_usage"]): boolean {
 
 /**
  * Returns true when context window data looks like a Claude Code reporting
- * glitch rather than a genuine zero-usage state. Two conditions trigger this:
+ * glitch rather than a genuine zero-usage state.
  *
- * 1. Accumulated token totals (input or output) are non-zero but
- *    `used_percentage` is 0 — the percentage hasn't caught up with reality.
- * 2. Total input tokens exceed the declared window size, `used_percentage`
- *    is still 0, AND every field in `current_usage` is also zero — the frame
- *    is entirely empty despite an overflow-level token count.
- *
- * Returns false when data is clearly valid: no window size, tokens within
- * bounds, or a non-zero `used_percentage` that confirms real usage.
+ * We only treat a zero-percent frame as suspicious when accumulated totals are
+ * non-zero and `current_usage` is still empty. If `current_usage` already shows
+ * non-zero token counters, keep the live frame instead of restoring stale cache.
  */
 function isSuspiciousZero(contextWindow: ContextWindow): boolean {
   const usedPercentage = contextWindow.used_percentage ?? 0;
-  const contextWindowSize = contextWindow.context_window_size ?? 0;
+  if (usedPercentage !== 0) {
+    return false;
+  }
+
+  if (!isAllUsageZero(contextWindow.current_usage)) {
+    return false;
+  }
+
   const totalInputTokens = contextWindow.total_input_tokens ?? 0;
   const totalOutputTokens = contextWindow.total_output_tokens ?? 0;
-  if ((totalInputTokens > 0 || totalOutputTokens > 0) && usedPercentage === 0) {
-    return true;
-  }
-  if (contextWindowSize <= 0 || totalInputTokens <= contextWindowSize) {
-    return false;
-  }
-  if ((contextWindow.used_percentage ?? 0) !== 0) {
-    return false;
-  }
-  return isAllUsageZero(contextWindow.current_usage);
+  return totalInputTokens > 0 || totalOutputTokens > 0;
 }
 
 /**

--- a/src/context-cache.ts
+++ b/src/context-cache.ts
@@ -202,12 +202,26 @@ function isAllUsageZero(usage: ContextWindow["current_usage"]): boolean {
 }
 
 /**
- * Detect the known Claude Code glitch where usage is reported as zero
- * despite a large accumulated input token count.
+ * Returns true when context window data looks like a Claude Code reporting
+ * glitch rather than a genuine zero-usage state. Two conditions trigger this:
+ *
+ * 1. Accumulated token totals (input or output) are non-zero but
+ *    `used_percentage` is 0 — the percentage hasn't caught up with reality.
+ * 2. Total input tokens exceed the declared window size, `used_percentage`
+ *    is still 0, AND every field in `current_usage` is also zero — the frame
+ *    is entirely empty despite an overflow-level token count.
+ *
+ * Returns false when data is clearly valid: no window size, tokens within
+ * bounds, or a non-zero `used_percentage` that confirms real usage.
  */
 function isSuspiciousZero(contextWindow: ContextWindow): boolean {
+  const usedPercentage = contextWindow.used_percentage ?? 0;
   const contextWindowSize = contextWindow.context_window_size ?? 0;
   const totalInputTokens = contextWindow.total_input_tokens ?? 0;
+  const totalOutputTokens = contextWindow.total_output_tokens ?? 0;
+  if ((totalInputTokens > 0 || totalOutputTokens > 0) && usedPercentage === 0) {
+    return true;
+  }
   if (contextWindowSize <= 0 || totalInputTokens <= contextWindowSize) {
     return false;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface StdinData {
   context_window?: {
     context_window_size?: number;
     total_input_tokens?: number | null;
+    total_output_tokens?: number | null;
     current_usage?: {
       input_tokens?: number;
       output_tokens?: number;

--- a/tests/context-cache.test.js
+++ b/tests/context-cache.test.js
@@ -171,40 +171,38 @@ test('applyContextWindowFallback ignores corrupted cache without throwing', asyn
   }
 });
 
-test('applyContextWindowFallback restores cache even when zero frame has not overflowed (new branch 1 logic)', async () => {
+test('applyContextWindowFallback keeps live usage when zero-percent frame already has current_usage data', async () => {
   const tempHome = await createTempHome();
   const transcriptPath = '/tmp/session-a.jsonl';
 
   try {
-    const cachePath = getCachePath(tempHome, transcriptPath);
-    await mkdir(path.dirname(cachePath), { recursive: true });
-    await writeFile(
-      cachePath,
-      JSON.stringify({
-        used_percentage: 61,
-        remaining_percentage: 39,
-        context_window_size: 200000,
-        current_usage: {
-          input_tokens: 120000,
-          output_tokens: 5000,
-          cache_creation_input_tokens: 1000,
-          cache_read_input_tokens: 800,
-        },
-        saved_at: 999_000,
-      }),
-      'utf8',
+    applyContextWindowFallback(
+      makeHealthyFrame(transcriptPath),
+      makeDeps(tempHome, 1_000_000),
     );
 
-    // With new branch 1 logic: totalInputTokens > 0 && usedPercentage === 0 triggers suspicious zero
-    // even when totalInputTokens <= contextWindowSize
-    const stdin = makeSuspiciousFrame({ total_input_tokens: 200000 });
+    const stdin = makeSuspiciousFrame({
+      total_input_tokens: 50000,
+      total_output_tokens: 3000,
+      current_usage: {
+        input_tokens: 48000,
+        output_tokens: 2000,
+        cache_creation_input_tokens: 400,
+        cache_read_input_tokens: 100,
+      },
+    });
     stdin.transcript_path = transcriptPath;
 
-    applyContextWindowFallback(stdin, makeDeps(tempHome));
+    applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
 
-    // Should restore from cache because branch 1 detects it as suspicious
-    assert.equal(stdin.context_window.used_percentage, 61);
-    assert.equal(stdin.context_window.remaining_percentage, 39);
+    assert.equal(stdin.context_window.used_percentage, 0);
+    assert.equal(stdin.context_window.remaining_percentage, 100);
+    assert.deepEqual(stdin.context_window.current_usage, {
+      input_tokens: 48000,
+      output_tokens: 2000,
+      cache_creation_input_tokens: 400,
+      cache_read_input_tokens: 100,
+    });
   } finally {
     await rm(tempHome, { recursive: true, force: true });
   }
@@ -565,24 +563,21 @@ test('_sweepCacheForTests evicts oldest entries when over the entry cap', async 
   }
 });
 
-test('applyContextWindowFallback detects suspicious zero when totalInputTokens > 0 but used_percentage is 0', async () => {
+test('applyContextWindowFallback restores cache for zero-percent frames with nonzero input totals and empty usage', async () => {
   const tempHome = await createTempHome();
   const transcriptPath = '/tmp/session-a.jsonl';
 
   try {
-    // Seed cache with healthy data
     applyContextWindowFallback(
       makeHealthyFrame(transcriptPath),
       makeDeps(tempHome, 1_000_000),
     );
 
-    // Frame with totalInputTokens > 0 but used_percentage = 0 (branch 1)
-    const stdin = makeSuspiciousFrame({ total_input_tokens: 50000 });
+    const stdin = makeSuspiciousFrame({ total_input_tokens: 50000, total_output_tokens: 0 });
     stdin.transcript_path = transcriptPath;
 
     applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
 
-    // Should restore from cache because it's suspicious
     assert.equal(stdin.context_window.used_percentage, 58);
     assert.equal(stdin.context_window.remaining_percentage, 42);
   } finally {
@@ -590,24 +585,21 @@ test('applyContextWindowFallback detects suspicious zero when totalInputTokens >
   }
 });
 
-test('applyContextWindowFallback detects suspicious zero when totalOutputTokens > 0 but used_percentage is 0', async () => {
+test('applyContextWindowFallback restores cache for zero-percent frames with nonzero output totals and empty usage', async () => {
   const tempHome = await createTempHome();
   const transcriptPath = '/tmp/session-a.jsonl';
 
   try {
-    // Seed cache with healthy data
     applyContextWindowFallback(
       makeHealthyFrame(transcriptPath),
       makeDeps(tempHome, 1_000_000),
     );
 
-    // Frame with totalOutputTokens > 0 but used_percentage = 0 (branch 1)
     const stdin = makeSuspiciousFrame({ total_input_tokens: 0, total_output_tokens: 3000 });
     stdin.transcript_path = transcriptPath;
 
     applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
 
-    // Should restore from cache because it's suspicious
     assert.equal(stdin.context_window.used_percentage, 58);
     assert.equal(stdin.context_window.remaining_percentage, 42);
   } finally {
@@ -615,104 +607,29 @@ test('applyContextWindowFallback detects suspicious zero when totalOutputTokens 
   }
 });
 
-test('applyContextWindowFallback detects suspicious zero when both totalInputTokens and totalOutputTokens > 0 but used_percentage is 0', async () => {
+test('applyContextWindowFallback keeps legitimate zero/reset frames unchanged', async () => {
   const tempHome = await createTempHome();
   const transcriptPath = '/tmp/session-a.jsonl';
 
   try {
-    // Seed cache with healthy data
     applyContextWindowFallback(
       makeHealthyFrame(transcriptPath),
       makeDeps(tempHome, 1_000_000),
     );
 
-    // Frame with both tokens > 0 but used_percentage = 0 (branch 1)
-    const stdin = makeSuspiciousFrame({ total_input_tokens: 50000, total_output_tokens: 3000 });
-    stdin.transcript_path = transcriptPath;
-
-    applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
-
-    // Should restore from cache because it's suspicious
-    assert.equal(stdin.context_window.used_percentage, 58);
-    assert.equal(stdin.context_window.remaining_percentage, 42);
-  } finally {
-    await rm(tempHome, { recursive: true, force: true });
-  }
-});
-
-test('applyContextWindowFallback does not treat as suspicious when all tokens and used_percentage are 0', async () => {
-  const tempHome = await createTempHome();
-  const transcriptPath = '/tmp/session-a.jsonl';
-
-  try {
-    // Seed cache with healthy data
-    applyContextWindowFallback(
-      makeHealthyFrame(transcriptPath),
-      makeDeps(tempHome, 1_000_000),
-    );
-
-    // Frame with all zeros - not suspicious by branch 1, falls through to branch 2
     const stdin = makeSuspiciousFrame({ total_input_tokens: 0, total_output_tokens: 0 });
     stdin.transcript_path = transcriptPath;
 
     applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
 
-    // Should NOT restore from cache - branch 2 returns false (totalInputTokens <= contextWindowSize)
     assert.equal(stdin.context_window.used_percentage, 0);
     assert.equal(stdin.context_window.remaining_percentage, 100);
-  } finally {
-    await rm(tempHome, { recursive: true, force: true });
-  }
-});
-
-test('applyContextWindowFallback does not treat as suspicious when contextWindowSize is 0', async () => {
-  const tempHome = await createTempHome();
-  const transcriptPath = '/tmp/session-a.jsonl';
-
-  try {
-    // Seed cache with healthy data
-    applyContextWindowFallback(
-      makeHealthyFrame(transcriptPath),
-      makeDeps(tempHome, 1_000_000),
-    );
-
-    // Frame with contextWindowSize = 0 - branch 1 triggers first
-    const stdin = makeSuspiciousFrame({ context_window_size: 0, total_input_tokens: 250000 });
-    stdin.transcript_path = transcriptPath;
-
-    applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
-
-    // Branch 1 triggers (totalInputTokens > 0 && usedPercentage === 0)
-    // So it should restore from cache
-    assert.equal(stdin.context_window.used_percentage, 58);
-    assert.equal(stdin.context_window.remaining_percentage, 42);
-  } finally {
-    await rm(tempHome, { recursive: true, force: true });
-  }
-});
-
-test('applyContextWindowFallback does not treat as suspicious when used_percentage is non-zero', async () => {
-  const tempHome = await createTempHome();
-  const transcriptPath = '/tmp/session-a.jsonl';
-
-  try {
-    // Frame with non-zero used_percentage - not suspicious
-    const stdin = makeHealthyFrame(transcriptPath, {
-      total_input_tokens: 120000,
-      total_output_tokens: 5000,
+    assert.deepEqual(stdin.context_window.current_usage, {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
     });
-
-    applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
-
-    // Should write to cache (healthy frame), not restore
-    assert.equal(stdin.context_window.used_percentage, 58);
-    assert.equal(stdin.context_window.remaining_percentage, 42);
-
-    // Verify cache was written
-    const cachePath = getCachePath(tempHome, transcriptPath);
-    assert.equal(existsSync(cachePath), true);
-    const cacheContent = JSON.parse(await readFile(cachePath, 'utf8'));
-    assert.equal(cacheContent.used_percentage, 58);
   } finally {
     await rm(tempHome, { recursive: true, force: true });
   }

--- a/tests/context-cache.test.js
+++ b/tests/context-cache.test.js
@@ -29,6 +29,7 @@ function makeSuspiciousFrame(overrides = {}) {
     context_window: {
       context_window_size: 200000,
       total_input_tokens: 250000,
+      total_output_tokens: 250000,
       used_percentage: 0,
       remaining_percentage: 100,
       current_usage: {
@@ -170,7 +171,7 @@ test('applyContextWindowFallback ignores corrupted cache without throwing', asyn
   }
 });
 
-test('applyContextWindowFallback does not restore cache when zero frame has not overflowed the context window', async () => {
+test('applyContextWindowFallback restores cache even when zero frame has not overflowed (new branch 1 logic)', async () => {
   const tempHome = await createTempHome();
   const transcriptPath = '/tmp/session-a.jsonl';
 
@@ -194,13 +195,16 @@ test('applyContextWindowFallback does not restore cache when zero frame has not 
       'utf8',
     );
 
+    // With new branch 1 logic: totalInputTokens > 0 && usedPercentage === 0 triggers suspicious zero
+    // even when totalInputTokens <= contextWindowSize
     const stdin = makeSuspiciousFrame({ total_input_tokens: 200000 });
     stdin.transcript_path = transcriptPath;
 
     applyContextWindowFallback(stdin, makeDeps(tempHome));
 
-    assert.equal(stdin.context_window.used_percentage, 0);
-    assert.equal(stdin.context_window.remaining_percentage, 100);
+    // Should restore from cache because branch 1 detects it as suspicious
+    assert.equal(stdin.context_window.used_percentage, 61);
+    assert.equal(stdin.context_window.remaining_percentage, 39);
   } finally {
     await rm(tempHome, { recursive: true, force: true });
   }
@@ -556,6 +560,159 @@ test('_sweepCacheForTests evicts oldest entries when over the entry cap', async 
     for (let i = TOTAL - CAP; i < TOTAL; i += 1) {
       assert.equal(existsSync(path.join(cacheDir, `entry-${i}.json`)), true, `entry-${i} should survive`);
     }
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback detects suspicious zero when totalInputTokens > 0 but used_percentage is 0', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+
+  try {
+    // Seed cache with healthy data
+    applyContextWindowFallback(
+      makeHealthyFrame(transcriptPath),
+      makeDeps(tempHome, 1_000_000),
+    );
+
+    // Frame with totalInputTokens > 0 but used_percentage = 0 (branch 1)
+    const stdin = makeSuspiciousFrame({ total_input_tokens: 50000 });
+    stdin.transcript_path = transcriptPath;
+
+    applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
+
+    // Should restore from cache because it's suspicious
+    assert.equal(stdin.context_window.used_percentage, 58);
+    assert.equal(stdin.context_window.remaining_percentage, 42);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback detects suspicious zero when totalOutputTokens > 0 but used_percentage is 0', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+
+  try {
+    // Seed cache with healthy data
+    applyContextWindowFallback(
+      makeHealthyFrame(transcriptPath),
+      makeDeps(tempHome, 1_000_000),
+    );
+
+    // Frame with totalOutputTokens > 0 but used_percentage = 0 (branch 1)
+    const stdin = makeSuspiciousFrame({ total_input_tokens: 0, total_output_tokens: 3000 });
+    stdin.transcript_path = transcriptPath;
+
+    applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
+
+    // Should restore from cache because it's suspicious
+    assert.equal(stdin.context_window.used_percentage, 58);
+    assert.equal(stdin.context_window.remaining_percentage, 42);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback detects suspicious zero when both totalInputTokens and totalOutputTokens > 0 but used_percentage is 0', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+
+  try {
+    // Seed cache with healthy data
+    applyContextWindowFallback(
+      makeHealthyFrame(transcriptPath),
+      makeDeps(tempHome, 1_000_000),
+    );
+
+    // Frame with both tokens > 0 but used_percentage = 0 (branch 1)
+    const stdin = makeSuspiciousFrame({ total_input_tokens: 50000, total_output_tokens: 3000 });
+    stdin.transcript_path = transcriptPath;
+
+    applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
+
+    // Should restore from cache because it's suspicious
+    assert.equal(stdin.context_window.used_percentage, 58);
+    assert.equal(stdin.context_window.remaining_percentage, 42);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback does not treat as suspicious when all tokens and used_percentage are 0', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+
+  try {
+    // Seed cache with healthy data
+    applyContextWindowFallback(
+      makeHealthyFrame(transcriptPath),
+      makeDeps(tempHome, 1_000_000),
+    );
+
+    // Frame with all zeros - not suspicious by branch 1, falls through to branch 2
+    const stdin = makeSuspiciousFrame({ total_input_tokens: 0, total_output_tokens: 0 });
+    stdin.transcript_path = transcriptPath;
+
+    applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
+
+    // Should NOT restore from cache - branch 2 returns false (totalInputTokens <= contextWindowSize)
+    assert.equal(stdin.context_window.used_percentage, 0);
+    assert.equal(stdin.context_window.remaining_percentage, 100);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback does not treat as suspicious when contextWindowSize is 0', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+
+  try {
+    // Seed cache with healthy data
+    applyContextWindowFallback(
+      makeHealthyFrame(transcriptPath),
+      makeDeps(tempHome, 1_000_000),
+    );
+
+    // Frame with contextWindowSize = 0 - branch 1 triggers first
+    const stdin = makeSuspiciousFrame({ context_window_size: 0, total_input_tokens: 250000 });
+    stdin.transcript_path = transcriptPath;
+
+    applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
+
+    // Branch 1 triggers (totalInputTokens > 0 && usedPercentage === 0)
+    // So it should restore from cache
+    assert.equal(stdin.context_window.used_percentage, 58);
+    assert.equal(stdin.context_window.remaining_percentage, 42);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback does not treat as suspicious when used_percentage is non-zero', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+
+  try {
+    // Frame with non-zero used_percentage - not suspicious
+    const stdin = makeHealthyFrame(transcriptPath, {
+      total_input_tokens: 120000,
+      total_output_tokens: 5000,
+    });
+
+    applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
+
+    // Should write to cache (healthy frame), not restore
+    assert.equal(stdin.context_window.used_percentage, 58);
+    assert.equal(stdin.context_window.remaining_percentage, 42);
+
+    // Verify cache was written
+    const cachePath = getCachePath(tempHome, transcriptPath);
+    assert.equal(existsSync(cachePath), true);
+    const cacheContent = JSON.parse(await readFile(cachePath, 'utf8'));
+    assert.equal(cacheContent.used_percentage, 58);
   } finally {
     await rm(tempHome, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Fix a Claude Code data reporting glitch where `total_input_tokens` or `total_output_tokens` are non-zero, but all fields in `current_usage` are zero, causing `used_percentage` to incorrectly display as 0%.

## Problem

Claude Code sometimes sends malformed context window data like this:

```json
{
  "context_window": {
    "total_input_tokens": 978337,  // ← Non-zero accumulated tokens
    "total_output_tokens": 51018,  // ← Non-zero accumulated tokens
    "context_window_size": 1000000,
    "current_usage": {
      "input_tokens": 0,
      "output_tokens": 0,
      "cache_creation_input_tokens": 0,
      "cache_read_input_tokens": 0
    },
    "used_percentage": 0,  // ← Incorrectly shows 0% despite ~1M tokens used
    "remaining_percentage": 100
  }
}
```

Despite nearly 1 million tokens being consumed, the `current_usage` frame is entirely empty, causing the statusline to display 0% usage instead of the actual ~97% usage.

## Changes

- **types.ts**: Add `total_output_tokens` to `StdinData` interface
- **context-cache.ts**: Enhance `isSuspiciousZero()` detection logic:
  - **New condition**: Detect when accumulated totals (input or output) are non-zero but `used_percentage` is 0
  - **Existing condition**: Detect when total tokens exceed window size with zero usage
  - Update function documentation with detailed explanation of both trigger conditions
- **tests/context-cache.test.js**: Comprehensive test coverage for all `isSuspiciousZero()` branches:
  - New branch 1 logic: totalInputTokens/totalOutputTokens > 0 with usedPercentage === 0
  - Edge cases: zero tokens, zero window size, non-zero percentage
  - Updated existing test to align with new logic

## Solution

By checking both `total_input_tokens` and `total_output_tokens`, when either is non-zero but `used_percentage` is 0, the system now correctly identifies this as malformed data and triggers the cache fallback mechanism to use the last valid context snapshot.

## Test Plan

- [x] Code compiles and passes type checking
- [x] All 25 unit tests pass, including 6 new tests for branch coverage:
  - ✅ Detects suspicious zero when `totalInputTokens > 0` but `usedPercentage === 0`
  - ✅ Detects suspicious zero when `totalOutputTokens > 0` but `usedPercentage === 0`
  - ✅ Detects suspicious zero when both tokens > 0 but `usedPercentage === 0`
  - ✅ Does not treat as suspicious when all tokens and percentage are 0
  - ✅ Handles edge case when `contextWindowSize === 0`
  - ✅ Does not treat as suspicious when `used_percentage` is non-zero
- [x] Updated existing test to reflect new branch 1 logic behavior
- [ ] Verify statusline displays correct usage percentage when encountering malformed data
- [ ] Confirm legitimate zero-usage scenarios (session start) are unaffected
- [ ] Test with real Claude Code sessions exhibiting this glitch

## Technical Details

The fix adds an early detection path in `isSuspiciousZero()`:

```typescript
if ((totalInputTokens > 0 || totalOutputTokens > 0) && usedPercentage === 0) {
  return true;
}
```

This catches the glitch before the existing overflow detection logic, ensuring the statusline falls back to cached context data rather than displaying misleading 0% usage.

## Test Coverage

All conditional branches in `isSuspiciousZero()` are now fully tested:

1. **Branch 1** (new): Non-zero accumulated tokens with zero percentage → suspicious
2. **Branch 2**: No window size or tokens within bounds → not suspicious  
3. **Branch 3**: Non-zero percentage → not suspicious
4. **Branch 4**: All current_usage fields are zero → suspicious (existing logic)

Tests use helper functions (`makeSuspiciousFrame`, `makeHealthyFrame`) for consistency and maintainability.