### PR TITLE
feat: add session start date and last response timestamp display

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `pathLevels` | 1-3 | 1 | Directory levels to show in project path |
 | `maxWidth` | number \| `null` | `null` | Optional fallback width used only when terminal width detection fails completely |
 | `forceMaxWidth` | boolean | false | Always use `maxWidth` when it is set, even if terminal width detection returns a smaller value |
-| `elementOrder` | string[] | `["project","context","usage","promptCache","memory","environment","tools","agents","todos"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. |
+| `elementOrder` | string[] | `["project","context","usage","promptCache","memory","environment","tools","agents","todos","sessionTime"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. Existing configs keep their explicit order until updated. |
 | `display.mergeGroups` | string[][] | `[["context","usage"]]` | Expanded-mode groups that should share a line when adjacent. Set `[]` to disable merged lines. |
 | `gitStatus.enabled` | boolean | true | Show git branch in HUD |
 | `gitStatus.showDirty` | boolean | true | Show `*` for uncommitted changes |
@@ -193,6 +193,8 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showAgents` | boolean | false | Show agents activity line |
 | `display.showTodos` | boolean | false | Show todos progress line |
 | `display.showSessionName` | boolean | false | Show session slug or custom title from `/rename` |
+| `display.showSessionStartDate` | boolean | false | Show the transcript session start timestamp |
+| `display.showLastResponseAt` | boolean | false | Show how long ago the last assistant response was written |
 | `display.showClaudeCodeVersion` | boolean | false | Show the installed Claude Code version, e.g. `CC v2.1.81` |
 | `display.showMemoryUsage` | boolean | false | Show an approximate system RAM usage line in expanded layout |
 | `display.showPromptCache` | boolean | false | Show a prompt cache countdown based on the last assistant response timestamp in the transcript |
@@ -285,7 +287,7 @@ Example fallback snapshot:
   "language": "zh",
   "lineLayout": "expanded",
   "pathLevels": 2,
-  "elementOrder": ["project", "tools", "context", "usage", "memory", "environment", "agents", "todos"],
+  "elementOrder": ["project", "tools", "context", "usage", "memory", "environment", "agents", "todos", "sessionTime"],
   "gitStatus": {
     "enabled": true,
     "showDirty": true,

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -255,6 +255,8 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 | Session name | `display.showSessionName` |
 | Session duration | `display.showDuration` |
 | Session tokens | `display.showSessionTokens` |
+| Session start date | `display.showSessionStartDate` |
+| Last response time | `display.showLastResponseAt` |
 | Custom line | `display.customLine` |
 
 **Always true (not configurable):**

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
  */
 export type ModelFormatMode = 'full' | 'compact' | 'short';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both';
-export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos';
+export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos' | 'sessionTime';
 
 export type AddedDirsLayout = 'inline' | 'line';
 export type HudColorName =
@@ -62,6 +62,7 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'tools',
   'agents',
   'todos',
+  'sessionTime',
 ];
 
 export const DEFAULT_MERGE_GROUPS: HudElement[][] = [
@@ -114,6 +115,8 @@ export interface HudConfig {
     promptCacheTtlSeconds: number;
     showSessionTokens: boolean;
     showOutputStyle: boolean;
+    showSessionStartDate: boolean;
+    showLastResponseAt: boolean;
     mergeGroups: HudElement[][];
     autocompactBuffer: AutocompactBufferMode;
     contextWarningThreshold: number;
@@ -175,6 +178,8 @@ export const DEFAULT_CONFIG: HudConfig = {
     promptCacheTtlSeconds: 300,
     showSessionTokens: false,
     showOutputStyle: false,
+    showSessionStartDate: false,
+    showLastResponseAt: false,
     mergeGroups: DEFAULT_MERGE_GROUPS.map(group => [...group]),
     autocompactBuffer: 'enabled',
     contextWarningThreshold: 70,
@@ -544,6 +549,12 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showOutputStyle: typeof migrated.display?.showOutputStyle === 'boolean'
       ? migrated.display.showOutputStyle
       : DEFAULT_CONFIG.display.showOutputStyle,
+    showSessionStartDate: typeof migrated.display?.showSessionStartDate === 'boolean'
+      ? migrated.display.showSessionStartDate
+      : DEFAULT_CONFIG.display.showSessionStartDate,
+    showLastResponseAt: typeof migrated.display?.showLastResponseAt === 'boolean'
+      ? migrated.display.showLastResponseAt
+      : DEFAULT_CONFIG.display.showLastResponseAt,
     mergeGroups: validateMergeGroups(migrated.display?.mergeGroups),
     autocompactBuffer: validateAutocompactBuffer(migrated.display?.autocompactBuffer)
       ? migrated.display.autocompactBuffer

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -12,6 +12,8 @@ export const en: Messages = {
   "label.estimatedCost": "Est.",
   "label.cost": "Cost",
   "label.tokens": "Tokens",
+  "label.sessionStarted": "Started",
+  "label.lastReply": "Last reply",
 
   // Status
   "status.limitReached": "Limit reached",
@@ -27,6 +29,8 @@ export const en: Messages = {
   "format.out": "out",
   "format.tok": "tok",
   "format.tokPerSec": "tok/s",
+  "format.justNow": "just now",
+  "format.ago": "ago",
 
   // Init
   "init.initializing": "[claude-hud] Initializing...",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -10,6 +10,8 @@ export type MessageKey =
   | "label.estimatedCost"
   | "label.cost"
   | "label.tokens"
+  | "label.sessionStarted"
+  | "label.lastReply"
   // Status
   | "status.limitReached"
   | "status.allTodosComplete"
@@ -23,6 +25,8 @@ export type MessageKey =
   | "format.out"
   | "format.tok"
   | "format.tokPerSec"
+  | "format.justNow"
+  | "format.ago"
   // Init
   | "init.initializing"
   | "init.macosNote";

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -12,6 +12,8 @@ export const zh: Messages = {
   "label.estimatedCost": "估算",
   "label.cost": "费用",
   "label.tokens": "令牌",
+  "label.sessionStarted": "开始",
+  "label.lastReply": "上次回复",
 
   // Status
   "status.limitReached": "已达上限",
@@ -27,6 +29,8 @@ export const zh: Messages = {
   "format.out": "输出",
   "format.tok": "令牌",
   "format.tokPerSec": "tok/s",
+  "format.justNow": "刚刚",
+  "format.ago": "前",
 
   // Init
   "init.initializing": "[claude-hud] 正在初始化...",

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -15,6 +15,7 @@ import {
   renderUsageLine,
   renderMemoryLine,
   renderSessionTokensLine,
+  renderSessionTimeLine,
 } from './lines/index.js';
 import { dim, RESET } from './colors.js';
 import { getTerminalWidth, UNKNOWN_TERMINAL_WIDTH } from '../utils/terminal.js';
@@ -375,6 +376,8 @@ function renderElementLine(
       return display?.showAgents === false ? null : renderAgentsLine(ctx);
     case 'todos':
       return display?.showTodos === false ? null : renderTodosLine(ctx);
+    case 'sessionTime':
+      return renderSessionTimeLine(ctx);
   }
 }
 

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -6,3 +6,4 @@ export { renderPromptCacheLine, formatPromptCacheCountdown } from './prompt-cach
 export { renderUsageLine } from './usage.js';
 export { renderMemoryLine } from './memory.js';
 export { renderSessionTokensLine } from './session-tokens.js';
+export { renderSessionTimeLine } from './session-time.js';

--- a/src/render/lines/session-time.ts
+++ b/src/render/lines/session-time.ts
@@ -1,0 +1,66 @@
+import type { RenderContext } from '../../types.js';
+import { dim, RESET } from '../colors.js';
+
+function pad(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}
+
+function formatStartDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = pad(date.getMonth() + 1);
+  const d = pad(date.getDate());
+  const h = pad(date.getHours());
+  const min = pad(date.getMinutes());
+  return `${y}-${m}-${d} ${h}:${min}`;
+}
+
+function formatRelativeTime(ms: number): string {
+  if (ms < 0) {
+    return 'just now';
+  }
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours < 24) {
+    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m ago` : `${hours}h ago`;
+  }
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return remainingHours > 0 ? `${days}d ${remainingHours}h ago` : `${days}d ago`;
+}
+
+export function renderSessionTimeLine(ctx: RenderContext, nowFn?: () => number): string | null {
+  const display = ctx.config?.display;
+  const showStart = display?.showSessionStartDate === true;
+  const showLastReply = display?.showLastResponseAt === true;
+
+  if (!showStart && !showLastReply) {
+    return null;
+  }
+
+  const parts: string[] = [];
+
+  if (showStart && ctx.transcript.sessionStart) {
+    const startStr = formatStartDate(ctx.transcript.sessionStart);
+    parts.push(`${dim}Started:${RESET} ${startStr}`);
+  }
+
+  if (showLastReply && ctx.transcript.lastAssistantResponseAt) {
+    const now = nowFn ? nowFn() : Date.now();
+    const elapsed = now - ctx.transcript.lastAssistantResponseAt.getTime();
+    parts.push(`${dim}Last reply:${RESET} ${formatRelativeTime(elapsed)}`);
+  }
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return parts.join(` ${dim}│${RESET} `);
+}

--- a/src/render/lines/session-time.ts
+++ b/src/render/lines/session-time.ts
@@ -1,5 +1,6 @@
 import type { RenderContext } from '../../types.js';
-import { dim, RESET } from '../colors.js';
+import { label } from '../colors.js';
+import { getLanguage, t } from '../../i18n/index.js';
 
 function pad(n: number): string {
   return n < 10 ? `0${n}` : `${n}`;
@@ -16,30 +17,37 @@ function formatStartDate(date: Date): string {
 
 function formatRelativeTime(ms: number): string {
   if (ms < 0) {
-    return 'just now';
+    return t('format.justNow');
   }
+
+  const withAgo = (value: string): string => {
+    const ago = t('format.ago');
+    return getLanguage() === 'zh' ? `${value}${ago}` : `${value} ${ago}`;
+  };
+
   const seconds = Math.floor(ms / 1000);
   if (seconds < 60) {
-    return `${seconds}s ago`;
+    return withAgo(`${seconds}s`);
   }
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) {
-    return `${minutes}m ago`;
+    return withAgo(`${minutes}m`);
   }
   const hours = Math.floor(minutes / 60);
   const remainingMinutes = minutes % 60;
   if (hours < 24) {
-    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m ago` : `${hours}h ago`;
+    return withAgo(remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`);
   }
   const days = Math.floor(hours / 24);
   const remainingHours = hours % 24;
-  return remainingHours > 0 ? `${days}d ${remainingHours}h ago` : `${days}d ago`;
+  return withAgo(remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`);
 }
 
 export function renderSessionTimeLine(ctx: RenderContext, nowFn?: () => number): string | null {
   const display = ctx.config?.display;
   const showStart = display?.showSessionStartDate === true;
   const showLastReply = display?.showLastResponseAt === true;
+  const colors = ctx.config?.colors;
 
   if (!showStart && !showLastReply) {
     return null;
@@ -49,18 +57,18 @@ export function renderSessionTimeLine(ctx: RenderContext, nowFn?: () => number):
 
   if (showStart && ctx.transcript.sessionStart) {
     const startStr = formatStartDate(ctx.transcript.sessionStart);
-    parts.push(`${dim}Started:${RESET} ${startStr}`);
+    parts.push(`${label(`${t('label.sessionStarted')}:`, colors)} ${startStr}`);
   }
 
   if (showLastReply && ctx.transcript.lastAssistantResponseAt) {
     const now = nowFn ? nowFn() : Date.now();
     const elapsed = now - ctx.transcript.lastAssistantResponseAt.getTime();
-    parts.push(`${dim}Last reply:${RESET} ${formatRelativeTime(elapsed)}`);
+    parts.push(`${label(`${t('label.lastReply')}:`, colors)} ${formatRelativeTime(elapsed)}`);
   }
 
   if (parts.length === 0) {
     return null;
   }
 
-  return parts.join(` ${dim}│${RESET} `);
+  return parts.join(` ${label('│', colors)} `);
 }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -6,6 +6,7 @@ import { coloredBar, critical, git as gitColor, gitBranch as gitBranchColor, lab
 import { getAdaptiveBarWidth } from '../utils/terminal.js';
 import { renderCostEstimate } from './lines/cost.js';
 import { renderPromptCacheLine } from './lines/prompt-cache.js';
+import { renderSessionTimeLine } from './lines/session-time.js';
 import { t } from '../i18n/index.js';
 import type { TimeFormatMode } from '../config.js';
 import { formatResetTime } from './format-reset-time.js';
@@ -264,6 +265,11 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   if (display?.showDuration !== false && ctx.sessionDuration) {
     parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
+  }
+
+  const sessionTimeLine = renderSessionTimeLine(ctx);
+  if (sessionTimeLine) {
+    parts.push(sessionTimeLine);
   }
 
   const promptCacheLine = renderPromptCacheLine(ctx);

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -16,6 +16,7 @@ import { renderMemoryLine } from '../dist/render/lines/memory.js';
 import { renderIdentityLine } from '../dist/render/lines/identity.js';
 import { renderEnvironmentLine } from '../dist/render/lines/environment.js';
 import { renderSessionTokensLine } from '../dist/render/lines/session-tokens.js';
+import { renderSessionTimeLine } from '../dist/render/lines/session-time.js';
 import { getContextColor, getQuotaColor } from '../dist/render/colors.js';
 import { setLanguage } from '../dist/i18n/index.js';
 
@@ -186,6 +187,19 @@ test('renderSessionLine includes duration and formats large tokens', () => {
   assert.ok(line.includes('⏱️'));
   assert.ok(line.includes('685k') || line.includes('685.0k'), 'expected large input token display');
   assert.ok(line.includes('2k'), 'expected cache token display');
+});
+
+test('renderSessionLine includes session time when enabled in compact layout', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'compact';
+  ctx.config.display.showSessionStartDate = true;
+  ctx.config.display.showLastResponseAt = true;
+  ctx.transcript.sessionStart = new Date(2026, 4, 8, 9, 14, 0);
+  ctx.transcript.lastAssistantResponseAt = new Date(Date.now() - 5 * 60 * 1000);
+
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('Started: 2026-05-08 09:14'), `should include session start: ${line}`);
+  assert.ok(line.includes('Last reply: 5m ago'), `should include last reply age: ${line}`);
 });
 
 test('renderSessionLine handles missing input tokens and cache creation usage', () => {
@@ -1983,6 +1997,17 @@ test('render expanded layout honors custom elementOrder including activity place
   assert.ok(memoryIndex < environmentIndex, 'environment line should follow memory');
   assert.ok(environmentIndex < agentIndex, 'agent line should follow environment');
   assert.ok(agentIndex < todoIndex, 'todo line should follow agent line');
+});
+
+test('render expanded layout includes sessionTime element when enabled', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.config.elementOrder = ['project', 'sessionTime'];
+  ctx.config.display.showSessionStartDate = true;
+  ctx.transcript.sessionStart = new Date(2026, 4, 8, 9, 14, 0);
+
+  const lines = captureRenderLines(ctx);
+  assert.ok(lines.some(line => line.includes('Started: 2026-05-08 09:14')), `should render sessionTime line: ${lines.join('\n')}`);
 });
 
 test('render expanded layout omits elements not present in elementOrder', () => {

--- a/tests/session-time.test.js
+++ b/tests/session-time.test.js
@@ -1,0 +1,150 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderSessionTimeLine } from '../dist/render/lines/session-time.js';
+
+function makeCtx(overrides = {}) {
+  return {
+    stdin: {},
+    transcript: {
+      tools: [],
+      agents: [],
+      todos: [],
+      ...(overrides.transcript || {}),
+    },
+    claudeMdCount: 0,
+    rulesCount: 0,
+    mcpCount: 0,
+    hooksCount: 0,
+    sessionDuration: '',
+    gitStatus: null,
+    usageData: null,
+    memoryUsage: null,
+    config: {
+      display: {
+        showSessionStartDate: false,
+        showLastResponseAt: false,
+        ...(overrides.display || {}),
+      },
+      ...(overrides.config || {}),
+    },
+    extraLabel: null,
+    ...(overrides.ctx || {}),
+  };
+}
+
+test('returns null when both toggles are off', () => {
+  const ctx = makeCtx({
+    transcript: {
+      sessionStart: new Date('2026-05-08T09:14:00Z'),
+      lastAssistantResponseAt: new Date('2026-05-08T10:00:00Z'),
+    },
+  });
+  const result = renderSessionTimeLine(ctx);
+  assert.equal(result, null);
+});
+
+test('renders session start date when showSessionStartDate is true', () => {
+  const startDate = new Date(2026, 4, 8, 9, 14, 0); // local time
+  const ctx = makeCtx({
+    display: { showSessionStartDate: true },
+    transcript: {
+      sessionStart: startDate,
+    },
+  });
+  const result = renderSessionTimeLine(ctx);
+  assert.ok(result);
+  assert.ok(result.includes('Started:'));
+  assert.ok(result.includes('2026-05-08 09:14'));
+});
+
+test('renders last response relative time when showLastResponseAt is true', () => {
+  const lastReply = new Date(2026, 4, 8, 10, 0, 0);
+  const now = lastReply.getTime() + 5 * 60 * 1000; // 5 minutes later
+  const ctx = makeCtx({
+    display: { showLastResponseAt: true },
+    transcript: {
+      lastAssistantResponseAt: lastReply,
+    },
+  });
+  const result = renderSessionTimeLine(ctx, () => now);
+  assert.ok(result);
+  assert.ok(result.includes('Last reply:'));
+  assert.ok(result.includes('5m ago'));
+});
+
+test('renders both when both toggles are on', () => {
+  const lastReply = new Date(2026, 4, 8, 11, 30, 0);
+  const now = lastReply.getTime() + 30 * 60 * 1000; // 30 minutes later
+  const ctx = makeCtx({
+    display: { showSessionStartDate: true, showLastResponseAt: true },
+    transcript: {
+      sessionStart: new Date(2026, 4, 8, 9, 14, 0),
+      lastAssistantResponseAt: lastReply,
+    },
+  });
+  const result = renderSessionTimeLine(ctx, () => now);
+  assert.ok(result);
+  assert.ok(result.includes('Started:'));
+  assert.ok(result.includes('Last reply:'));
+  assert.ok(result.includes('30m ago'));
+});
+
+test('returns null when showSessionStartDate is true but no sessionStart', () => {
+  const ctx = makeCtx({
+    display: { showSessionStartDate: true },
+    transcript: {},
+  });
+  const result = renderSessionTimeLine(ctx);
+  assert.equal(result, null);
+});
+
+test('returns null when showLastResponseAt is true but no lastAssistantResponseAt', () => {
+  const ctx = makeCtx({
+    display: { showLastResponseAt: true },
+    transcript: {},
+  });
+  const result = renderSessionTimeLine(ctx);
+  assert.equal(result, null);
+});
+
+test('formats hours correctly for last response', () => {
+  const lastReply = new Date(2026, 4, 8, 12, 0, 0);
+  const now = lastReply.getTime() + (2 * 60 + 30) * 60 * 1000; // 2h 30m later
+  const ctx = makeCtx({
+    display: { showLastResponseAt: true },
+    transcript: {
+      lastAssistantResponseAt: lastReply,
+    },
+  });
+  const result = renderSessionTimeLine(ctx, () => now);
+  assert.ok(result);
+  assert.ok(result.includes('2h 30m ago'));
+});
+
+test('formats days correctly for last response', () => {
+  const lastReply = new Date(2026, 4, 8, 10, 0, 0);
+  const now = lastReply.getTime() + 2 * 24 * 60 * 60 * 1000; // 2 days later
+  const ctx = makeCtx({
+    display: { showLastResponseAt: true },
+    transcript: {
+      lastAssistantResponseAt: lastReply,
+    },
+  });
+  const result = renderSessionTimeLine(ctx, () => now);
+  assert.ok(result);
+  assert.ok(result.includes('2d ago'));
+});
+
+test('formats seconds for very recent last response', () => {
+  const lastReply = new Date(2026, 4, 8, 10, 0, 0);
+  const now = lastReply.getTime() + 45 * 1000; // 45 seconds later
+  const ctx = makeCtx({
+    display: { showLastResponseAt: true },
+    transcript: {
+      lastAssistantResponseAt: lastReply,
+    },
+  });
+  const result = renderSessionTimeLine(ctx, () => now);
+  assert.ok(result);
+  assert.ok(result.includes('45s ago'));
+});

--- a/tests/session-time.test.js
+++ b/tests/session-time.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { renderSessionTimeLine } from '../dist/render/lines/session-time.js';
+import { setLanguage } from '../dist/i18n/index.js';
 
 function makeCtx(overrides = {}) {
   return {
@@ -87,6 +88,7 @@ test('renders both when both toggles are on', () => {
   assert.ok(result.includes('Started:'));
   assert.ok(result.includes('Last reply:'));
   assert.ok(result.includes('30m ago'));
+  assert.equal(result.includes('function dim'), false);
 });
 
 test('returns null when showSessionStartDate is true but no sessionStart', () => {
@@ -147,4 +149,26 @@ test('formats seconds for very recent last response', () => {
   const result = renderSessionTimeLine(ctx, () => now);
   assert.ok(result);
   assert.ok(result.includes('45s ago'));
+});
+
+test('renders localized labels and relative suffix', () => {
+  setLanguage('zh');
+  try {
+    const lastReply = new Date(2026, 4, 8, 10, 0, 0);
+    const now = lastReply.getTime() + 5 * 60 * 1000;
+    const ctx = makeCtx({
+      display: { showSessionStartDate: true, showLastResponseAt: true },
+      transcript: {
+        sessionStart: new Date(2026, 4, 8, 9, 14, 0),
+        lastAssistantResponseAt: lastReply,
+      },
+    });
+    const result = renderSessionTimeLine(ctx, () => now);
+    assert.ok(result);
+    assert.ok(result.includes('开始:'));
+    assert.ok(result.includes('上次回复:'));
+    assert.ok(result.includes('5m前'));
+  } finally {
+    setLanguage('en');
+  }
 });


### PR DESCRIPTION
## Summary

Add two new opt-in display toggles for session time awareness:

- **`showSessionStartDate`**: Shows when the session started (e.g., `Started: 2026-05-08 09:14`)
- **`showLastResponseAt`**: Shows time since Claude's last response (e.g., `Last reply: 2m ago`)

When both are enabled:
```
Started: 2026-05-08 09:14 │ Last reply: 2m ago
```

## Implementation

- Uses existing `sessionStart` and `lastAssistantResponseAt` from the transcript parser — no new data extraction needed
- Rendered as a new `sessionTime` HUD element in the element order system
- Both default to `false` (opt-in)
- Relative time formatting: `45s ago` → `5m ago` → `2h 30m ago` → `2d ago`
- `renderSessionTimeLine` accepts an optional `nowFn` parameter for deterministic testing

## Config

```json
{
  "display": {
    "showSessionStartDate": true,
    "showLastResponseAt": true
  }
}
```

## Tests

8 new tests covering:
- Both toggles off → null
- Each toggle independently
- Both together with separator
- Missing data gracefully returns null
- Time formatting: seconds, minutes, hours+minutes, days

All 559 tests pass.

Closes #529