### PR TITLE
fix(linux): use MemAvailable from /proc/meminfo instead of os.freemem()

### DIFF
--- a/src/memory.ts
+++ b/src/memory.ts
@@ -22,6 +22,22 @@ export function parseVmStat(
   };
 }
 
+export function parseLinuxMeminfo(
+  output: string,
+): { totalBytes: number; freeBytes: number } | null {
+  const totalMatch = output.match(/^MemTotal:\s+(\d+)\s+kB/m);
+  const availMatch = output.match(/^MemAvailable:\s+(\d+)\s+kB/m);
+  if (!totalMatch || !availMatch) return null;
+
+  const totalBytes = Number(totalMatch[1]) * 1024;
+  const freeBytes = Number(availMatch[1]) * 1024;
+  if (!Number.isFinite(totalBytes) || !Number.isFinite(freeBytes)) {
+    return null;
+  }
+
+  return { totalBytes, freeBytes };
+}
+
 const readDefaultMemory: MemoryReader = () => ({
   totalBytes: os.totalmem(),
   freeBytes: os.freemem(),
@@ -30,12 +46,7 @@ const readDefaultMemory: MemoryReader = () => ({
 const readLinuxMemory: MemoryReader = () => {
   try {
     const content = readFileSync('/proc/meminfo', 'utf8');
-    const totalMatch = content.match(/^MemTotal:\s+(\d+)\s+kB/m);
-    const availMatch = content.match(/^MemAvailable:\s+(\d+)\s+kB/m);
-    if (!totalMatch || !availMatch) return readDefaultMemory();
-    const totalBytes = Number(totalMatch[1]) * 1024;
-    const freeBytes = Number(availMatch[1]) * 1024;
-    return { totalBytes, freeBytes };
+    return parseLinuxMeminfo(content) ?? readDefaultMemory();
   } catch {
     return readDefaultMemory();
   }

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,5 +1,6 @@
 import os from 'node:os';
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import type { MemoryInfo } from './types.js';
 
 type MemoryReader = () => { totalBytes: number; freeBytes: number };
@@ -26,6 +27,20 @@ const readDefaultMemory: MemoryReader = () => ({
   freeBytes: os.freemem(),
 });
 
+const readLinuxMemory: MemoryReader = () => {
+  try {
+    const content = readFileSync('/proc/meminfo', 'utf8');
+    const totalMatch = content.match(/^MemTotal:\s+(\d+)\s+kB/m);
+    const availMatch = content.match(/^MemAvailable:\s+(\d+)\s+kB/m);
+    if (!totalMatch || !availMatch) return readDefaultMemory();
+    const totalBytes = Number(totalMatch[1]) * 1024;
+    const freeBytes = Number(availMatch[1]) * 1024;
+    return { totalBytes, freeBytes };
+  } catch {
+    return readDefaultMemory();
+  }
+};
+
 const readMacOSMemory: MemoryReader = () => {
   try {
     const output = execFileSync('/usr/bin/vm_stat', {
@@ -43,7 +58,9 @@ const readMacOSMemory: MemoryReader = () => {
 };
 
 let readMemory: MemoryReader =
-  process.platform === 'darwin' ? readMacOSMemory : readDefaultMemory;
+  process.platform === 'darwin' ? readMacOSMemory :
+  process.platform === 'linux' ? readLinuxMemory :
+  readDefaultMemory;
 
 export async function getMemoryUsage(): Promise<MemoryInfo | null> {
   try {
@@ -88,5 +105,9 @@ export function formatBytes(bytes: number): string {
 }
 
 export function _setMemoryReaderForTests(reader: MemoryReader | null): void {
-  readMemory = reader ?? (process.platform === 'darwin' ? readMacOSMemory : readDefaultMemory);
+  readMemory = reader ?? (
+    process.platform === 'darwin' ? readMacOSMemory :
+    process.platform === 'linux' ? readLinuxMemory :
+    readDefaultMemory
+  );
 }

--- a/tests/memory.test.js
+++ b/tests/memory.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { _setMemoryReaderForTests, formatBytes, getMemoryUsage, parseVmStat } from '../dist/memory.js';
+import { _setMemoryReaderForTests, formatBytes, getMemoryUsage, parseLinuxMeminfo, parseVmStat } from '../dist/memory.js';
 
 test('getMemoryUsage returns coarse system RAM usage with clamped values', async () => {
   _setMemoryReaderForTests(() => ({
@@ -62,6 +62,25 @@ test('parseVmStat returns null for empty string', () => {
 
 test('parseVmStat returns null for malformed output', () => {
   assert.equal(parseVmStat('not valid vm_stat output'), null);
+});
+
+test('parseLinuxMeminfo uses MemAvailable for Linux free memory', () => {
+  const output = `MemTotal:       31982940 kB
+MemFree:         7105992 kB
+MemAvailable:   18290212 kB
+Buffers:          372008 kB`;
+
+  assert.deepEqual(parseLinuxMeminfo(output), {
+    totalBytes: 31982940 * 1024,
+    freeBytes: 18290212 * 1024,
+  });
+});
+
+test('parseLinuxMeminfo returns null without MemAvailable', () => {
+  const output = `MemTotal:       31982940 kB
+MemFree:         7105992 kB`;
+
+  assert.equal(parseLinuxMeminfo(output), null);
 });
 
 test('macOS memory calculation: 16GB total, active+wired via vm_stat → 43%', async () => {


### PR DESCRIPTION
## Summary

`os.freemem()` on Linux returns `MemFree` — only truly free RAM, excluding reclaimable disk cache and buffers. This inflates reported memory usage significantly (e.g. 88% when ~43% is actually used).

Add `readLinuxMemory` reader that reads `MemAvailable` from `/proc/meminfo` — the same metric used by `htop` and `free(1)`. Mirrors the existing `readMacOSMemory` pattern. Falls back to `readDefaultMemory` if `/proc/meminfo` is unavailable.

Closes #522

## Testing

- [ ] `npm test`
- [ ] `npm run test:coverage`

## Checklist

- [ ] Tests updated or not needed
- [ ] Docs updated if behavior changed