### PR TITLE
fix(transcript): deduplicate consecutive token usage entries

### DIFF
--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -251,6 +251,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
     cacheCreationTokens: 0,
     cacheReadTokens: 0,
   };
+  let lastUsageKey = '';
 
   let parsedCleanly = false;
 
@@ -271,9 +272,14 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
         } else if (typeof entry.slug === 'string') {
           latestSlug = entry.slug;
         }
-        // Accumulate token usage from assistant messages
+        // Accumulate token usage from assistant messages.
+        // Claude Code can write the same API response to the transcript 2-3 times
+        // consecutively (dual-logging). Skip consecutive duplicates to avoid inflating counts.
         if (entry.type === 'assistant' && entry.message?.usage) {
           const usage = entry.message.usage;
+          const key = `${usage.input_tokens}|${usage.output_tokens}|${usage.cache_creation_input_tokens}|${usage.cache_read_input_tokens}`;
+          if (key === lastUsageKey) continue;
+          lastUsageKey = key;
           sessionTokens.inputTokens += normalizeTokenCount(usage.input_tokens);
           sessionTokens.outputTokens += normalizeTokenCount(usage.output_tokens);
           sessionTokens.cacheCreationTokens += normalizeTokenCount(usage.cache_creation_input_tokens);

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -74,7 +74,7 @@ interface TranscriptCacheFile {
   data: SerializedTranscriptData;
 }
 
-const TRANSCRIPT_CACHE_VERSION = 4;
+const TRANSCRIPT_CACHE_VERSION = 5;
 
 let createReadStreamImpl: typeof fs.createReadStream = fs.createReadStream;
 
@@ -251,7 +251,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
     cacheCreationTokens: 0,
     cacheReadTokens: 0,
   };
-  let lastUsageKey = '';
+  let lastUsageKey: string | undefined;
 
   let parsedCleanly = false;
 
@@ -263,7 +263,10 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
     });
 
     for await (const line of rl) {
-      if (!line.trim()) continue;
+      if (!line.trim()) {
+        lastUsageKey = undefined;
+        continue;
+      }
 
       try {
         const entry = JSON.parse(line) as TranscriptLine;
@@ -278,12 +281,15 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
         if (entry.type === 'assistant' && entry.message?.usage) {
           const usage = entry.message.usage;
           const key = `${usage.input_tokens}|${usage.output_tokens}|${usage.cache_creation_input_tokens}|${usage.cache_read_input_tokens}`;
-          if (key === lastUsageKey) continue;
+          if (key !== lastUsageKey) {
+            sessionTokens.inputTokens += normalizeTokenCount(usage.input_tokens);
+            sessionTokens.outputTokens += normalizeTokenCount(usage.output_tokens);
+            sessionTokens.cacheCreationTokens += normalizeTokenCount(usage.cache_creation_input_tokens);
+            sessionTokens.cacheReadTokens += normalizeTokenCount(usage.cache_read_input_tokens);
+          }
           lastUsageKey = key;
-          sessionTokens.inputTokens += normalizeTokenCount(usage.input_tokens);
-          sessionTokens.outputTokens += normalizeTokenCount(usage.output_tokens);
-          sessionTokens.cacheCreationTokens += normalizeTokenCount(usage.cache_creation_input_tokens);
-          sessionTokens.cacheReadTokens += normalizeTokenCount(usage.cache_read_input_tokens);
+        } else {
+          lastUsageKey = undefined;
         }
         // Track Claude Code's compact_boundary marker. Both manual (/compact)
         // and auto compaction emit this system entry with compactMetadata; we
@@ -316,6 +322,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
         }
         processEntry(entry, toolMap, agentMap, taskIdToIndex, latestTodos, result);
       } catch {
+        lastUsageKey = undefined;
         // Skip malformed lines
       }
     }

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -566,6 +566,59 @@ test('parseTranscript accumulates session token usage from assistant messages', 
   }
 });
 
+test('parseTranscript counts adjacent duplicate assistant usage once', async () => {
+  const usageEntry = {
+    type: 'assistant',
+    message: {
+      usage: {
+        input_tokens: 100,
+        output_tokens: 25,
+        cache_creation_input_tokens: 10,
+        cache_read_input_tokens: 5,
+      },
+    },
+  };
+
+  const result = await parseTempTranscript('session-tokens-adjacent-duplicate.jsonl', [
+    usageEntry,
+    usageEntry,
+  ]);
+
+  assert.deepEqual(result.sessionTokens, {
+    inputTokens: 100,
+    outputTokens: 25,
+    cacheCreationTokens: 10,
+    cacheReadTokens: 5,
+  });
+});
+
+test('parseTranscript counts identical assistant usage separated by another line twice', async () => {
+  const usageEntry = {
+    type: 'assistant',
+    message: {
+      usage: {
+        input_tokens: 100,
+        output_tokens: 25,
+        cache_creation_input_tokens: 10,
+        cache_read_input_tokens: 5,
+      },
+    },
+  };
+
+  const result = await parseTempTranscript('session-tokens-separated-duplicate.jsonl', [
+    usageEntry,
+    { type: 'user', timestamp: '2024-01-01T00:00:01.000Z' },
+    usageEntry,
+  ]);
+
+  assert.deepEqual(result.sessionTokens, {
+    inputTokens: 200,
+    outputTokens: 50,
+    cacheCreationTokens: 20,
+    cacheReadTokens: 10,
+  });
+});
+
 test('parseTranscript records the most recent compact_boundary and postTokens', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-'));
   const filePath = path.join(dir, 'compact-boundary.jsonl');


### PR DESCRIPTION
Claude Code writes each API response's usage to the transcript
2-3 times consecutively (dual-logging). The transcript parser was
summing every entry, inflating session token counts by ~2.3x.

This skips consecutive entries with identical usage values.

Refs #556