### PR TITLE
fix: use queue-operation timestamps for accurate background agent duration

### DIFF
--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -238,6 +238,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   const agentMap = new Map<string, AgentEntry>();
   let latestTodos: TodoItem[] = [];
   const taskIdToIndex = new Map<string, number>();
+  const queueCompletionMap = new Map<string, Date>();
   let latestSlug: string | undefined;
   let customTitle: string | undefined;
   let lastCompactBoundaryAt: Date | undefined;
@@ -292,6 +293,19 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
             }
           }
         }
+        // Capture accurate background-agent completion timestamps from queue-operation entries.
+        // The tool_result timestamp in the parent transcript is written at launch time, not
+        // when the agent actually finishes, so we override with the enqueue timestamp.
+        if (entry.type === 'queue-operation' && entry.operation === 'enqueue' && entry.content) {
+          const taskIdMatch = entry.content.match(/<task-id>([^<]+)<\/task-id>/);
+          const toolUseIdMatch = entry.content.match(/<tool-use-id>([^<]+)<\/tool-use-id>/);
+          if (taskIdMatch && toolUseIdMatch && entry.timestamp) {
+            const ts = new Date(entry.timestamp);
+            if (!Number.isNaN(ts.getTime())) {
+              queueCompletionMap.set(toolUseIdMatch[1], ts);
+            }
+          }
+        }
         processEntry(entry, toolMap, agentMap, taskIdToIndex, latestTodos, result);
       } catch {
         // Skip malformed lines
@@ -303,6 +317,13 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
     // Return partial results on error
   }
 
+  // Override agent endTimes with accurate queue-operation timestamps where available
+  for (const [toolUseId, endTime] of queueCompletionMap) {
+    const agent = agentMap.get(toolUseId);
+    if (agent) {
+      agent.endTime = endTime;
+    }
+  }
   result.tools = Array.from(toolMap.values()).slice(-20);
   result.agents = Array.from(agentMap.values()).slice(-10);
   result.todos = latestTodos;


### PR DESCRIPTION
## Problem

Background agents (`run_in_background: true`) show wildly inaccurate durations in the HUD. For example, an agent that ran for 77 seconds shows as "4s", and a 93-second agent shows as "<1s".

**Root cause**: In the parent transcript, the `tool_result` entry for background agents is written near launch time (not when the agent completes), so the transcript timestamp difference between `tool_use` and `tool_result` is typically 0-8 seconds — even for agents that ran for minutes.

## Evidence

From a real transcript (all agents `run_in_background: true`):

| Agent | Transcript duration | Queue-op duration | Actual wall-clock |
|-------|-------------------|-------------------|-------------------|
| Long task X | 4s | 82s | ~77s |
| Long task Y | 0s | 93s | ~93s |
| Slow task A | 8s | 71s | ~62s |

## Fix

Parse `queue-operation` entries in the transcript. These entries contain accurate completion timestamps and the `<task-id>` → `<tool-use-id>` mapping:

```xml
<task-notification>
  <task-id>a0d1fbeb82232a5a4</task-id>
  <tool-use-id>call_00_COFVZvzwVlcSu4WRMUPXLfze</tool-use-id>
</task-notification>
```

Override agent `endTime` with the queue-operation timestamp when available.

## Test plan

- [x] Verified correct durations on a transcript with 10 background agents
- [x] No regression for inline agents (no queue-operation entries)
- [x] Cache invalidation works correctly (mtime/size-based)