### PR TITLE
fix: git status octal-escaped unicode paths rendered as garbled text

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -85,7 +85,7 @@ export async function getGitStatus(cwd?: string): Promise<GitStatus | null> {
       try {
         const { stdout: numstatOut } = await execFileAsync(
           'git',
-          ['diff', '--numstat', 'HEAD'],
+          ['-c', 'core.quotePath=false', 'diff', '--numstat', 'HEAD'],
           { cwd, timeout: 2000, encoding: 'utf8' }
         );
         const trackedPaths = new Set(fileStats?.trackedFiles.map((file) => file.fullPath) ?? []);

--- a/src/git.ts
+++ b/src/git.ts
@@ -68,7 +68,7 @@ export async function getGitStatus(cwd?: string): Promise<GitStatus | null> {
     try {
       const { stdout: statusOut } = await execFileAsync(
         'git',
-        ['--no-optional-locks', 'status', '--porcelain'],
+        ['-c', 'core.quotePath=false', '--no-optional-locks', 'status', '--porcelain'],
         { cwd, timeout: 1000, encoding: 'utf8' }
       );
       const trimmed = statusOut.trim();

--- a/tests/git.test.js
+++ b/tests/git.test.js
@@ -165,6 +165,37 @@ test('getGitStatus counts modified files', async () => {
   }
 });
 
+test('getGitStatus returns UTF-8 filenames when core.quotePath is true', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-git-'));
+  try {
+    execFileSync('git', ['init'], { cwd: dir, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: dir, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir, stdio: 'ignore' });
+    execFileSync('git', ['config', 'core.quotePath', 'true'], { cwd: dir, stdio: 'ignore' });
+
+    const fileName = '日本語.txt';
+    await writeFile(path.join(dir, fileName), 'original\n');
+    execFileSync('git', ['add', fileName], { cwd: dir, stdio: 'ignore' });
+    execFileSync('git', ['commit', '-m', 'add utf8 file'], { cwd: dir, stdio: 'ignore' });
+
+    await writeFile(path.join(dir, fileName), 'modified\n');
+    const quotedStatus = execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' });
+    assert.match(quotedStatus, /\\[0-7]{3}/, `expected git to octal-escape path, got ${quotedStatus}`);
+    assert.equal(quotedStatus.includes(fileName), false);
+
+    const result = await getGitStatus(dir);
+    const tracked = result?.fileStats?.trackedFiles ?? [];
+
+    assert.equal(result?.fileStats?.modified, 1);
+    assert.deepEqual(
+      tracked.map((file) => ({ basename: file.basename, fullPath: file.fullPath, lineDiff: file.lineDiff })),
+      [{ basename: fileName, fullPath: fileName, lineDiff: { added: 1, deleted: 1 } }]
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('getGitStatus counts staged added files', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-git-'));
   try {


### PR DESCRIPTION
## Summary
- `git status --porcelain` with default `core.quotePath=true` outputs non-ASCII paths as C-style octal escapes (e.g. `"\346\265\213"` for Chinese)
- `parsePorcelainPath` tries `JSON.parse` which fails on octal escapes, falls back to raw escape string → HUD shows garbled `\346...` instead of actual filename
- Fix: pass `-c core.quotePath=false` to get raw UTF-8 paths

## Test plan
- [x] Create a file with CJK characters in name, run `git status`, verify HUD shows readable filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)