### PR TITLE
fix: add space between effort symbol and level text

### DIFF
--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -66,7 +66,7 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     const modelQualifier = providerLabel ?? undefined;
     let modelDisplay = modelQualifier ? `${model} | ${modelQualifier}` : model;
     if (ctx.effortLevel && ctx.effortSymbol) {
-      modelDisplay += ` ${ctx.effortSymbol}${ctx.effortLevel}`;
+      modelDisplay += ` ${ctx.effortSymbol} ${ctx.effortLevel}`;
     } else if (ctx.effortLevel) {
       modelDisplay += ` ${ctx.effortLevel}`;
     }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -49,7 +49,7 @@ export function renderSessionLine(ctx: RenderContext): string {
   const modelQualifier = providerLabel ?? undefined;
   let modelDisplay = modelQualifier ? `${model} | ${modelQualifier}` : model;
   if (ctx.effortLevel && ctx.effortSymbol) {
-    modelDisplay += ` ${ctx.effortSymbol}${ctx.effortLevel}`;
+    modelDisplay += ` ${ctx.effortSymbol} ${ctx.effortLevel}`;
   } else if (ctx.effortLevel) {
     modelDisplay += ` ${ctx.effortLevel}`;
   }


### PR DESCRIPTION
## Summary

- The effort symbol characters (`◑`, `◕`, etc.) have ambiguous width in many terminal emulators — some render them as full-width, causing the symbol to visually overlap the first letter of the level text (e.g. `◑high` renders with `h` hidden behind the circle)
- Added a space between the symbol and the level text in both `session-line.ts` and `lines/project.ts` so it renders as `◑ high` instead of `◑high`

## Test plan

- [x] Existing tests pass (`npm test` — the 1 pre-existing failure in `countConfigs cache` is unrelated)
- [x] Only `src/` files modified per CONTRIBUTING.md guidelines
- [x] Visual verification: enable `showEffortLevel` in config and confirm the symbol no longer overlaps the level text

🤖 Generated with [Claude Code](https://claude.com/claude-code)