### PR TITLE
fix(setup): generate PowerShell wrapper with try/catch + corrected version-dir glob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Windows + PowerShell `/claude-hud:setup` now writes a `statusline.ps1` wrapper that guards `[Console]::WindowWidth` in `try/catch` and uses the corrected `plugins\cache\*\claude-hud\*` glob with the required trailing wildcard. The HUD no longer silently fails on Windows when the statusLine subprocess has no console handle, and the cache glob no longer matches the `claude-hud` directory itself instead of its version subdirectories. Added guidance for writing `settings.json` without a UTF-8 BOM on Windows PowerShell 5.1, where `Set-Content -Encoding UTF8` emits `EF BB BF` (#521).
+
 ## [0.0.12] - 2026-04-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to Claude HUD will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Windows + PowerShell `/claude-hud:setup` now writes a `statusline.ps1` wrapper that guards `[Console]::WindowWidth` in `try/catch` and uses the corrected `plugins\cache\*\claude-hud\*` glob with the required trailing wildcard. The HUD no longer silently fails on Windows when the statusLine subprocess has no console handle, and the cache glob no longer matches the `claude-hud` directory itself instead of its version subdirectories. Added guidance for writing `settings.json` without a UTF-8 BOM on Windows PowerShell 5.1, where `Set-Content -Encoding UTF8` emits `EF BB BF` (#521).
+- Windows + PowerShell `/claude-hud:setup` now writes a `statusline.ps1` wrapper with a guarded width fallback and corrected version-directory glob (#521).
+- Added Windows PowerShell 5.1 guidance for writing `settings.json` without a UTF-8 BOM.
 
 ## [0.0.12] - 2026-04-04
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -205,7 +205,7 @@ Instead, use `sort -V` (GNU version sort, included with Git for Windows) which a
 1. Get plugin path:
    ```powershell
    $claudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
-   (Get-ChildItem (Join-Path $claudeDir "plugins\cache\*\claude-hud\*") -Directory | Where-Object { $_.Name -match '^\d+(\.\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName
+   (Get-ChildItem (Join-Path $claudeDir "plugins\cache\*\claude-hud\*") -Directory -ErrorAction SilentlyContinue | Where-Object { $_.Name -match '^\d+(\.\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName
    ```
    The trailing `\*` on the cache glob is required. Without it, `Get-ChildItem` returns the `claude-hud` directory itself, whose name does not match the `^\d+(\.\d+)+$` version pattern, so the lookup resolves to `$null` and any subsequent `Join-Path` throws (see [#521](https://github.com/jarrodwatts/claude-hud/issues/521)).
 
@@ -238,7 +238,7 @@ Instead, use `sort -V` (GNU version sort, included with Git for Windows) which a
    try { $w = [Console]::WindowWidth } catch { $w = 120 }
    $env:COLUMNS = [Math]::Max(1, $w - 4)
    $claudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME '.claude' }
-   $pluginDir = (Get-ChildItem (Join-Path $claudeDir 'plugins\cache\*\claude-hud\*') -Directory |
+   $pluginDir = (Get-ChildItem (Join-Path $claudeDir 'plugins\cache\*\claude-hud\*') -Directory -ErrorAction SilentlyContinue |
        Where-Object { $_.Name -match '^\d+(\.\d+)+$' } |
        Sort-Object { [version]$_.Name } -Descending |
        Select-Object -First 1).FullName
@@ -252,21 +252,22 @@ Instead, use `sort -V` (GNU version sort, included with Git for Windows) which a
    $wrapperDir = Join-Path $claudeDir "plugins\claude-hud"
    New-Item -ItemType Directory -Force -Path $wrapperDir | Out-Null
    $wrapperPath = Join-Path $wrapperDir "statusline.ps1"
+   $runtimePathLiteral = $runtimePath.Replace("'", "''")
    $wrapperBody = ({
        try { $w = [Console]::WindowWidth } catch { $w = 120 }
        $env:COLUMNS = [Math]::Max(1, $w - 4)
        $claudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME '.claude' }
-       $pluginDir = (Get-ChildItem (Join-Path $claudeDir 'plugins\cache\*\claude-hud\*') -Directory |
+       $pluginDir = (Get-ChildItem (Join-Path $claudeDir 'plugins\cache\*\claude-hud\*') -Directory -ErrorAction SilentlyContinue |
            Where-Object { $_.Name -match '^\d+(\.\d+)+$' } |
            Sort-Object { [version]$_.Name } -Descending |
            Select-Object -First 1).FullName
        if (-not $pluginDir) { exit 0 }
        & '__RUNTIME_PATH__' (Join-Path $pluginDir 'dist\index.js')
-   }.ToString().Trim()) -replace '__RUNTIME_PATH__', $runtimePath
+   }.ToString().Trim()).Replace('__RUNTIME_PATH__', $runtimePathLiteral)
    [System.IO.File]::WriteAllText($wrapperPath, $wrapperBody, (New-Object System.Text.UTF8Encoding $false))
    ```
 
-   `$runtimePath` is the value detected in step 2 (the absolute path returned by `(Get-Command node).Source`, typically `C:\Program Files\nodejs\node.exe`). The `__RUNTIME_PATH__` placeholder + `-replace` pattern avoids embedding a literal path inside the script block (where `{}` braces would parse the path's quoting differently).
+   `$runtimePath` is the value detected in step 2 (the absolute path returned by `(Get-Command node).Source`, typically `C:\Program Files\nodejs\node.exe`). `$runtimePathLiteral` escapes single quotes for the generated single-quoted PowerShell command, and `.Replace()` performs literal replacement so `$` and other regex replacement characters in the runtime path are preserved.
 
    `Set-Content -Encoding UTF8` and `Out-File -Encoding UTF8` on Windows PowerShell 5.1 both emit a UTF-8 BOM — PS 7+ added `-Encoding utf8NoBOM`, but PS 5.1 ships as the Windows 10/11 default and does not. `WriteAllText` + `UTF8Encoding $false` writes without a BOM in both versions.
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -205,8 +205,10 @@ Instead, use `sort -V` (GNU version sort, included with Git for Windows) which a
 1. Get plugin path:
    ```powershell
    $claudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
-   (Get-ChildItem (Join-Path $claudeDir "plugins\cache\*\claude-hud") -Directory | Where-Object { $_.Name -match '^\d+(\.\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName
+   (Get-ChildItem (Join-Path $claudeDir "plugins\cache\*\claude-hud\*") -Directory | Where-Object { $_.Name -match '^\d+(\.\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName
    ```
+   The trailing `\*` on the cache glob is required. Without it, `Get-ChildItem` returns the `claude-hud` directory itself, whose name does not match the `^\d+(\.\d+)+$` version pattern, so the lookup resolves to `$null` and any subsequent `Join-Path` throws (see [#521](https://github.com/jarrodwatts/claude-hud/issues/521)).
+
    If empty or errors, the plugin is not installed. Ask the user to install via marketplace first.
 
 2. Get runtime absolute path (require node on Windows):
@@ -224,15 +226,57 @@ Instead, use `sort -V` (GNU version sort, included with Git for Windows) which a
 
 3. Use `dist\index.js`.
 
-4. Generate command (note: quotes around runtime path handle spaces in paths):
+4. Write the PowerShell wrapper script.
 
-   The command exports `COLUMNS` so the HUD knows the real terminal width.
-   `[Console]::WindowWidth` reads the console buffer width. The `- 4`
-   accounts for Claude Code's input area padding (2 columns on each side).
+   Claude Code spawns the statusLine subprocess with no console handle attached. On Windows PowerShell 5.1, that makes `[Console]::WindowWidth` throw `System.IO.IOException: The handle is invalid.`, which halts the script before `node` runs — the HUD shows only "initializing..." and no error reaches any log. The macOS/Linux branch sidesteps this with `${cols:-120}` (`stty size` falls back when the controlling terminal is missing); the PowerShell equivalent is `try/catch` around `[Console]::WindowWidth`.
+
+   Inline `powershell -Command "..."` strings in `settings.json` make `try/catch` and multi-line control flow awkward because of nested quoting and the `cmd /s /c` rules that wrap the call. A standalone `.ps1` wrapper is the PowerShell equivalent of the macOS/Linux `bash -c '...'` script body — proper control flow, no JSON-string quoting pressure, and a single source of truth that future PS-side fixes can extend.
+
+   The wrapper file at `$claudeDir/plugins/claude-hud/statusline.ps1` should contain:
+
+   ```powershell
+   try { $w = [Console]::WindowWidth } catch { $w = 120 }
+   $env:COLUMNS = [Math]::Max(1, $w - 4)
+   $claudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME '.claude' }
+   $pluginDir = (Get-ChildItem (Join-Path $claudeDir 'plugins\cache\*\claude-hud\*') -Directory |
+       Where-Object { $_.Name -match '^\d+(\.\d+)+$' } |
+       Sort-Object { [version]$_.Name } -Descending |
+       Select-Object -First 1).FullName
+   if (-not $pluginDir) { exit 0 }
+   & '{RUNTIME_PATH}' (Join-Path $pluginDir 'dist\index.js')
+   ```
+
+   Write it using `[System.IO.File]::WriteAllText` with `New-Object System.Text.UTF8Encoding $false` so the file is UTF-8 without a BOM. A script block with `.ToString()` is the cleanest way to embed the body without here-string quoting pressure:
+
+   ```powershell
+   $wrapperDir = Join-Path $claudeDir "plugins\claude-hud"
+   New-Item -ItemType Directory -Force -Path $wrapperDir | Out-Null
+   $wrapperPath = Join-Path $wrapperDir "statusline.ps1"
+   $wrapperBody = ({
+       try { $w = [Console]::WindowWidth } catch { $w = 120 }
+       $env:COLUMNS = [Math]::Max(1, $w - 4)
+       $claudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME '.claude' }
+       $pluginDir = (Get-ChildItem (Join-Path $claudeDir 'plugins\cache\*\claude-hud\*') -Directory |
+           Where-Object { $_.Name -match '^\d+(\.\d+)+$' } |
+           Sort-Object { [version]$_.Name } -Descending |
+           Select-Object -First 1).FullName
+       if (-not $pluginDir) { exit 0 }
+       & '__RUNTIME_PATH__' (Join-Path $pluginDir 'dist\index.js')
+   }.ToString().Trim()) -replace '__RUNTIME_PATH__', $runtimePath
+   [System.IO.File]::WriteAllText($wrapperPath, $wrapperBody, (New-Object System.Text.UTF8Encoding $false))
+   ```
+
+   `$runtimePath` is the value detected in step 2 (the absolute path returned by `(Get-Command node).Source`, typically `C:\Program Files\nodejs\node.exe`). The `__RUNTIME_PATH__` placeholder + `-replace` pattern avoids embedding a literal path inside the script block (where `{}` braces would parse the path's quoting differently).
+
+   `Set-Content -Encoding UTF8` and `Out-File -Encoding UTF8` on Windows PowerShell 5.1 both emit a UTF-8 BOM — PS 7+ added `-Encoding utf8NoBOM`, but PS 5.1 ships as the Windows 10/11 default and does not. `WriteAllText` + `UTF8Encoding $false` writes without a BOM in both versions.
+
+5. Generate command (points at the wrapper file, not an inline `-Command` string):
 
    ```
-   powershell -Command "& {$env:COLUMNS=[Math]::Max(1,[Console]::WindowWidth-4); $claudeDir=if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME '.claude' }; $p=(Get-ChildItem (Join-Path $claudeDir 'plugins\cache\*\claude-hud') -Directory | Where-Object { $_.Name -match '^\d+(\.\d+)+$' } | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1).FullName; & '{RUNTIME_PATH}' (Join-Path $p '{SOURCE}')}"
+   powershell -NoProfile -ExecutionPolicy Bypass -File "{WRAPPER_PATH}"
    ```
+
+   `{WRAPPER_PATH}` is the value of `$wrapperPath` from step 4 (typically `C:\Users\<user>\.claude\plugins\claude-hud\statusline.ps1`).
 
 **WSL (Windows Subsystem for Linux)**: If running in WSL, use the macOS/Linux instructions. Ensure the plugin is installed in the Linux environment (`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/...`), not the Windows side.
 
@@ -265,6 +309,18 @@ If a write fails with `File has been unexpectedly modified`, re-read the file an
 **JSON safety**: Write `settings.json` with a real JSON serializer or editor API, not manual string concatenation.
 If you must inspect the saved JSON manually, the embedded bash command must preserve escaped backslashes inside the awk fragment.
 For example, the saved JSON should contain `\\$(NF-1)` and `\\$0`, not `\$(NF-1)` and `\$0`.
+
+**Windows PowerShell 5.1 BOM**: on Windows PowerShell 5.1 (the default shell on Windows 10/11), `Set-Content -Encoding UTF8` and `Out-File -Encoding UTF8` emit a UTF-8 BOM (`EF BB BF`). RFC 8259 §8.1 forbids BOM in JSON. PowerShell 7+ added `-Encoding utf8NoBOM`, but PS 5.1 did not. Use `[System.IO.File]::WriteAllText` with `New-Object System.Text.UTF8Encoding $false` to write UTF-8 without a BOM from both PS versions:
+
+```powershell
+[System.IO.File]::WriteAllText($path, $json, (New-Object System.Text.UTF8Encoding $false))
+```
+
+Verify the first bytes are `7B 0D 0A` (`{` + CRLF) or `7B 0A` (`{` + LF), not `EF BB BF`:
+
+```powershell
+[System.IO.File]::ReadAllBytes($path)[0..2]
+```
 
 
 After successfully writing the config, tell the user:
@@ -356,6 +412,15 @@ Use AskUserQuestion:
    - Root cause: `Shell: powershell` with `$OSTYPE=msys` or `$OSTYPE=cygwin`, causing bash to process the command before PowerShell
    - Check: run `echo $OSTYPE` in the Bash tool — if it returns `msys` or `cygwin`, this is the issue
    - Solution: re-run setup; when OSTYPE is `msys`/`cygwin`, follow the Windows + Git Bash path in Step 1
+
+   **Windows + PowerShell: HUD silent or "initializing..." with no error in any log (OSTYPE is not msys/cygwin)**:
+   - Symptoms: HUD stays at "initializing..." or shows nothing. Running the generated command interactively in a PowerShell prompt produces the expected HUD output, but the version invoked through Claude Code does not.
+   - Root cause: either (a) `[Console]::WindowWidth` threw `System.IO.IOException: The handle is invalid.` because the subprocess Claude Code spawns has no console handle, or (b) the cache glob `plugins\cache\*\claude-hud` (with no trailing `\*`) matched the `claude-hud` directory itself, leaving `$pluginDir` as `$null` and `Join-Path` throwing `Cannot bind argument to parameter 'Path' because it is null`.
+   - Check: pipe stdin through `cmd.exe` to mirror Claude Code's invocation:
+     ```powershell
+     '{}' | & cmd.exe /c '{GENERATED_COMMAND}'
+     ```
+     If you see either error, the existing setup predates the wrapper-based command format. Re-run `/claude-hud:setup` to regenerate `statusline.ps1` with `try/catch` and the corrected version-dir glob. See [#521](https://github.com/jarrodwatts/claude-hud/issues/521).
 
    **Windows: PowerShell execution policy error**:
    - Run: `Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned`


### PR DESCRIPTION
## Problem

On Windows + PowerShell 5.1 (the default shell on Windows 10/11), the statusLine command generated by `/claude-hud:setup` fails silently in two distinct ways when Claude Code spawns the subprocess. Multiple users on #521 confirmed both failure modes: HUD stays at "initializing..." or shows nothing, and no error reaches any log.

Closes #521

## Root cause

Two separate bugs in the inline `powershell -Command "..."` script that setup writes into `settings.json`:

1. **`[Console]::WindowWidth` throws `System.IO.IOException: "The handle is invalid."`** because the spawned process has no console handle attached. PowerShell halts before `node` runs. The macOS/Linux branch sidesteps this with `${cols:-120}` (stty falls back when the controlling terminal is missing); the PowerShell branch has no fallback.

2. **The cache glob `plugins\cache\*\claude-hud` (no trailing `\*`) matches the `claude-hud` directory itself**, whose name does not satisfy the `^\d+(\.\d+)+$` version pattern. `$pluginDir` resolves to `$null`, and the subsequent `Join-Path` throws `Cannot bind argument to parameter 'Path' because it is null`.

There is also a related PS 5.1 BOM gotcha that bites users who hand-edit `settings.json` from PowerShell: `Set-Content -Encoding UTF8` and `Out-File -Encoding UTF8` both emit a UTF-8 BOM on PS 5.1 (`-Encoding utf8NoBOM` only landed in PS 7+), which violates RFC 8259 §8.1 and breaks the JSON parser.

## Diagnosis steps used

1. Read the original `commands/setup.md` Windows + PowerShell branch and walked the generated command byte-by-byte under `pwsh` with no console handle, confirming `[Console]::WindowWidth` throws before `node` runs
2. Ran `Get-ChildItem (Join-Path $claudeDir "plugins\cache\*\claude-hud") -Directory` against a real plugin install: it returns the `claude-hud` directory, not the version subdirectories
3. Confirmed `Get-ChildItem (Join-Path $claudeDir "plugins\cache\*\claude-hud\*") -Directory` returns the version subdirectories (e.g. `0.0.12`) as intended
4. Verified `Set-Content -Encoding UTF8` emits `EF BB BF` on PS 5.1 by writing `{}` and inspecting `[System.IO.File]::ReadAllBytes($path)[0..2]`
5. End-to-end tested the new wrapper-file approach: wrote `statusline.ps1` to a temp dir, confirmed BOM-free (first 3 bytes `74 72 79` = `"try"`), parsed it cleanly with `[System.Management.Automation.Language.Parser]::ParseInput`, and ran it through `cmd.exe /c` with piped stdin to mirror Claude Code's invocation path

## Changes

- **`commands/setup.md` Step 1 (PS glob)**: corrected `plugins\cache\*\claude-hud` to `plugins\cache\*\claude-hud\*`, plus a paragraph explaining why the trailing `\*` is required
- **`commands/setup.md` Step 4 (wrapper file)**: setup now writes `statusline.ps1` to `$claudeDir/plugins/claude-hud/` containing the actual logic, and `settings.json` points at the wrapper via `-File`. The wrapper guards `[Console]::WindowWidth` in `try/catch` (fallback 120, matching macOS/Linux's `${cols:-120}` branch), uses the corrected glob, and exits cleanly when no plugin version is present. Written with `[System.IO.File]::WriteAllText` + `UTF8Encoding $false` for BOM-free output. The script-block-as-string pattern (`{ ... }.ToString().Trim()`) avoids here-string quoting pressure inside markdown
- **`commands/setup.md` Step 3 (settings.json BOM guidance)**: documents the PS 5.1 BOM trap with the `WriteAllText` / `UTF8Encoding $false` workaround and a verification snippet (`[System.IO.File]::ReadAllBytes($path)[0..2]`)
- **`commands/setup.md` Step 5 (debug)**: new entry for "HUD silent or 'initializing...' with no error in any log (OSTYPE is not msys/cygwin)" that distinguishes this from #531/#532's `OSTYPE=msys` case and points at the wrapper regeneration
- **`CHANGELOG.md`**: entry under `[Unreleased] > Fixed`

## Testing

Verified end-to-end in a real PowerShell environment:

- Wrapper written to `$claudeDir/plugins/claude-hud/statusline.ps1` — BOM-free (first 3 bytes `74 72 79`), parses cleanly under `[System.Management.Automation.Language.Parser]::ParseInput`
- `try/catch` around `[Console]::WindowWidth` — fallback `$w = 120` fires correctly when no console handle is attached
- Corrected glob — returns the version subdirectory (e.g. `0.0.12`) not the `claude-hud` directory itself
- `if (-not $pluginDir) { exit 0 }` — clean exit when plugin cache is empty
- End-to-end through `cmd.exe /c` with piped stdin (mirroring Claude Code's spawn path) — exit code 0