### PR TITLE
fix: detect statusline width from controlling terminal

### DIFF
--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs';
+import * as tty from 'node:tty';
+
 export const UNKNOWN_TERMINAL_WIDTH = null;
 
 function parseEnvColumns(): number | null {
@@ -11,6 +14,33 @@ function parseStreamColumns(columns: unknown): number | null {
     : null;
 }
 
+function parseControllingTerminalColumns(): number | null {
+  if (process.platform === 'win32' || process.env.CLAUDE_HUD_DISABLE_TTY_WIDTH === '1') {
+    return null;
+  }
+
+  let fd: number | null = null;
+  let stream: tty.WriteStream | null = null;
+  try {
+    fd = fs.openSync('/dev/tty', 'r+');
+    stream = new tty.WriteStream(fd);
+    fd = null;
+    return parseStreamColumns(stream.columns);
+  } catch {
+    return null;
+  } finally {
+    if (stream) {
+      stream.destroy();
+    } else if (fd !== null) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // Ignore close errors; width detection is best-effort.
+      }
+    }
+  }
+}
+
 export function getTerminalWidth(options: { preferEnv?: boolean; fallback?: number | null } = {}): number | null {
   const { preferEnv = false, fallback = null } = options;
 
@@ -18,12 +48,14 @@ export function getTerminalWidth(options: { preferEnv?: boolean; fallback?: numb
     return parseEnvColumns()
       ?? parseStreamColumns(process.stdout?.columns)
       ?? parseStreamColumns(process.stderr?.columns)
+      ?? parseControllingTerminalColumns()
       ?? fallback;
   }
 
   return parseStreamColumns(process.stdout?.columns)
     ?? parseStreamColumns(process.stderr?.columns)
     ?? parseEnvColumns()
+    ?? parseControllingTerminalColumns()
     ?? fallback;
 }
 

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -3,6 +3,22 @@ import * as tty from 'node:tty';
 
 export const UNKNOWN_TERMINAL_WIDTH = null;
 
+type TtyWriteStreamLike = Pick<tty.WriteStream, 'columns' | 'destroy'>;
+type TtyWidthProbeDeps = {
+  openSync: typeof fs.openSync;
+  closeSync: typeof fs.closeSync;
+  createWriteStream: (fd: number) => TtyWriteStreamLike;
+};
+
+const DEFAULT_TTY_WIDTH_PROBE_DEPS: TtyWidthProbeDeps = {
+  openSync: fs.openSync,
+  closeSync: fs.closeSync,
+  createWriteStream: fd => new tty.WriteStream(fd),
+};
+
+let ttyWidthProbeDeps = DEFAULT_TTY_WIDTH_PROBE_DEPS;
+let cachedControllingTerminalColumns: number | null | undefined;
+
 function parseEnvColumns(): number | null {
   const envColumns = Number.parseInt(process.env.COLUMNS ?? '', 10);
   return Number.isFinite(envColumns) && envColumns > 0 ? envColumns : null;
@@ -14,31 +30,42 @@ function parseStreamColumns(columns: unknown): number | null {
     : null;
 }
 
-function parseControllingTerminalColumns(): number | null {
-  if (process.platform === 'win32' || process.env.CLAUDE_HUD_DISABLE_TTY_WIDTH === '1') {
-    return null;
-  }
-
+function readControllingTerminalColumns(): number | null {
   let fd: number | null = null;
-  let stream: tty.WriteStream | null = null;
+  let stream: TtyWriteStreamLike | null = null;
   try {
-    fd = fs.openSync('/dev/tty', 'r+');
-    stream = new tty.WriteStream(fd);
+    fd = ttyWidthProbeDeps.openSync('/dev/tty', 'r+');
+    stream = ttyWidthProbeDeps.createWriteStream(fd);
     fd = null;
     return parseStreamColumns(stream.columns);
   } catch {
     return null;
   } finally {
+    // Once tty.WriteStream is constructed, it owns the fd; destroy only the
+    // stream to avoid double-closing under Node or Bun-compatible runtimes.
     if (stream) {
       stream.destroy();
     } else if (fd !== null) {
       try {
-        fs.closeSync(fd);
+        ttyWidthProbeDeps.closeSync(fd);
       } catch {
         // Ignore close errors; width detection is best-effort.
       }
     }
   }
+}
+
+function parseControllingTerminalColumns(): number | null {
+  if (process.platform === 'win32' || process.env.CLAUDE_HUD_DISABLE_TTY_WIDTH === '1') {
+    return null;
+  }
+
+  if (cachedControllingTerminalColumns !== undefined) {
+    return cachedControllingTerminalColumns;
+  }
+
+  cachedControllingTerminalColumns = readControllingTerminalColumns();
+  return cachedControllingTerminalColumns;
 }
 
 export function getTerminalWidth(options: { preferEnv?: boolean; fallback?: number | null } = {}): number | null {
@@ -70,4 +97,15 @@ export function getAdaptiveBarWidth(): number {
     return 4;
   }
   return 10;
+}
+
+export function _resetTerminalWidthCacheForTests(): void {
+  cachedControllingTerminalColumns = undefined;
+}
+
+export function _setTtyWidthProbeDepsForTests(deps: Partial<TtyWidthProbeDeps> | null): void {
+  ttyWidthProbeDeps = deps
+    ? { ...DEFAULT_TTY_WIDTH_PROBE_DEPS, ...deps }
+    : DEFAULT_TTY_WIDTH_PROBE_DEPS;
+  _resetTerminalWidthCacheForTests();
 }

--- a/tests/terminal.test.js
+++ b/tests/terminal.test.js
@@ -6,12 +6,15 @@ describe('getAdaptiveBarWidth', () => {
   let originalStdoutColumns;
   let originalStderrColumns;
   let originalEnvColumns;
+  let originalDisableTtyWidth;
 
   beforeEach(() => {
     originalStdoutColumns = Object.getOwnPropertyDescriptor(process.stdout, 'columns');
     originalStderrColumns = Object.getOwnPropertyDescriptor(process.stderr, 'columns');
     originalEnvColumns = process.env.COLUMNS;
+    originalDisableTtyWidth = process.env.CLAUDE_HUD_DISABLE_TTY_WIDTH;
     delete process.env.COLUMNS;
+    process.env.CLAUDE_HUD_DISABLE_TTY_WIDTH = '1';
   });
 
   afterEach(() => {
@@ -29,6 +32,11 @@ describe('getAdaptiveBarWidth', () => {
       process.env.COLUMNS = originalEnvColumns;
     } else {
       delete process.env.COLUMNS;
+    }
+    if (originalDisableTtyWidth !== undefined) {
+      process.env.CLAUDE_HUD_DISABLE_TTY_WIDTH = originalDisableTtyWidth;
+    } else {
+      delete process.env.CLAUDE_HUD_DISABLE_TTY_WIDTH;
     }
   });
 

--- a/tests/terminal.test.js
+++ b/tests/terminal.test.js
@@ -1,6 +1,11 @@
 import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { getAdaptiveBarWidth } from '../dist/utils/terminal.js';
+import {
+  _resetTerminalWidthCacheForTests,
+  _setTtyWidthProbeDepsForTests,
+  getAdaptiveBarWidth,
+  getTerminalWidth,
+} from '../dist/utils/terminal.js';
 
 describe('getAdaptiveBarWidth', () => {
   let originalStdoutColumns;
@@ -15,9 +20,12 @@ describe('getAdaptiveBarWidth', () => {
     originalDisableTtyWidth = process.env.CLAUDE_HUD_DISABLE_TTY_WIDTH;
     delete process.env.COLUMNS;
     process.env.CLAUDE_HUD_DISABLE_TTY_WIDTH = '1';
+    _resetTerminalWidthCacheForTests();
   });
 
   afterEach(() => {
+    _setTtyWidthProbeDepsForTests(null);
+    _resetTerminalWidthCacheForTests();
     if (originalStdoutColumns) {
       Object.defineProperty(process.stdout, 'columns', originalStdoutColumns);
     } else {
@@ -104,5 +112,83 @@ describe('getAdaptiveBarWidth', () => {
     Object.defineProperty(process.stderr, 'columns', { value: undefined, configurable: true });
     delete process.env.COLUMNS;
     assert.equal(getAdaptiveBarWidth(), 10);
+  });
+
+  test('falls back to cached controlling terminal columns when streams are unavailable', () => {
+    let openCalls = 0;
+    let destroyCalls = 0;
+    let closeCalls = 0;
+    Object.defineProperty(process.stdout, 'columns', { value: undefined, configurable: true });
+    Object.defineProperty(process.stderr, 'columns', { value: undefined, configurable: true });
+    delete process.env.COLUMNS;
+    delete process.env.CLAUDE_HUD_DISABLE_TTY_WIDTH;
+    _setTtyWidthProbeDepsForTests({
+      openSync(path, flags) {
+        openCalls += 1;
+        assert.equal(path, '/dev/tty');
+        assert.equal(flags, 'r+');
+        return 42;
+      },
+      createWriteStream(fd) {
+        assert.equal(fd, 42);
+        return {
+          columns: 88,
+          destroy() {
+            destroyCalls += 1;
+          },
+        };
+      },
+      closeSync() {
+        closeCalls += 1;
+      },
+    });
+
+    assert.equal(getTerminalWidth(), 88);
+    assert.equal(getAdaptiveBarWidth(), 6);
+    assert.equal(getTerminalWidth({ preferEnv: true }), 88);
+    assert.equal(openCalls, 1, 'tty should be opened once per process');
+    assert.equal(destroyCalls, 1, 'constructed tty stream should be destroyed once');
+    assert.equal(closeCalls, 0, 'constructed tty stream owns the fd');
+  });
+
+  test('falls back and caches null when controlling terminal is unavailable', () => {
+    let openCalls = 0;
+    Object.defineProperty(process.stdout, 'columns', { value: undefined, configurable: true });
+    Object.defineProperty(process.stderr, 'columns', { value: undefined, configurable: true });
+    delete process.env.COLUMNS;
+    delete process.env.CLAUDE_HUD_DISABLE_TTY_WIDTH;
+    _setTtyWidthProbeDepsForTests({
+      openSync() {
+        openCalls += 1;
+        throw new Error('no controlling terminal');
+      },
+    });
+
+    assert.equal(getTerminalWidth({ fallback: 72 }), 72);
+    assert.equal(getTerminalWidth({ fallback: 80 }), 80);
+    assert.equal(openCalls, 1, 'unavailable tty should not be reprobed in the same process');
+  });
+
+  test('closes the fd when tty stream construction fails', () => {
+    let closeCalls = 0;
+    Object.defineProperty(process.stdout, 'columns', { value: undefined, configurable: true });
+    Object.defineProperty(process.stderr, 'columns', { value: undefined, configurable: true });
+    delete process.env.COLUMNS;
+    delete process.env.CLAUDE_HUD_DISABLE_TTY_WIDTH;
+    _setTtyWidthProbeDepsForTests({
+      openSync() {
+        return 43;
+      },
+      createWriteStream() {
+        throw new Error('constructor failed');
+      },
+      closeSync(fd) {
+        closeCalls += 1;
+        assert.equal(fd, 43);
+      },
+    });
+
+    assert.equal(getTerminalWidth({ fallback: 90 }), 90);
+    assert.equal(closeCalls, 1);
   });
 });


### PR DESCRIPTION
## Summary

- When the statusline process's stdout is piped to Claude Code, `process.stdout.columns` is `undefined` and terminal width detection fails
- Falls back to a hardcoded default (120) even when the real terminal is narrower or wider, causing broken wrapping or wasted space
- Adds `/dev/tty` fallback: opens the controlling terminal directly to query its column count when stdout/stderr streams and `COLUMNS` env are all unavailable
- Skipped on Windows (no `/dev/tty`) and when `CLAUDE_HUD_DISABLE_TTY_WIDTH=1` is set (for testing)

## Test plan

- [x] Updated `tests/terminal.test.js` to set `CLAUDE_HUD_DISABLE_TTY_WIDTH=1` in the test harness so unit tests don't accidentally read the real terminal
- [x] Full test suite passes (508/508)
- [x] Manual verification: statusline correctly detects terminal width in Ghostty, iTerm2, and Terminal.app when stdout is piped