### PR TITLE
fix: defer background agent completion to queue-operation for accurate timing and ◐ icon

### DIFF
--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -317,11 +317,19 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
     // Return partial results on error
   }
 
-  // Override agent endTimes with accurate queue-operation timestamps where available
+  // Resolve agent completion: prefer queue-operation timestamps (accurate for
+  // background agents), fall back to tool_result timestamps (inline agents).
+  // Status is deferred so background agents show ◐ until they truly finish.
   for (const [toolUseId, endTime] of queueCompletionMap) {
     const agent = agentMap.get(toolUseId);
     if (agent) {
       agent.endTime = endTime;
+      agent.status = 'completed';
+    }
+  }
+  for (const agent of agentMap.values()) {
+    if (agent.status === 'running' && agent.endTime) {
+      agent.status = 'completed';
     }
   }
   result.tools = Array.from(toolMap.values()).slice(-20);
@@ -383,6 +391,7 @@ function processEntry(
           description: (input?.description as string) ?? undefined,
           status: 'running',
           startTime: timestamp,
+          background: (input?.run_in_background as boolean) === true,
         };
         agentMap.set(block.id, agentEntry);
       } else if (block.name === 'TodoWrite') {
@@ -468,8 +477,7 @@ function processEntry(
       }
 
       const agent = agentMap.get(block.tool_use_id);
-      if (agent) {
-        agent.status = 'completed';
+      if (agent && !agent.background) {
         agent.endTime = timestamp;
       }
     }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -238,6 +238,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   const agentMap = new Map<string, AgentEntry>();
   let latestTodos: TodoItem[] = [];
   const taskIdToIndex = new Map<string, number>();
+  const queueCompletionMap = new Map<string, Date>();
   let latestSlug: string | undefined;
   let customTitle: string | undefined;
   let lastCompactBoundaryAt: Date | undefined;
@@ -292,6 +293,19 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
             }
           }
         }
+        // Capture accurate background-agent completion timestamps from queue-operation entries.
+        // The tool_result timestamp in the parent transcript is written at launch time, not
+        // when the agent actually finishes, so we override with the enqueue timestamp.
+        if (entry.type === 'queue-operation' && entry.operation === 'enqueue' && entry.content) {
+          const taskIdMatch = entry.content.match(/<task-id>([^<]+)<\/task-id>/);
+          const toolUseIdMatch = entry.content.match(/<tool-use-id>([^<]+)<\/tool-use-id>/);
+          if (taskIdMatch && toolUseIdMatch && entry.timestamp) {
+            const ts = new Date(entry.timestamp);
+            if (!Number.isNaN(ts.getTime())) {
+              queueCompletionMap.set(toolUseIdMatch[1], ts);
+            }
+          }
+        }
         processEntry(entry, toolMap, agentMap, taskIdToIndex, latestTodos, result);
       } catch {
         // Skip malformed lines
@@ -303,6 +317,13 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
     // Return partial results on error
   }
 
+  // Override agent endTimes with accurate queue-operation timestamps where available
+  for (const [toolUseId, endTime] of queueCompletionMap) {
+    const agent = agentMap.get(toolUseId);
+    if (agent) {
+      agent.endTime = endTime;
+    }
+  }
   result.tools = Array.from(toolMap.values()).slice(-20);
   result.agents = Array.from(agentMap.values()).slice(-10);
   result.todos = latestTodos;

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -10,6 +10,8 @@ interface TranscriptLine {
   timestamp?: string;
   type?: string;
   subtype?: string;
+  operation?: string;
+  content?: string;
   slug?: string;
   customTitle?: string;
   message?: {
@@ -322,7 +324,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   // Status is deferred so background agents show ◐ until they truly finish.
   for (const [toolUseId, endTime] of queueCompletionMap) {
     const agent = agentMap.get(toolUseId);
-    if (agent) {
+    if (agent?.background) {
       agent.endTime = endTime;
       agent.status = 'completed';
     }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -74,7 +74,7 @@ interface TranscriptCacheFile {
   data: SerializedTranscriptData;
 }
 
-const TRANSCRIPT_CACHE_VERSION = 3;
+const TRANSCRIPT_CACHE_VERSION = 4;
 
 let createReadStreamImpl: typeof fs.createReadStream = fs.createReadStream;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export interface AgentEntry {
   status: 'running' | 'completed';
   startTime: Date;
   endTime?: Date;
+  background?: boolean;
 }
 
 export interface TodoItem {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -26,6 +26,19 @@ async function getTranscriptCacheFile(configDir) {
   return path.join(cacheDir, files[0]);
 }
 
+async function parseTempTranscript(name, entries) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-'));
+  const filePath = path.join(dir, name);
+  const lines = entries.map(entry => typeof entry === 'string' ? entry : JSON.stringify(entry));
+  await writeFile(filePath, lines.join('\n'), 'utf8');
+
+  try {
+    return await parseTranscript(filePath);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
 test('getContextPercent returns 0 when data is missing', () => {
   assert.equal(getContextPercent({}), 0);
   assert.equal(getContextPercent({ context_window: { context_window_size: 0 } }), 0);
@@ -1020,6 +1033,145 @@ test('parseTranscript detects agents recorded with the Agent tool name', async (
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+test('parseTranscript keeps background agents running until queue completion', async () => {
+  const result = await parseTempTranscript('background-agent-running.jsonl', [
+    {
+      timestamp: '2024-01-01T00:00:00.000Z',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'agent-bg',
+            name: 'Task',
+            input: { subagent_type: 'explore', run_in_background: true },
+          },
+        ],
+      },
+    },
+    {
+      timestamp: '2024-01-01T00:00:04.000Z',
+      message: {
+        content: [
+          { type: 'tool_result', tool_use_id: 'agent-bg', is_error: false },
+        ],
+      },
+    },
+  ]);
+
+  assert.equal(result.agents.length, 1);
+  assert.equal(result.agents[0].status, 'running');
+  assert.equal(result.agents[0].endTime, undefined);
+});
+
+test('parseTranscript completes background agents from matching queue-operation timestamps', async () => {
+  const result = await parseTempTranscript('background-agent-completed.jsonl', [
+    {
+      timestamp: '2024-01-01T00:00:00.000Z',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'agent-bg',
+            name: 'Task',
+            input: { subagent_type: 'explore', run_in_background: true },
+          },
+        ],
+      },
+    },
+    {
+      timestamp: '2024-01-01T00:00:04.000Z',
+      message: {
+        content: [
+          { type: 'tool_result', tool_use_id: 'agent-bg', is_error: false },
+        ],
+      },
+    },
+    {
+      timestamp: '2024-01-01T00:01:17.000Z',
+      type: 'queue-operation',
+      operation: 'enqueue',
+      content: '<task-id>task-1</task-id><tool-use-id>agent-bg</tool-use-id>',
+    },
+  ]);
+
+  assert.equal(result.agents.length, 1);
+  assert.equal(result.agents[0].status, 'completed');
+  assert.equal(result.agents[0].endTime?.toISOString(), '2024-01-01T00:01:17.000Z');
+});
+
+test('parseTranscript leaves foreground agent timing on tool_result', async () => {
+  const result = await parseTempTranscript('foreground-agent.jsonl', [
+    {
+      timestamp: '2024-01-01T00:00:00.000Z',
+      message: {
+        content: [
+          { type: 'tool_use', id: 'agent-fg', name: 'Task', input: { subagent_type: 'explore' } },
+        ],
+      },
+    },
+    {
+      timestamp: '2024-01-01T00:00:04.000Z',
+      message: {
+        content: [
+          { type: 'tool_result', tool_use_id: 'agent-fg', is_error: false },
+        ],
+      },
+    },
+    {
+      timestamp: '2024-01-01T00:01:17.000Z',
+      type: 'queue-operation',
+      operation: 'enqueue',
+      content: '<task-id>task-1</task-id><tool-use-id>agent-fg</tool-use-id>',
+    },
+  ]);
+
+  assert.equal(result.agents.length, 1);
+  assert.equal(result.agents[0].status, 'completed');
+  assert.equal(result.agents[0].endTime?.toISOString(), '2024-01-01T00:00:04.000Z');
+});
+
+test('parseTranscript ignores malformed and unrelated queue-operation completions', async () => {
+  const result = await parseTempTranscript('background-agent-forged.jsonl', [
+    {
+      timestamp: '2024-01-01T00:00:00.000Z',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'agent-bg',
+            name: 'Task',
+            input: { subagent_type: 'explore', run_in_background: true },
+          },
+        ],
+      },
+    },
+    {
+      timestamp: '2024-01-01T00:00:04.000Z',
+      message: {
+        content: [
+          { type: 'tool_result', tool_use_id: 'agent-bg', is_error: false },
+        ],
+      },
+    },
+    {
+      timestamp: '2024-01-01T00:01:17.000Z',
+      type: 'queue-operation',
+      operation: 'enqueue',
+      content: '<task-id>task-1</task-id>',
+    },
+    {
+      timestamp: '2024-01-01T00:01:18.000Z',
+      type: 'queue-operation',
+      operation: 'enqueue',
+      content: '<task-id>task-2</task-id><tool-use-id>other-agent</tool-use-id>',
+    },
+  ]);
+
+  assert.equal(result.agents.length, 1);
+  assert.equal(result.agents[0].status, 'running');
+  assert.equal(result.agents[0].endTime, undefined);
 });
 
 test('parseTranscript returns undefined targets for unknown tools', async () => {


### PR DESCRIPTION
## Problem

Background agents (`run_in_background: true`) have two display bugs in the HUD:

1. **Wrong duration**: Agent ran 77s but HUD shows "4s"
2. **◐ icon never visible**: Agent flips from running to completed immediately

**Root cause**: In the parent transcript, `tool_result` for background agents is written as a launch acknowledgment (within ~4 seconds), not at actual completion. The HUD interprets this as the agent finishing.

## Fix

- Store `run_in_background` flag on the agent entry
- For **background agents**: skip the tool_result timestamp entirely; keep status `running` until the `queue-operation` entry provides the real completion time
- For **inline agents**: use tool_result timestamp as before (unchanged behavior)
- `queue-operation` entries already contain accurate `<task-id>` → `<tool-use-id>` mappings with real completion timestamps

## Result

| Agent | Before | After |
|-------|--------|-------|
| Long task X (77s actual) | ✓ 4s | ◐ during → ✓ 1m 17s |
| HUD running test (48s) | ✓ <1s | ◐ during → ✓ 48s |

## Test plan

- [x] Background agent shows yellow ◐ during execution
- [x] Background agent shows green ✓ with accurate duration after completion
- [x] Inline (foreground) agent still works correctly
- [x] Simultaneous foreground + background agents display properly