### PR TITLE
feat: add showSkills and showMcp HUD display elements

### DIFF
--- a/src/config-reader.ts
+++ b/src/config-reader.ts
@@ -13,6 +13,8 @@ export interface ConfigCounts {
   mcpCount: number;
   hooksCount: number;
   outputStyle?: string;
+  skillNames: string[];
+  mcpServerNames: string[];
 }
 
 interface SentinelState {
@@ -46,6 +48,28 @@ function getMcpServerNames(filePath: string): Set<string> {
     debug(`Failed to read MCP servers from ${filePath}:`, error);
   }
   return new Set();
+}
+
+function getSkillNames(filePath: string): string[] {
+  if (!fs.existsSync(filePath)) return [];
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const config = JSON.parse(content);
+    if (Array.isArray(config.skills)) {
+      return config.skills
+        .filter((s: unknown) => typeof s === 'string')
+        .map((s: string) => {
+          // Extract skill name from path like '/home/user/.claude/skills/opc/skill.md'
+          const parts = s.replace(/\\/g, '/').split('/');
+          const mdIndex = parts.lastIndexOf('skill.md');
+          return mdIndex > 0 ? parts[mdIndex - 1] : parts[parts.length - 1];
+        })
+        .filter((name: string) => name.length > 0);
+    }
+  } catch (error) {
+    debug(`Failed to read skills from ${filePath}:`, error);
+  }
+  return [];
 }
 
 function getDisabledMcpServers(filePath: string, key: DisabledMcpKey): Set<string> {
@@ -255,6 +279,8 @@ function isConfigCounts(value: unknown): value is ConfigCounts {
     && Number.isFinite(counts.hooksCount)
     && counts.hooksCount >= 0
     && (counts.outputStyle === undefined || typeof counts.outputStyle === 'string')
+    && Array.isArray(counts.skillNames)
+    && Array.isArray(counts.mcpServerNames)
   );
 }
 
@@ -405,8 +431,22 @@ function computeConfigCountsFresh(cwd?: string): ConfigCounts {
   // Note: Deduplication only occurs within each scope, not across scopes.
   // A server with the same name in both user and project scope counts as 2 (separate configs).
   const mcpCount = userMcpServers.size + projectMcpServers.size;
+  const mcpServerNames = [...userMcpServers, ...projectMcpServers];
 
-  return { claudeMdCount, rulesCount, mcpCount, hooksCount, outputStyle };
+  // Collect skill names from user and project settings
+  const skillNameSet = new Set<string>();
+  for (const name of getSkillNames(userSettings)) {
+    skillNameSet.add(name);
+  }
+  if (cwd) {
+    const projectSettings = path.join(cwd, '.claude', 'settings.json');
+    for (const name of getSkillNames(projectSettings)) {
+      skillNameSet.add(name);
+    }
+  }
+  const skillNames = [...skillNameSet];
+
+  return { claudeMdCount, rulesCount, mcpCount, hooksCount, outputStyle, skillNames, mcpServerNames };
 }
 
 export async function countConfigs(cwd?: string): Promise<ConfigCounts> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
  */
 export type ModelFormatMode = 'full' | 'compact' | 'short';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both';
-export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos';
+export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos' | 'skills' | 'mcp';
 
 export type AddedDirsLayout = 'inline' | 'line';
 export type HudColorName =
@@ -62,6 +62,8 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'tools',
   'agents',
   'todos',
+  'skills',
+  'mcp',
 ];
 
 export const DEFAULT_MERGE_GROUPS: HudElement[][] = [
@@ -106,6 +108,8 @@ export interface HudConfig {
     showTools: boolean;
     showAgents: boolean;
     showTodos: boolean;
+    showSkills: boolean;
+    showMcp: boolean;
     showSessionName: boolean;
     showClaudeCodeVersion: boolean;
     showEffortLevel: boolean;
@@ -167,6 +171,8 @@ export const DEFAULT_CONFIG: HudConfig = {
     showTools: false,
     showAgents: false,
     showTodos: false,
+    showSkills: false,
+    showMcp: false,
     showSessionName: false,
     showClaudeCodeVersion: false,
     showEffortLevel: false,
@@ -519,6 +525,12 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showTodos: typeof migrated.display?.showTodos === 'boolean'
       ? migrated.display.showTodos
       : DEFAULT_CONFIG.display.showTodos,
+    showSkills: typeof migrated.display?.showSkills === 'boolean'
+      ? migrated.display.showSkills
+      : DEFAULT_CONFIG.display.showSkills,
+    showMcp: typeof migrated.display?.showMcp === 'boolean'
+      ? migrated.display.showMcp
+      : DEFAULT_CONFIG.display.showMcp,
     showSessionName: typeof migrated.display?.showSessionName === 'boolean'
       ? migrated.display.showSessionName
       : DEFAULT_CONFIG.display.showSessionName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       lastCompactPostTokens: transcript.lastCompactPostTokens,
     });
 
-    const { claudeMdCount, rulesCount, mcpCount, hooksCount, outputStyle } =
+    const { claudeMdCount, rulesCount, mcpCount, hooksCount, outputStyle, skillNames, mcpServerNames } =
       await deps.countConfigs(stdin.cwd);
 
     const config = await deps.loadConfig();
@@ -119,6 +119,8 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       claudeMdCount,
       rulesCount,
       mcpCount,
+      skillNames,
+      mcpServerNames,
       hooksCount,
       sessionDuration,
       gitStatus,

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -15,6 +15,8 @@ import {
   renderUsageLine,
   renderMemoryLine,
   renderSessionTokensLine,
+  renderSkillsLine,
+  renderMcpLine,
 } from './lines/index.js';
 import { dim, RESET } from './colors.js';
 import { getTerminalWidth, UNKNOWN_TERMINAL_WIDTH } from '../utils/terminal.js';
@@ -282,7 +284,7 @@ function makeSeparator(length: number): string {
   return dim('─'.repeat(repeats));
 }
 
-const ACTIVITY_ELEMENTS = new Set<HudElement>(['tools', 'agents', 'todos']);
+const ACTIVITY_ELEMENTS = new Set<HudElement>(['tools', 'agents', 'todos', 'skills', 'mcp']);
 
 function buildMergeGroupLookup(mergeGroups: HudElement[][]): Map<HudElement, Set<HudElement>> {
   const lookup = new Map<HudElement, Set<HudElement>>();
@@ -343,6 +345,20 @@ function collectActivityLines(ctx: RenderContext): string[] {
     }
   }
 
+  if (display?.showSkills !== false) {
+    const skillsLine = renderSkillsLine(ctx);
+    if (skillsLine) {
+      activityLines.push(skillsLine);
+    }
+  }
+
+  if (display?.showMcp !== false) {
+    const mcpLine = renderMcpLine(ctx);
+    if (mcpLine) {
+      activityLines.push(mcpLine);
+    }
+  }
+
   return activityLines;
 }
 
@@ -375,6 +391,10 @@ function renderElementLine(
       return display?.showAgents === false ? null : renderAgentsLine(ctx);
     case 'todos':
       return display?.showTodos === false ? null : renderTodosLine(ctx);
+    case 'skills':
+      return display?.showSkills === false ? null : renderSkillsLine(ctx);
+    case 'mcp':
+      return display?.showMcp === false ? null : renderMcpLine(ctx);
   }
 }
 

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -6,3 +6,5 @@ export { renderPromptCacheLine, formatPromptCacheCountdown } from './prompt-cach
 export { renderUsageLine } from './usage.js';
 export { renderMemoryLine } from './memory.js';
 export { renderSessionTokensLine } from './session-tokens.js';
+export { renderSkillsLine } from './skills-line.js';
+export { renderMcpLine } from './mcp-line.js';

--- a/src/render/lines/mcp-line.ts
+++ b/src/render/lines/mcp-line.ts
@@ -1,0 +1,27 @@
+import type { RenderContext } from '../../types.js';
+import { yellow, cyan, label } from '../colors.js';
+
+const MAX_MCP_SHOWN = 4;
+
+export function renderMcpLine(ctx: RenderContext): string | null {
+  const { mcpServerNames } = ctx;
+  const colors = ctx.config?.colors;
+
+  if (!mcpServerNames || mcpServerNames.length === 0) {
+    return null;
+  }
+
+  const shown = mcpServerNames.slice(0, MAX_MCP_SHOWN);
+  const parts: string[] = [];
+
+  for (const name of shown) {
+    parts.push(`${yellow('◐')} ${cyan(name)}`);
+  }
+
+  const remaining = mcpServerNames.length - shown.length;
+  if (remaining > 0) {
+    parts.push(label(`+${remaining} more`, colors));
+  }
+
+  return parts.join(' | ');
+}

--- a/src/render/lines/skills-line.ts
+++ b/src/render/lines/skills-line.ts
@@ -1,0 +1,27 @@
+import type { RenderContext } from '../../types.js';
+import { yellow, cyan, label } from '../colors.js';
+
+const MAX_SKILLS_SHOWN = 4;
+
+export function renderSkillsLine(ctx: RenderContext): string | null {
+  const { skillNames } = ctx;
+  const colors = ctx.config?.colors;
+
+  if (!skillNames || skillNames.length === 0) {
+    return null;
+  }
+
+  const shown = skillNames.slice(0, MAX_SKILLS_SHOWN);
+  const parts: string[] = [];
+
+  for (const name of shown) {
+    parts.push(`${yellow('◐')} ${cyan(name)}`);
+  }
+
+  const remaining = skillNames.length - shown.length;
+  if (remaining > 0) {
+    parts.push(label(`+${remaining} more`, colors));
+  }
+
+  return parts.join(' | ');
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,8 @@ export interface RenderContext {
   claudeMdCount: number;
   rulesCount: number;
   mcpCount: number;
+  skillNames: string[];
+  mcpServerNames: string[];
   hooksCount: number;
   sessionDuration: string;
   gitStatus: GitStatus | null;

--- a/tests/skills-mcp.test.js
+++ b/tests/skills-mcp.test.js
@@ -1,0 +1,131 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderSkillsLine } from '../dist/render/lines/skills-line.js';
+import { renderMcpLine } from '../dist/render/lines/mcp-line.js';
+import { mergeConfig } from '../dist/config.js';
+
+function stripAnsi(str) {
+  // eslint-disable-next-line no-control-regex
+  return str
+    .replace(/\x1b\[[0-9;]*m/g, '')
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
+}
+
+function baseContext(overrides = {}) {
+  return {
+    stdin: {
+      model: { display_name: 'Opus' },
+      context_window: {
+        context_window_size: 200000,
+        current_usage: { input_tokens: 10000 },
+      },
+    },
+    transcript: { tools: [], agents: [], todos: [] },
+    claudeMdCount: 0,
+    rulesCount: 0,
+    mcpCount: 0,
+    hooksCount: 0,
+    skillNames: [],
+    mcpServerNames: [],
+    sessionDuration: '',
+    gitStatus: null,
+    usageData: null,
+    memoryUsage: null,
+    config: mergeConfig({}),
+    extraLabel: null,
+    ...overrides,
+  };
+}
+
+// === renderSkillsLine ===
+
+test('renderSkillsLine returns null when no skills', () => {
+  const ctx = baseContext();
+  assert.equal(renderSkillsLine(ctx), null);
+});
+
+test('renderSkillsLine renders a single skill', () => {
+  const ctx = baseContext({ skillNames: ['opc'] });
+  const result = stripAnsi(renderSkillsLine(ctx));
+  assert.ok(result.includes('opc'));
+  assert.ok(result.includes('◐'));
+});
+
+test('renderSkillsLine renders 4 skills without truncation', () => {
+  const ctx = baseContext({ skillNames: ['a', 'b', 'c', 'd'] });
+  const result = stripAnsi(renderSkillsLine(ctx));
+  assert.ok(result.includes('a'));
+  assert.ok(result.includes('d'));
+  assert.ok(!result.includes('+'));
+});
+
+test('renderSkillsLine truncates at 5+ skills', () => {
+  const ctx = baseContext({ skillNames: ['alpha', 'beta', 'gamma', 'delta', 'epsilon'] });
+  const result = stripAnsi(renderSkillsLine(ctx));
+  assert.ok(result.includes('alpha'));
+  assert.ok(result.includes('delta'));
+  assert.ok(result.includes('+1 more'));
+  assert.ok(!result.includes('epsilon'));
+});
+
+// === renderMcpLine ===
+
+test('renderMcpLine returns null when no servers', () => {
+  const ctx = baseContext();
+  assert.equal(renderMcpLine(ctx), null);
+});
+
+test('renderMcpLine renders a single server', () => {
+  const ctx = baseContext({ mcpServerNames: ['filesystem'] });
+  const result = stripAnsi(renderMcpLine(ctx));
+  assert.ok(result.includes('filesystem'));
+  assert.ok(result.includes('◐'));
+});
+
+test('renderMcpLine renders 4 servers without truncation', () => {
+  const ctx = baseContext({ mcpServerNames: ['a', 'b', 'c', 'd'] });
+  const result = stripAnsi(renderMcpLine(ctx));
+  assert.ok(result.includes('a'));
+  assert.ok(result.includes('d'));
+  assert.ok(!result.includes('+'));
+});
+
+test('renderMcpLine truncates at 5+ servers', () => {
+  const ctx = baseContext({ mcpServerNames: ['a', 'b', 'c', 'd', 'e', 'f'] });
+  const result = stripAnsi(renderMcpLine(ctx));
+  assert.ok(result.includes('+2 more'));
+});
+
+// === Config validation ===
+
+test('mergeConfig includes skills and mcp in DEFAULT_ELEMENT_ORDER', () => {
+  const config = mergeConfig({});
+  assert.ok(config.elementOrder.includes('skills'));
+  assert.ok(config.elementOrder.includes('mcp'));
+});
+
+test('mergeConfig defaults showSkills and showMcp to false', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.showSkills, false);
+  assert.equal(config.display.showMcp, false);
+});
+
+test('mergeConfig respects showSkills and showMcp overrides', () => {
+  const config = mergeConfig({ display: { showSkills: true, showMcp: true } });
+  assert.equal(config.display.showSkills, true);
+  assert.equal(config.display.showMcp, true);
+});
+
+// === Display toggle ===
+
+test('renderSkillsLine returns null when skills exist but undefined skillNames', () => {
+  const ctx = baseContext();
+  delete ctx.skillNames;
+  assert.equal(renderSkillsLine(ctx), null);
+});
+
+test('renderMcpLine returns null when undefined mcpServerNames', () => {
+  const ctx = baseContext();
+  delete ctx.mcpServerNames;
+  assert.equal(renderMcpLine(ctx), null);
+});


### PR DESCRIPTION
## Summary

Add two new HUD elements to display configured Claude Code skills and MCP servers.

### Skills element (`showSkills`)
- Reads skill paths from `~/.claude/settings.json` and project `.claude/settings.json`
- Extracts skill names from directory paths (e.g. `opc` from `/home/user/.claude/skills/opc/skill.md`)
- Deduplicates across user and project scopes
- Shows up to 4 skills with `+N more` truncation

### MCP element (`showMcp`)
- Displays MCP server names from both user and project settings
- Reuses existing `getMcpServerNames()` infrastructure
- Shows up to 4 servers with `+N more` truncation

Both elements default to `false` and can be enabled via display config:
```json
{
  "display": {
    "showSkills": true,
    "showMcp": true
  }
}
```

### Files changed
- `src/config.ts` — Add `skills`/`mcp` to `HudElement`, `DEFAULT_ELEMENT_ORDER`, display toggles
- `src/config-reader.ts` — Add `getSkillNames()`, extend `ConfigCounts` with `skillNames`/`mcpServerNames`
- `src/types.ts` — Add fields to `RenderContext`
- `src/index.ts` — Wire new fields through data flow
- `src/render/lines/skills-line.ts` — New renderer
- `src/render/lines/mcp-line.ts` — New renderer
- `src/render/lines/index.ts` — Export new renderers
- `src/render/index.ts` — Wire into expanded + compact render paths

### Testing
- 13 new tests in `tests/skills-mcp.test.js`
- All 576 tests pass (563 existing + 13 new)

Closes #527