### PR TITLE
feat: use line-style instead of block-style usage progress bars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ src/
 
 ```
 [Opus] │ my-project git:(main*)
-Context █████░░░░░ 45% │ Usage ██░░░░░░░░ 25% (1h 30m / 5h)
+Context ━━━━━───── 45% │ Usage ━━━─────── 25% (1h 30m / 5h)
 ```
 
 Lines 1-2 always shown. Additional lines are opt-in via config:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Claude HUD gives you better insights into what's happening in your Claude Code s
 ### Default (2 lines)
 ```
 [Opus] │ my-project git:(main*)
-Context █████░░░░░ 45% │ Usage ██░░░░░░░░ 25% (1h 30m / 5h)
+Context ━━━━━───── 45% │ Usage ━━━─────── 25% (1h 30m / 5h)
 ```
 - **Line 1** — Model, provider label when positively identified (for example `Bedrock`, `Vertex`), project path, git branch
 - **Line 2** — Context bar (green → yellow → red) and usage rate limits
@@ -173,7 +173,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showModel` | boolean | true | Show model name `[Opus]` |
 | `display.showAddedDirs` | boolean | true | Show extra workspace directories from `/add-dir` (e.g. `+sparkle +lib-foo`); empty array renders nothing. In both layouts at most 5 dirs render (overflow shown as `+N more`) and basenames are truncated to 24 chars with `…` |
 | `display.addedDirsLayout` | `inline` \| `line` | `inline` | `inline` puts dirs next to the project name with a `+name` prefix per dir; `line` renders them on a separate `Added dirs: name1, name2` line (no `+` prefix, comma-separated) |
-| `display.showContextBar` | boolean | true | Show visual context bar `████░░░░░░` |
+| `display.showContextBar` | boolean | true | Show visual context bar `━━━━━─────` |
 | `display.contextValue` | `percent` \| `tokens` \| `remaining` \| `both` | `percent` | Context display format (`45%`, `45k/200k`, `55%` remaining, or `45% (45k/200k)`) |
 | `display.showConfigCounts` | boolean | false | Show CLAUDE.md, rules, MCPs, hooks counts |
 | `display.showCost` | boolean | false | Show session cost using Claude Code's native `cost.total_cost_usd` when available, with a local estimate fallback for direct Anthropic sessions |
@@ -211,8 +211,8 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `colors.gitBranch` | color value | `cyan` | Color for the git branch and branch status text |
 | `colors.label` | color value | `dim` | Color for labels and secondary metadata such as `Context`, `Usage`, counts, and progress text |
 | `colors.custom` | color value | `208` | Color for the optional custom line |
-| `colors.barFilled` | string | `█` | Character used for the filled portion of progress bars |
-| `colors.barEmpty` | string | `░` | Character used for the empty portion of progress bars |
+| `colors.barFilled` | string | `━` | Character used for the filled portion of progress bars |
+| `colors.barEmpty` | string | `─` | Character used for the empty portion of progress bars |
 
 `colors.barFilled` and `colors.barEmpty` accept a single visible grapheme. Control characters, invisible format characters (bidi controls, zero-width joiners, variation selectors), line/paragraph separators, and noncharacters are rejected. Wide characters (emoji, CJK) may affect bar alignment depending on the terminal.
 
@@ -239,7 +239,7 @@ Free/weekly-only accounts render the weekly window by itself instead of showing 
 The 7-day percentage appears when above the `display.sevenDayThreshold` (default 80%):
 
 ```
-Context █████░░░░░ 45% │ Usage ██░░░░░░░░ 25% (1h 30m / 5h) | ██████████ 85% (2d / 7d)
+Context ━━━━━───── 45% │ Usage ━━━─────── 25% (1h 30m / 5h) | ━━━━━━━━━─ 85% (2d / 7d)
 ```
 
 To disable, set `display.showUsage` to `false`.

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -13,7 +13,7 @@ Store current values and note whether config exists (determines which flow to us
 
 These are always enabled and NOT configurable:
 - Model name `[Opus]`
-- Context bar `████░░░░░░ 45%`
+- Context bar `━━━━━───── 45%`
 
 Advanced settings such as `colors.*`, `pathLevels`, `display.timeFormat`,
 `display.usageThreshold`, `display.usageValue`, `display.environmentThreshold`,
@@ -117,7 +117,7 @@ If user chooses "Enter custom text", use AskUserQuestion to get their text. Save
   - "Git status" - git:(main*) branch indicator
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
-  - "Usage bar style" - ██░░ 25% visual bar (only if usageBarEnabled is true)
+  - "Usage bar style" - ━─── 25% visual bar (only if usageBarEnabled is true)
   - "Compact usage" - 5h: 25% (1h 30m) shorter format (only if usageCompact is false)
 
 If more than 4 items ON, show Activity items (Tools, Agents, Todos, Project, Git) first.
@@ -132,7 +132,7 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
   - "Token breakdown" - (in: 45k, cache: 12k)
   - "Output speed" - out: 42.1 tok/s
   - "Usage limits" - 5h: 25% | 7d: 10%
-  - "Usage bar style" - ██░░ 25% visual bar (only if usageBarEnabled is false)
+  - "Usage bar style" - ━─── 25% visual bar (only if usageBarEnabled is false)
   - "Compact usage" - 5h: 25% (1h 30m) shorter format (only if usageCompact is false)
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
@@ -270,7 +270,7 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 
 | Option | Config | Example |
 |--------|--------|---------|
-| Bar style | `usageBarEnabled: true` | `Usage ██░░ 25% (resets in 1h 30m)` |
+| Bar style | `usageBarEnabled: true` | `Usage ━─── 25% (resets in 1h 30m)` |
 | Text style | `usageBarEnabled: false` | `Usage 5h 25% (resets in 1h 30m)` |
 | Compact | `usageCompact: true` | `5h: 25% (1h 30m)` — no "Usage" label, shorter reset format |
 
@@ -322,14 +322,14 @@ Changes:
 2. **Preview of HUD (Expanded layout):**
 ```
 [Opus | Pro] │ my-project git:(main*)
-Context ████░░░░░ 45% │ Usage ██░░░░░░░░ 25% (1h 30m / 5h)
+Context ━━━━━───── 45% │ Usage ━━━─────── 25% (1h 30m / 5h)
 ◐ Edit: file.ts | ✓ Read ×3
 ▸ Fix auth bug (2/5)
 ```
 
 **Preview of HUD (Compact layout):**
 ```
-[Opus | Pro] ████░░░░░ 45% | my-project git:(main*) | 5h: 25% | ⏱️ 5m
+[Opus | Pro] ━━━━━───── 45% | my-project git:(main*) | 5h: 25% | ⏱️ 5m
 ◐ Edit: file.ts | ✓ Read ×3
 ▸ Fix auth bug (2/5)
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -209,8 +209,8 @@ export const DEFAULT_CONFIG: HudConfig = {
     gitBranch: 'cyan',
     label: 'dim',
     custom: 208,
-    barFilled: '█',
-    barEmpty: '░',
+    barFilled: '━',
+    barEmpty: '─',
   },
 };
 

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -145,8 +145,8 @@ export function quotaBar(percent: number, width: number = 10, colors?: Partial<H
   const filled = Math.round((safePercent / 100) * safeWidth);
   const empty = safeWidth - filled;
   const color = getQuotaColor(safePercent, colors);
-  const filledChar = colors?.barFilled ?? '█';
-  const emptyChar = colors?.barEmpty ?? '░';
+  const filledChar = colors?.barFilled ?? '━';
+  const emptyChar = colors?.barEmpty ?? '─';
   return `${color}${filledChar.repeat(filled)}${DIM}${emptyChar.repeat(empty)}${RESET}`;
 }
 
@@ -161,7 +161,7 @@ export function coloredBar(
   const filled = Math.round((safePercent / 100) * safeWidth);
   const empty = safeWidth - filled;
   const color = getContextColor(safePercent, colors, thresholds);
-  const filledChar = colors?.barFilled ?? '█';
-  const emptyChar = colors?.barEmpty ?? '░';
+  const filledChar = colors?.barFilled ?? '━';
+  const emptyChar = colors?.barEmpty ?? '─';
   return `${color}${filledChar.repeat(filled)}${DIM}${emptyChar.repeat(empty)}${RESET}`;
 }

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -556,6 +556,8 @@ test('mergeConfig defaults colors to expected semantic palette', () => {
   assert.equal(config.colors.gitBranch, 'cyan');
   assert.equal(config.colors.label, 'dim');
   assert.equal(config.colors.custom, 208);
+  assert.equal(config.colors.barFilled, '━');
+  assert.equal(config.colors.barEmpty, '─');
 });
 
 test('mergeConfig accepts valid color overrides and filters invalid values', () => {

--- a/tests/fixtures/expected/render-basic.txt
+++ b/tests/fixtures/expected/render-basic.txt
@@ -1,2 +1,2 @@
 [Opus] │ my-project
-Context ███░░░░░░░ 29%
+Context ━━━─────── 29%

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -17,7 +17,7 @@ import { renderIdentityLine } from '../dist/render/lines/identity.js';
 import { renderEnvironmentLine } from '../dist/render/lines/environment.js';
 import { renderSessionTokensLine } from '../dist/render/lines/session-tokens.js';
 import { renderSessionTimeLine } from '../dist/render/lines/session-time.js';
-import { getContextColor, getQuotaColor } from '../dist/render/colors.js';
+import { coloredBar, getContextColor, getQuotaColor, quotaBar } from '../dist/render/colors.js';
 import { setLanguage } from '../dist/i18n/index.js';
 
 function stripAnsi(str) {
@@ -296,6 +296,14 @@ test('getContextColor and getQuotaColor resolve hex color strings', () => {
   assert.equal(getContextColor(70, colors), '\x1b[38;2;255;135;215m');
   assert.equal(getQuotaColor(25, colors), '\x1b[38;2;255;176;0m');
   assert.equal(getQuotaColor(80, colors), '\x1b[38;2;175;135;255m');
+});
+
+test('progress bars use line characters with rounded fill', () => {
+  assert.equal(stripAnsi(coloredBar(0, 10)), '──────────');
+  assert.equal(stripAnsi(coloredBar(4, 10)), '──────────');
+  assert.equal(stripAnsi(coloredBar(20, 10)), '━━────────');
+  assert.equal(stripAnsi(coloredBar(100, 10)), '━━━━━━━━━━');
+  assert.equal(stripAnsi(quotaBar(4, 10)), '──────────');
 });
 
 test('renderSessionLine includes config counts when present', () => {
@@ -1695,10 +1703,31 @@ test('renderUsageLine uses custom usage palette overrides', () => {
 
   const line = withTerminal(120, () => renderUsageLine(ctx));
   assert.ok(line, 'should render usage line');
-  assert.ok(line.includes('\x1b[36m███'), `expected custom usage bar color, got: ${JSON.stringify(line)}`);
+  assert.ok(line.includes('\x1b[36m━━━'), `expected custom usage bar color, got: ${JSON.stringify(line)}`);
   assert.ok(line.includes('\x1b[36m25%\x1b[0m'), `expected custom usage percentage color, got: ${JSON.stringify(line)}`);
-  assert.ok(line.includes('\x1b[35m████████'), `expected custom usage warning color, got: ${JSON.stringify(line)}`);
+  assert.ok(line.includes('\x1b[35m━━━━━━━━'), `expected custom usage warning color, got: ${JSON.stringify(line)}`);
   assert.ok(line.includes('\x1b[35m80%\x1b[0m'), `expected custom usage warning percentage color, got: ${JSON.stringify(line)}`);
+});
+
+test('rendered context and usage bars use line-style defaults', () => {
+  const ctx = baseContext();
+  ctx.config.display.usageBarEnabled = true;
+  ctx.usageData = {
+    planName: 'Pro',
+    fiveHour: 20,
+    sevenDay: null,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+  };
+
+  const identityLine = stripAnsi(renderIdentityLine(ctx));
+  const usageLine = stripAnsi(withTerminal(120, () => renderUsageLine(ctx)) ?? '');
+
+  assert.ok(identityLine.includes('━'), `expected context line bar to use filled line character: ${identityLine}`);
+  assert.ok(identityLine.includes('─'), `expected context line bar to use empty line character: ${identityLine}`);
+  assert.ok(!identityLine.includes('█'), `context line should not use block filled default: ${identityLine}`);
+  assert.ok(!identityLine.includes('░'), `context line should not use shaded empty default: ${identityLine}`);
+  assert.ok(usageLine.includes('━━──────── 20%'), `expected usage line to use line-style bar: ${usageLine}`);
 });
 
 test('quotaBar and coloredBar use custom barFilled and barEmpty characters', () => {
@@ -1794,7 +1823,7 @@ test('render adds separator line when showSeparators is true and activity exists
   }
 
   assert.ok(logs.length > 1, 'should render multiple lines');
-  assert.ok(logs.some(l => l.includes('─')), 'should include separator line');
+  assert.ok(logs.some(l => /^─+$/.test(stripAnsi(l))), 'should include separator line');
 });
 
 test('render omits separator when showSeparators is true but no activity', () => {
@@ -1810,7 +1839,7 @@ test('render omits separator when showSeparators is true but no activity', () =>
     console.log = originalLog;
   }
 
-  assert.ok(!logs.some(l => l.includes('─')), 'should not include separator');
+  assert.ok(!logs.some(l => /^─+$/.test(stripAnsi(l))), 'should not include separator');
 });
 
 test('render preserves regular spaces instead of non-breaking spaces', () => {


### PR DESCRIPTION
## problem
- my team finds the block-style progress bars too visually heavy, and often distracting w.r.t. the other elements of the hud.

## solution, design, scope

- Switch progress bars from block/shade characters to cleaner line characters (`━` / `─`), similar to the progress bars that other tools (e.g. uv) use.
- Update docs, configuration examples, fixtures, and focused render/config tests.

## test plan

- `npm run build && node --test tests/config.test.js tests/render.test.js`
- `npm test`
- `git diff --check`


new visual:
<img width="854" height="120" alt="Screenshot 2026-05-17 at 8 50 30 PM" src="https://github.com/user-attachments/assets/5ff3fc18-0d63-4071-ae63-603abda3dfd1" />
