### PR TITLE
fix: simplify COLUMNS detection in setup to avoid stty/awk fragility

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -150,32 +150,23 @@ This is a [Claude Code platform limitation](https://github.com/anthropics/claude
 
 5. Generate command (quotes around runtime path handle spaces):
 
-   The command exports `COLUMNS` so the HUD knows the real terminal width.
-   Claude Code pipes the subprocess stdout, so `process.stdout.columns` is
-   unavailable at runtime. `stty size </dev/tty` reads from the controlling
-   terminal. The `- 4` accounts for Claude Code's input area padding
-   (2 columns on each side).
+   Claude Code sets the `COLUMNS` environment variable before invoking the
+   statusLine command, so no terminal probing (`stty`/`tput`) is needed.
+   Fall back to 120 if the variable is somehow unset.
 
-   The grep pattern uses `[[:space:]]` rather than `\t` to match the tab
-   separator emitted by awk. GNU grep (BRE/ERE) does **not** interpret
-   `\t` as a tab character — it emits `warning: stray \ before t` and
-   treats the pattern as literal `t`, so the regex never matches the awk
-   output and `plugin_dir` resolves to an empty string. The runtime then
-   exits with `Module not found "src/index.ts"` and no HUD appears.
-   Setup verification can hide this because some shells alias `grep` to
-   alternatives (e.g. `ugrep`) that *do* expand `\t`, while the actual
-   `statusLine` subprocess invokes `/usr/bin/grep`. `[[:space:]]` is a
-   POSIX character class supported by both BSD grep (macOS default) and
-   GNU grep (Linux default).
+   Use `ls -dt` (sort by modification time, newest first) with `head -1`
+   to find the latest plugin version. This avoids the complex awk/grep/sort
+   pipeline and its shell-quoting pitfalls (nested single quotes inside
+   `bash -c`, `[[:space:]]` regex portability, etc.).
 
    **When runtime is bun** - add `--env-file /dev/null` to prevent Bun from auto-loading project `.env` files:
    ```
-   bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | grep -E '"'"'^[0-9]+\.[0-9]+\.[0-9]+[[:space:]]'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
+   bash -c 'export COLUMNS=${COLUMNS:-120}; plugin_dir=$(ls -dt "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | head -1); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
    ```
 
    **When runtime is node**:
    ```
-   bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | grep -E '"'"'^[0-9]+\.[0-9]+\.[0-9]+[[:space:]]'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
+   bash -c 'export COLUMNS=${COLUMNS:-120}; plugin_dir=$(ls -dt "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | head -1); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
    ```
 
 **Windows + Git Bash** (Platform: `win32`, Shell: `bash`):
@@ -184,12 +175,14 @@ Do not use PowerShell commands when the shell is bash. Claude Code invokes statu
 
 On Windows require `node` and always use `dist/index.js`.
 
-**Important**: Do **not** reuse the macOS/Linux awk-based command on Windows + Git Bash. The `awk` fragment requires `'"'"'` quoting to nest single quotes inside `bash -c '...'`. After JSON encoding and decoding, this quoting breaks on Windows Git Bash, causing a silent syntax error that prevents the HUD process from starting (see [#326](https://github.com/jarrodwatts/claude-hud/issues/326)).
-
-Instead, use `sort -V` (GNU version sort, included with Git for Windows) which avoids nested single quotes entirely. Also avoid wrapping the generated command in a second `bash -c ...` layer. Claude Code is already invoking the statusline through bash, so the direct shell command lets `exec` replace that shell instead of spawning an extra bash wrapper first. The command still exports `COLUMNS` so the HUD receives the real terminal width, and it uses the marketplace-aware cache glob:
+Claude Code already sets `COLUMNS` before invoking statusLine commands, so no
+terminal probing is needed. Use `sort -V` (GNU version sort, included with Git
+for Windows) for version directory lookup. Avoid wrapping the generated command
+in a second `bash -c ...` layer — Claude Code is already invoking the statusline
+through bash, so the direct shell command lets `exec` replace that shell.
 
    ```
-   cols=$(stty size </dev/tty 2>/dev/null | awk '{print $2}'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -1d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | sort -V | tail -1); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"
+   export COLUMNS=${COLUMNS:-120}; plugin_dir=$(ls -1d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | sort -V | tail -1); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"
    ```
 
 **Windows + PowerShell** (Platform: `win32`, Shell: `powershell`, `pwsh`, or `cmd`):


### PR DESCRIPTION
## Problem

The current setup.md instructs the LLM to generate a `statusLine.command` that probes terminal width with:

```bash
cols=$(stty size </dev/tty 2>/dev/null | awk '{print $2}')
```

This approach has two failure modes:

1. **LLM misinterpretation**: The shell quoting is extremely complex (`'"'"'` to nest single quotes). LLMs frequently drop the `$2`, generating `awk '{print }'` instead of `awk '{print $2}'`. When `/dev/tty` is available (macOS desktop app), `stty size` returns `"rows cols"`, `awk '{print }'` outputs both numbers, and the bash arithmetic `$(( 24 80 > 4 ? ... ))` hits a syntax error. The entire wrapper exits before reaching Node.js, and the HUD never appears. See #512.

2. **Unnecessary complexity**: Claude Code already sets the `COLUMNS` environment variable before invoking statusLine commands, making the `stty` probe redundant. If `/dev/tty` is unavailable, the fallback to 120 is used anyway.

## Fix

- Replace `stty` + `awk` terminal probing with `${COLUMNS:-120}`
- Replace the complex `awk/grep/sort` version-lookup pipeline with `ls -dt .../claude-hud/*/ | head -1` on macOS/Linux
- Update Windows + Git Bash instructions to also use `${COLUMNS:-120}`

## Test plan

- [x] Verified the simplified command works on macOS with Node.js
- [x] The command produces correct HUD output when stdin is provided
- [x] No regression in plugin path resolution