### PR TITLE
feat: migrate data directory to $CLAUDE_PLUGIN_DATA (fixes #519)

### DIFF
--- a/src/claude-config-dir.ts
+++ b/src/claude-config-dir.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 
 function expandHomeDirPrefix(inputPath: string, homeDir: string): string {
   if (inputPath === '~') {
@@ -22,6 +23,44 @@ export function getClaudeConfigJsonPath(homeDir: string): string {
   return `${getClaudeConfigDir(homeDir)}.json`;
 }
 
-export function getHudPluginDir(homeDir: string): string {
+/**
+ * Returns the legacy plugin directory path (~/.claude/plugins/claude-hud/).
+ * Used as fallback and for migration source detection.
+ */
+export function getLegacyHudPluginDir(homeDir: string): string {
   return path.join(getClaudeConfigDir(homeDir), 'plugins', 'claude-hud');
+}
+
+/**
+ * Returns the HUD plugin data directory.
+ *
+ * Priority:
+ * 1. $CLAUDE_PLUGIN_DATA (set by Claude Code plugin runtime)
+ * 2. Legacy path (~/.claude/plugins/claude-hud/)
+ */
+export function getHudPluginDir(homeDir: string): string {
+  const envPluginData = process.env.CLAUDE_PLUGIN_DATA?.trim();
+  if (envPluginData) {
+    return path.resolve(expandHomeDirPrefix(envPluginData, homeDir));
+  }
+  return getLegacyHudPluginDir(homeDir);
+}
+
+/**
+ * One-time migration from legacy path to $CLAUDE_PLUGIN_DATA.
+ * If the legacy dir exists and the new dir does not, moves data over.
+ * Safe to call on every startup — no-ops when migration is unnecessary.
+ */
+export function migrateDataDirIfNeeded(homeDir: string): void {
+  const newDir = getHudPluginDir(homeDir);
+  const legacyDir = getLegacyHudPluginDir(homeDir);
+
+  // No migration needed if paths are the same or legacy doesn't exist
+  if (newDir === legacyDir) return;
+  if (!fs.existsSync(legacyDir)) return;
+  if (fs.existsSync(newDir)) return;
+
+  // Ensure parent directory exists
+  fs.mkdirSync(path.dirname(newDir), { recursive: true });
+  fs.renameSync(legacyDir, newDir);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { resolveEffortLevel } from "./effort.js";
 import { applyContextWindowFallback } from "./context-cache.js";
 import { getUsageFromExternalSnapshot } from "./external-usage.js";
 import { setLanguage, t } from "./i18n/index.js";
+import { migrateDataDirIfNeeded } from "./claude-config-dir.js";
 import type { RenderContext } from "./types.js";
 
 export { getUsageFromExternalSnapshot } from "./external-usage.js";
@@ -56,6 +57,9 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
   };
 
   try {
+    // Migrate data directory to $CLAUDE_PLUGIN_DATA if available (one-time, no-op after first run)
+    migrateDataDirIfNeeded((await import('node:os')).homedir());
+
     const stdin = await deps.readStdin();
 
     if (!stdin) {

--- a/tests/claude-config-dir.test.js
+++ b/tests/claude-config-dir.test.js
@@ -1,0 +1,163 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import {
+  getHudPluginDir,
+  getLegacyHudPluginDir,
+  migrateDataDirIfNeeded,
+} from '../dist/claude-config-dir.js';
+
+function restoreEnvVar(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+test('getHudPluginDir returns legacy path when CLAUDE_PLUGIN_DATA is not set', () => {
+  const saved = process.env.CLAUDE_PLUGIN_DATA;
+  delete process.env.CLAUDE_PLUGIN_DATA;
+  try {
+    const result = getHudPluginDir('/home/user');
+    assert.equal(result, path.join('/home/user', '.claude', 'plugins', 'claude-hud'));
+  } finally {
+    restoreEnvVar('CLAUDE_PLUGIN_DATA', saved);
+  }
+});
+
+test('getHudPluginDir returns CLAUDE_PLUGIN_DATA when set', () => {
+  const saved = process.env.CLAUDE_PLUGIN_DATA;
+  process.env.CLAUDE_PLUGIN_DATA = '/custom/plugin/data';
+  try {
+    const result = getHudPluginDir('/home/user');
+    assert.equal(result, '/custom/plugin/data');
+  } finally {
+    restoreEnvVar('CLAUDE_PLUGIN_DATA', saved);
+  }
+});
+
+test('getHudPluginDir ignores empty CLAUDE_PLUGIN_DATA', () => {
+  const saved = process.env.CLAUDE_PLUGIN_DATA;
+  process.env.CLAUDE_PLUGIN_DATA = '   ';
+  try {
+    const result = getHudPluginDir('/home/user');
+    assert.equal(result, path.join('/home/user', '.claude', 'plugins', 'claude-hud'));
+  } finally {
+    restoreEnvVar('CLAUDE_PLUGIN_DATA', saved);
+  }
+});
+
+test('getHudPluginDir expands ~ in CLAUDE_PLUGIN_DATA', () => {
+  const saved = process.env.CLAUDE_PLUGIN_DATA;
+  process.env.CLAUDE_PLUGIN_DATA = '~/my-plugin-data';
+  try {
+    const result = getHudPluginDir('/home/user');
+    assert.equal(result, path.join('/home/user', 'my-plugin-data'));
+  } finally {
+    restoreEnvVar('CLAUDE_PLUGIN_DATA', saved);
+  }
+});
+
+test('getLegacyHudPluginDir always returns legacy path', () => {
+  const saved = process.env.CLAUDE_PLUGIN_DATA;
+  process.env.CLAUDE_PLUGIN_DATA = '/custom/path';
+  try {
+    const result = getLegacyHudPluginDir('/home/user');
+    assert.equal(result, path.join('/home/user', '.claude', 'plugins', 'claude-hud'));
+  } finally {
+    restoreEnvVar('CLAUDE_PLUGIN_DATA', saved);
+  }
+});
+
+test('migrateDataDirIfNeeded moves legacy dir to new location', async () => {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'hud-migrate-'));
+  const saved = process.env.CLAUDE_PLUGIN_DATA;
+  const savedConfig = process.env.CLAUDE_CONFIG_DIR;
+
+  try {
+    // Set up legacy dir with a test file
+    const legacyDir = path.join(tmpDir, '.claude', 'plugins', 'claude-hud');
+    await mkdir(legacyDir, { recursive: true });
+    await writeFile(path.join(legacyDir, 'config.json'), '{"test":true}');
+
+    // Set new target
+    const newDir = path.join(tmpDir, 'new-data');
+    delete process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_PLUGIN_DATA = newDir;
+
+    migrateDataDirIfNeeded(tmpDir);
+
+    // Old dir should be gone, new dir should have the file
+    assert.equal(fs.existsSync(legacyDir), false, 'legacy dir should be removed');
+    assert.equal(fs.existsSync(newDir), true, 'new dir should exist');
+    assert.equal(
+      fs.readFileSync(path.join(newDir, 'config.json'), 'utf8'),
+      '{"test":true}',
+    );
+  } finally {
+    restoreEnvVar('CLAUDE_PLUGIN_DATA', saved);
+    restoreEnvVar('CLAUDE_CONFIG_DIR', savedConfig);
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('migrateDataDirIfNeeded no-ops when CLAUDE_PLUGIN_DATA is not set', async () => {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'hud-migrate-'));
+  const saved = process.env.CLAUDE_PLUGIN_DATA;
+  const savedConfig = process.env.CLAUDE_CONFIG_DIR;
+
+  try {
+    const legacyDir = path.join(tmpDir, '.claude', 'plugins', 'claude-hud');
+    await mkdir(legacyDir, { recursive: true });
+    await writeFile(path.join(legacyDir, 'config.json'), '{"test":true}');
+
+    delete process.env.CLAUDE_PLUGIN_DATA;
+    delete process.env.CLAUDE_CONFIG_DIR;
+
+    migrateDataDirIfNeeded(tmpDir);
+
+    // Legacy dir should still exist (no migration needed, paths are the same)
+    assert.equal(fs.existsSync(legacyDir), true, 'legacy dir should remain');
+  } finally {
+    restoreEnvVar('CLAUDE_PLUGIN_DATA', saved);
+    restoreEnvVar('CLAUDE_CONFIG_DIR', savedConfig);
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('migrateDataDirIfNeeded no-ops when new dir already exists', async () => {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'hud-migrate-'));
+  const saved = process.env.CLAUDE_PLUGIN_DATA;
+  const savedConfig = process.env.CLAUDE_CONFIG_DIR;
+
+  try {
+    const legacyDir = path.join(tmpDir, '.claude', 'plugins', 'claude-hud');
+    await mkdir(legacyDir, { recursive: true });
+    await writeFile(path.join(legacyDir, 'config.json'), '{"old":true}');
+
+    const newDir = path.join(tmpDir, 'new-data');
+    await mkdir(newDir, { recursive: true });
+    await writeFile(path.join(newDir, 'config.json'), '{"new":true}');
+
+    delete process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_PLUGIN_DATA = newDir;
+
+    migrateDataDirIfNeeded(tmpDir);
+
+    // Both should remain untouched
+    assert.equal(
+      fs.readFileSync(path.join(newDir, 'config.json'), 'utf8'),
+      '{"new":true}',
+      'new dir should not be overwritten',
+    );
+    assert.equal(fs.existsSync(legacyDir), true, 'legacy dir should remain');
+  } finally {
+    restoreEnvVar('CLAUDE_PLUGIN_DATA', saved);
+    restoreEnvVar('CLAUDE_CONFIG_DIR', savedConfig);
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Uses the standardized `$CLAUDE_PLUGIN_DATA` directory introduced by the [Claude Code plugin spec](https://code.claude.com/docs/en/plugins-reference) when available, falling back to the current `~/.claude/plugins/claude-hud/` path.

Closes #519

## Changes

### `src/claude-config-dir.ts`

- Renamed existing `getHudPluginDir()` to `getLegacyHudPluginDir()` (always returns `~/.claude/plugins/claude-hud/`)
- New `getHudPluginDir()` checks `$CLAUDE_PLUGIN_DATA` first, falls back to legacy path
- Added `migrateDataDirIfNeeded()` — one-time migration that moves data from legacy to new path on first run (no-ops afterward)

### `src/index.ts`

- Calls `migrateDataDirIfNeeded()` early in `main()` before any data paths are accessed

### `tests/claude-config-dir.test.js` (new)

- 8 tests covering: env var priority, empty/whitespace env handling, tilde expansion, legacy fallback, migration (happy path, no-op when same path, no-op when target exists)

## How it works

| $CLAUDE_PLUGIN_DATA | Legacy dir exists | New dir exists | Result |
|---|---|---|---|
| not set | — | — | Uses legacy path (no change) |
| set | yes | no | Migrates legacy → new, uses new |
| set | yes | yes | Uses new (no migration) |
| set | no | — | Uses new (no migration needed) |

## Testing

```
npm run build && npm test
# 520 tests, 519 pass, 0 fail, 1 skipped
```