### PR TITLE
fix: close OSC 8 hyperlink on truncation so its underline does not bleed

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -157,6 +157,26 @@ function sliceVisible(str: string, maxVisible: number): string {
   return result;
 }
 
+// OSC 8 close sequence (`\x1b]8;;\x1b\\`) terminates the current hyperlink.
+// If truncation cuts inside an open OSC 8 hyperlink, emitting only an SGR
+// reset (`\x1b[0m`) is not enough — the terminal keeps treating subsequent
+// output as part of the link and renders its underline across the rest of
+// the line. This helper returns the close sequence iff the last OSC 8 in
+// `str` opened a hyperlink (non-empty URL) without being followed by a
+// closer (empty URL).
+const OSC8_OPEN_OR_CLOSE = /\x1b\]8;;([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
+const OSC8_CLOSE = '\x1b]8;;\x1b\\';
+
+function closeOpenHyperlink(str: string): string {
+  let last: RegExpExecArray | null = null;
+  let match: RegExpExecArray | null;
+  OSC8_OPEN_OR_CLOSE.lastIndex = 0;
+  while ((match = OSC8_OPEN_OR_CLOSE.exec(str)) !== null) {
+    last = match;
+  }
+  return last && last[1].length > 0 ? OSC8_CLOSE : '';
+}
+
 function truncateToWidth(str: string, maxWidth: number): string {
   if (maxWidth <= 0 || visualLength(str) <= maxWidth) {
     return str;
@@ -164,7 +184,10 @@ function truncateToWidth(str: string, maxWidth: number): string {
 
   const suffix = maxWidth >= 3 ? '...' : '.'.repeat(maxWidth);
   const keep = Math.max(0, maxWidth - suffix.length);
-  return `${sliceVisible(str, keep)}${suffix}${RESET}`;
+  const sliced = sliceVisible(str, keep);
+  // Close the hyperlink (if any) before the ellipsis so the suffix renders
+  // as plain text rather than as part of the truncated link.
+  return `${sliced}${closeOpenHyperlink(sliced)}${suffix}${RESET}`;
 }
 
 function splitLineBySeparators(line: string): { segments: string[]; separators: string[] } {

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -348,6 +348,44 @@ test('render ignores BEL-terminated OSC 8 hyperlink sequences when measuring lin
   assert.ok(displayWidth(lines[0]) <= 47, 'visible width should respect terminal width');
 });
 
+test('render closes an OSC 8 hyperlink when truncation cuts inside it', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'compact';
+  ctx.stdin.context_window.current_usage.input_tokens = 0;
+  ctx.config.display.showContextBar = false;
+  ctx.config.display.showConfigCounts = false;
+  ctx.config.display.showUsage = false;
+  ctx.stdin.cwd = '/tmp/p';
+  // Label is wider than the terminal so truncation must cut inside it.
+  const linkLabel = 'a-very-long-hyperlink-label-that-must-be-truncated';
+  ctx.extraLabel = `\x1b]8;;file:///tmp/p/x\x1b\\${linkLabel}\x1b]8;;\x1b\\`;
+
+  const logs = [];
+  const originalLog = console.log;
+  console.log = line => logs.push(line);
+  try {
+    // Drive render directly so logs retain ANSI/OSC sequences (the
+    // shared captureRender helper strips them before returning).
+    withTerminal(20, () => render(ctx));
+  } finally {
+    console.log = originalLog;
+  }
+
+  const rawLines = logs;
+  const truncated = rawLines.find(line => line.includes('...'));
+  assert.ok(truncated, 'one line should have been truncated with an ellipsis');
+
+  const sliceBeforeEllipsis = truncated.slice(0, truncated.indexOf('...'));
+  assert.ok(
+    /\x1b\]8;;[^\x07\x1b]+(?:\x07|\x1b\\)/.test(sliceBeforeEllipsis),
+    'the truncated slice should have opened an OSC 8 hyperlink',
+  );
+  assert.ok(
+    /\x1b\]8;;(?:\x07|\x1b\\)/.test(sliceBeforeEllipsis),
+    'the truncated slice should close the hyperlink before the ellipsis so the underline does not bleed past',
+  );
+});
+
 test('render does not wrap when no real terminal width is available', () => {
   const ctx = baseContext();
   ctx.stdin.model = { display_name: 'Sonnet 4.6' };


### PR DESCRIPTION
## Summary

`truncateToWidth` (in `src/render/index.ts`) appends only an SGR reset (`\x1b[0m`) after the ellipsis. SGR reset clears the underline *attribute* but does not close an open **OSC 8** hyperlink. When the slice cuts inside a `\x1b]8;;URL\x1b\\…label…` sequence, the hyperlink remains open and most terminals (iTerm2, Ghostty, kitty, …) render the link's underline through the rest of the line — looking like a long stream of underscores.

This is most visible in `renderGitFilesLine` (`src/render/lines/project.ts`), where each changed-file basename is wrapped in an OSC 8 hyperlink via `safeHyperlink(...)`. With many changed files in a narrow terminal, the line truncates inside one of those links and every character after `~some_filename_...` gets underlined.

## Repro

Modify several files with long basenames, e.g.

```
~/src/internal/portalapi/argocd/get_application_deployment_stats_v1.go
~/src/internal/portalapi/argocd/get_sync_operations_events_v1.go
~/src/internal/portalapi/argocd/get_sync_operations_stats_v1.go
```

…in a repo where `gitStatus.showFileStats = true` and the terminal is narrow enough that the file list overflows the available width. In the status line the truncated entry shows as `~get_application_deployment_..._` with the underline continuing past the ellipsis into the rest of the line.

## Fix

Detect the trailing unclosed OSC 8 in the truncated slice and emit the close sequence (`\x1b]8;;\x1b\\`) **before** the ellipsis, so the `...` renders as plain text and the underline stops at the link's last visible character. Detection scans the kept slice for the last `\x1b]8;;…(BEL|ST)` sequence; if its URL component is non-empty (an open), we emit a closer. Closing an already-closed link would be a no-op anyway, but detection keeps the output clean for hyperlink-free lines.

The close is inserted before the ellipsis intentionally so the truncation marker is not part of the link's clickable text.

## Tests

- New: `render closes an OSC 8 hyperlink when truncation cuts inside it` in `tests/render-width.test.js`. Renders a long `extraLabel` wrapped in an OSC 8 hyperlink at terminal width 20, then asserts the truncated slice contains both an opening OSC 8 sequence and a closing one before `...`.
- All 578 existing tests still pass (`npm test`).

## Notes

- Only `src/` and `tests/` are modified, per `CONTRIBUTING.md`. `dist/` will be rebuilt by CI on merge.