### PR TITLE
fix(render): account for CJK ambiguous-width glyphs in width calculations

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -17,6 +17,7 @@ import {
 } from './lines/index.js';
 import { dim, RESET } from './colors.js';
 import { getTerminalWidth, UNKNOWN_TERMINAL_WIDTH } from '../utils/terminal.js';
+import { codePointCellWidth, isCjkAmbiguousWide } from './width.js';
 
 // eslint-disable-next-line no-control-regex
 const ANSI_ESCAPE_PATTERN = /^(?:\x1b\[[0-9;]*m|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\))/;
@@ -67,24 +68,7 @@ function segmentGraphemes(text: string): string[] {
   return Array.from(GRAPHEME_SEGMENTER.segment(text), segment => segment.segment);
 }
 
-function isWideCodePoint(codePoint: number): boolean {
-  return codePoint >= 0x1100 && (
-    codePoint <= 0x115F || // Hangul Jamo
-    codePoint === 0x2329 ||
-    codePoint === 0x232A ||
-    (codePoint >= 0x2E80 && codePoint <= 0xA4CF && codePoint !== 0x303F) ||
-    (codePoint >= 0xAC00 && codePoint <= 0xD7A3) ||
-    (codePoint >= 0xF900 && codePoint <= 0xFAFF) ||
-    (codePoint >= 0xFE10 && codePoint <= 0xFE19) ||
-    (codePoint >= 0xFE30 && codePoint <= 0xFE6F) ||
-    (codePoint >= 0xFF00 && codePoint <= 0xFF60) ||
-    (codePoint >= 0xFFE0 && codePoint <= 0xFFE6) ||
-    (codePoint >= 0x1F300 && codePoint <= 0x1FAFF) ||
-    (codePoint >= 0x20000 && codePoint <= 0x3FFFD)
-  );
-}
-
-function graphemeWidth(grapheme: string): number {
+function graphemeWidth(grapheme: string, ambiguousWide: boolean): number {
   if (!grapheme || /^\p{Control}$/u.test(grapheme)) {
     return 0;
   }
@@ -102,8 +86,8 @@ function graphemeWidth(grapheme: string): number {
     }
     hasVisibleBase = true;
     const codePoint = char.codePointAt(0);
-    if (codePoint !== undefined && isWideCodePoint(codePoint)) {
-      width = Math.max(width, 2);
+    if (codePoint !== undefined) {
+      width = Math.max(width, codePointCellWidth(codePoint, ambiguousWide));
     } else {
       width = Math.max(width, 1);
     }
@@ -113,13 +97,14 @@ function graphemeWidth(grapheme: string): number {
 }
 
 function visualLength(str: string): number {
+  const ambiguousWide = isCjkAmbiguousWide();
   let width = 0;
   for (const token of splitAnsiTokens(str)) {
     if (token.type === 'ansi') {
       continue;
     }
     for (const grapheme of segmentGraphemes(token.value)) {
-      width += graphemeWidth(grapheme);
+      width += graphemeWidth(grapheme, ambiguousWide);
     }
   }
   return width;
@@ -130,6 +115,7 @@ function sliceVisible(str: string, maxVisible: number): string {
     return '';
   }
 
+  const ambiguousWide = isCjkAmbiguousWide();
   let result = '';
   let visibleWidth = 0;
   let done = false;
@@ -154,7 +140,7 @@ function sliceVisible(str: string, maxVisible: number): string {
 
     const plainChunk = str.slice(i, j);
     for (const grapheme of segmentGraphemes(plainChunk)) {
-      const graphemeCellWidth = graphemeWidth(grapheme);
+      const graphemeCellWidth = graphemeWidth(grapheme, ambiguousWide);
       if (visibleWidth + graphemeCellWidth > maxVisible) {
         done = true;
         break;
@@ -285,8 +271,14 @@ function wrapLineToWidth(line: string, maxWidth: number): string[] {
   return wrapped;
 }
 
+// `length` is a target visual width in cells.
+// `─` (U+2500) is East Asian Ambiguous-width: rendered as 2 cells in CJK
+// terminals and 1 cell elsewhere. Repeating it `length` times in CJK mode
+// would double the visual width and force the terminal to wrap.
 function makeSeparator(length: number): string {
-  return dim('─'.repeat(Math.max(length, 1)));
+  const cellsPerDash = isCjkAmbiguousWide() ? 2 : 1;
+  const repeats = Math.max(1, Math.floor(length / cellsPerDash));
+  return dim('─'.repeat(repeats));
 }
 
 const ACTIVITY_ELEMENTS = new Set<HudElement>(['tools', 'agents', 'todos']);

--- a/src/render/lines/label-align.ts
+++ b/src/render/lines/label-align.ts
@@ -2,6 +2,7 @@ import type { HudColorOverrides } from "../../config.js";
 import type { MessageKey } from "../../i18n/types.js";
 import { label } from "../colors.js";
 import { t } from "../../i18n/index.js";
+import { codePointCellWidth, isCjkAmbiguousWide } from "../width.js";
 
 /** Label keys that should be aligned when rendered on separate lines. */
 const PROGRESS_LABEL_KEYS: MessageKey[] = [
@@ -13,36 +14,20 @@ const PROGRESS_LABEL_KEYS: MessageKey[] = [
 /**
  * Compute the visual width of a plain-text string (no ANSI).
  * CJK ideographs count as 2 cells; ASCII characters count as 1.
+ * In CJK locales, East Asian Ambiguous-width chars also count as 2.
  */
 function plainTextWidth(str: string): number {
+  const ambiguousWide = isCjkAmbiguousWide();
   let width = 0;
   for (const char of str) {
     const cp = char.codePointAt(0);
-    if (cp !== undefined && isWideCodePoint(cp)) {
-      width += 2;
+    if (cp !== undefined) {
+      width += codePointCellWidth(cp, ambiguousWide);
     } else {
       width += 1;
     }
   }
   return width;
-}
-
-function isWideCodePoint(codePoint: number): boolean {
-  return (
-    codePoint >= 0x1100 &&
-    (codePoint <= 0x115f ||
-      codePoint === 0x2329 ||
-      codePoint === 0x232a ||
-      (codePoint >= 0x2e80 && codePoint <= 0xa4cf && codePoint !== 0x303f) ||
-      (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
-      (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
-      (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
-      (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
-      (codePoint >= 0xff00 && codePoint <= 0xff60) ||
-      (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
-      (codePoint >= 0x1f300 && codePoint <= 0x1faff) ||
-      (codePoint >= 0x20000 && codePoint <= 0x3fffd))
-  );
 }
 
 /** Compute the max visual width across the three progress-bar labels. */

--- a/src/render/width.ts
+++ b/src/render/width.ts
@@ -1,0 +1,53 @@
+import { getLanguage } from '../i18n/index.js';
+
+// CJK terminals render East Asian Ambiguous-width chars (box drawing,
+// block elements, arrows, etc.) as 2 cells. The HUD bar/separator/icon
+// glyphs fall in those ranges, so width math must follow suit when the
+// user's language is CJK — otherwise wrap calculations under-report
+// visual width and the terminal itself wraps.
+export function isCjkAmbiguousWide(): boolean {
+  return getLanguage() === 'zh';
+}
+
+export function isWideCodePoint(codePoint: number): boolean {
+  return codePoint >= 0x1100 && (
+    codePoint <= 0x115F || // Hangul Jamo
+    codePoint === 0x2329 ||
+    codePoint === 0x232A ||
+    (codePoint >= 0x2E80 && codePoint <= 0xA4CF && codePoint !== 0x303F) ||
+    (codePoint >= 0xAC00 && codePoint <= 0xD7A3) ||
+    (codePoint >= 0xF900 && codePoint <= 0xFAFF) ||
+    (codePoint >= 0xFE10 && codePoint <= 0xFE19) ||
+    (codePoint >= 0xFE30 && codePoint <= 0xFE6F) ||
+    (codePoint >= 0xFF00 && codePoint <= 0xFF60) ||
+    (codePoint >= 0xFFE0 && codePoint <= 0xFFE6) ||
+    (codePoint >= 0x1F300 && codePoint <= 0x1FAFF) ||
+    (codePoint >= 0x20000 && codePoint <= 0x3FFFD)
+  );
+}
+
+// East Asian Ambiguous-width ranges actually emitted by the HUD:
+// box drawing (│ ─), block elements (█ ░), geometric shapes (◐ ● ▸),
+// arrows (↑ ↓ →), math operators (≤ ≥), misc symbols (⚠), dingbats
+// (✓ ✘), general punctuation (— …), misc technical (⏱).
+export function isAmbiguousWideCodePoint(codePoint: number): boolean {
+  if (codePoint < 0x2010) return false;
+  return (
+    (codePoint >= 0x2010 && codePoint <= 0x2027) ||
+    (codePoint >= 0x2030 && codePoint <= 0x205E) ||
+    (codePoint >= 0x2190 && codePoint <= 0x21FF) ||
+    (codePoint >= 0x2200 && codePoint <= 0x22FF) ||
+    (codePoint >= 0x2300 && codePoint <= 0x23FF) ||
+    (codePoint >= 0x2460 && codePoint <= 0x24FF) ||
+    (codePoint >= 0x2500 && codePoint <= 0x259F) ||
+    (codePoint >= 0x25A0 && codePoint <= 0x25FF) ||
+    (codePoint >= 0x2600 && codePoint <= 0x26FF) ||
+    (codePoint >= 0x2700 && codePoint <= 0x27BF)
+  );
+}
+
+export function codePointCellWidth(codePoint: number, ambiguousWide: boolean): number {
+  if (isWideCodePoint(codePoint)) return 2;
+  if (ambiguousWide && isAmbiguousWideCodePoint(codePoint)) return 2;
+  return 1;
+}

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -565,3 +565,133 @@ test('render respects terminal width with Chinese labels enabled', () => {
   assert.ok(lines.some(line => line.includes('用量')), 'should render the translated usage label');
   assert.ok(lines.every(line => displayWidth(line) <= 18), 'all lines should fit terminal width with CJK labels');
 });
+
+// CJK terminals render East Asian Ambiguous chars (█ ░ │ ◐ ✓ etc.) as 2 cells.
+// Without compensating width math, lines that look short to the code overflow
+// the visible terminal and get wrapped by the terminal itself.
+function ambiguousDisplayWidth(text) {
+  let width = 0;
+  for (const char of Array.from(text)) {
+    const cp = char.codePointAt(0);
+    if (cp === undefined) {
+      width += 1;
+      continue;
+    }
+    if (isWideCodePoint(cp)) {
+      width += 2;
+      continue;
+    }
+    const isAmbiguousWide =
+      (cp >= 0x2010 && cp <= 0x2027) ||
+      (cp >= 0x2030 && cp <= 0x205E) ||
+      (cp >= 0x2190 && cp <= 0x21FF) ||
+      (cp >= 0x2200 && cp <= 0x22FF) ||
+      (cp >= 0x2300 && cp <= 0x23FF) ||
+      (cp >= 0x2460 && cp <= 0x24FF) ||
+      (cp >= 0x2500 && cp <= 0x259F) ||
+      (cp >= 0x25A0 && cp <= 0x25FF) ||
+      (cp >= 0x2600 && cp <= 0x26FF) ||
+      (cp >= 0x2700 && cp <= 0x27BF);
+    width += isAmbiguousWide ? 2 : 1;
+  }
+  return width;
+}
+
+test('render wraps progress bars when CJK ambiguous-width chars overflow the terminal', () => {
+  const ctx = baseContext();
+  ctx.config.language = 'zh';
+  ctx.config.lineLayout = 'expanded';
+  ctx.config.display.showUsage = true;
+  ctx.config.display.usageBarEnabled = true;
+  ctx.usageData = {
+    fiveHour: 49,
+    sevenDay: null,
+    fiveHourResetAt: new Date(Date.now() + 3 * 3600 * 1000 + 12 * 60 * 1000),
+    sevenDayResetAt: null,
+  };
+
+  let cjkLines = [];
+  setLanguage('zh');
+  try {
+    withTerminal(40, () => {
+      cjkLines = captureRender(ctx);
+    });
+  } finally {
+    setLanguage('en');
+  }
+
+  assert.ok(
+    cjkLines.every(line => ambiguousDisplayWidth(line) <= 40),
+    'no line should overflow 40 cells when ambiguous-width chars count as 2',
+  );
+
+  let enLines = [];
+  withTerminal(40, () => {
+    enLines = captureRender(ctx);
+  });
+  assert.ok(enLines.length > 0, 'non-CJK mode should still produce output');
+});
+
+test('separator width accounts for CJK ambiguous-wide dashes so the terminal does not wrap it', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.config.showSeparators = true;
+  ctx.config.display.showContextBar = true;
+  ctx.config.display.showUsage = true;
+  ctx.config.display.usageBarEnabled = true;
+  ctx.usageData = {
+    fiveHour: 49,
+    sevenDay: null,
+    fiveHourResetAt: new Date(Date.now() + 3 * 3600 * 1000),
+    sevenDayResetAt: null,
+  };
+  ctx.transcript.tools = [
+    { id: 'tool-1', name: 'Read', status: 'completed', startTime: new Date(0), endTime: new Date(0), duration: 0 },
+  ];
+
+  let cjkLines = [];
+  setLanguage('zh');
+  try {
+    withTerminal(120, () => {
+      cjkLines = captureRender(ctx);
+    });
+  } finally {
+    setLanguage('en');
+  }
+
+  const separatorLines = cjkLines.filter(line => /^[\s─]+$/.test(line));
+  assert.equal(separatorLines.length, 1, 'separator should render exactly once and not be split into multiple lines');
+  assert.ok(
+    ambiguousDisplayWidth(separatorLines[0]) <= 120,
+    `separator visual width must fit terminal in CJK mode (got ${ambiguousDisplayWidth(separatorLines[0])} cells, terminal=120)`,
+  );
+
+  for (const line of cjkLines) {
+    assert.ok(
+      ambiguousDisplayWidth(line) <= 120,
+      `line "${line}" exceeds 120 cells in CJK mode (got ${ambiguousDisplayWidth(line)})`,
+    );
+  }
+});
+
+
+test('width math counts ambiguous chars as 2 cells only in CJK mode', async () => {
+  const { codePointCellWidth, isAmbiguousWideCodePoint, isCjkAmbiguousWide } =
+    await import('../dist/render/width.js');
+
+  assert.equal(isAmbiguousWideCodePoint(0x2588), true, '█ U+2588 is ambiguous');
+  assert.equal(isAmbiguousWideCodePoint(0x2502), true, '│ U+2502 is ambiguous');
+  assert.equal(isAmbiguousWideCodePoint(0x0041), false, 'ASCII A is not ambiguous');
+
+  setLanguage('zh');
+  try {
+    assert.equal(isCjkAmbiguousWide(), true);
+    assert.equal(codePointCellWidth(0x2588, isCjkAmbiguousWide()), 2);
+    assert.equal(codePointCellWidth(0x0041, isCjkAmbiguousWide()), 1);
+  } finally {
+    setLanguage('en');
+  }
+
+  assert.equal(isCjkAmbiguousWide(), false);
+  assert.equal(codePointCellWidth(0x2588, isCjkAmbiguousWide()), 1);
+});


### PR DESCRIPTION
## Summary

- East Asian Ambiguous-width characters (`█` `░` `│` `⚠` `─` etc.) render as 2 cells in CJK terminals but were counted as 1 cell in width calculations
- This caused lines to overflow the terminal width without the code knowing, leading to broken wrapping and display issues in Claude Code's statusline UI
- Adds `src/render/width.ts` with `codePointCellWidth()` and `isCjkAmbiguousWide()` to detect CJK mode (when `language: 'zh'`) and account for double-width ambiguous chars
- Updates `visualLength()`, `makeSeparator()`, and label alignment to use the new CJK-aware width math

## Test plan

- [x] Added unit tests for `codePointCellWidth`, `isAmbiguousWideCodePoint`, `isCjkAmbiguousWide`
- [x] Added integration test: progress bars wrap correctly in CJK mode at narrow widths
- [x] Added integration test: separator `─` repeats halved in CJK mode so it doesn't overflow
- [x] Full test suite passes (511/511)