### PR TITLE
feat: DeepSeek balance companion script for external usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,3 +118,32 @@ Note: `statusLine` is NOT a valid plugin.json field. It must be configured in se
 
 - **Runtime**: Node.js 18+ or Bun
 - **Build**: TypeScript 5, ES2022 target, NodeNext modules
+
+## Companion Scripts
+
+### deepseek-balance.js — DeepSeek 余额显示
+
+`scripts/deepseek-balance.js` 是一个独立 Node.js 脚本，调用 DeepSeek API `GET /user/balance` 获取账户余额，输出为 ExternalUsageSnapshot JSON 格式。
+
+**用途：** 当 Claude Code 使用 DeepSeek 作为 API Provider（Anthropic 兼容接口）时，ClaudeHUD 无法获取 Anthropic 的速率限制百分比。此脚本通过 `balance_label` 字段显示 DeepSeek 余额。
+
+**使用：**
+```bash
+DEEPSEEK_API_KEY=sk-your-key node scripts/deepseek-balance.js --output /path/to/snapshot.json
+```
+
+**配置 claude-hud：**
+```json
+{
+  "display": {
+    "externalUsagePath": "/path/to/snapshot.json",
+    "externalUsageFreshnessMs": 600000
+  }
+}
+```
+
+**定时刷新（macOS launchd）：**
+将 `com.deepseek-balance.plist` 复制到 `~/Library/LaunchAgents/`，修改 API Key，然后：
+```bash
+launchctl load ~/Library/LaunchAgents/com.deepseek-balance.plist
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,18 +121,28 @@ Note: `statusLine` is NOT a valid plugin.json field. It must be configured in se
 
 ## Companion Scripts
 
-### deepseek-balance.js — DeepSeek 余额显示
+### deepseek-balance.js — DeepSeek Balance Display
 
-`scripts/deepseek-balance.js` 是一个独立 Node.js 脚本，调用 DeepSeek API `GET /user/balance` 获取账户余额，输出为 ExternalUsageSnapshot JSON 格式。
+`scripts/deepseek-balance.js` is a standalone Node.js script that fetches DeepSeek account balance via `GET /user/balance` and outputs an `ExternalUsageSnapshot` JSON for claude-hud's external usage mechanism.
 
-**用途：** 当 Claude Code 使用 DeepSeek 作为 API Provider（Anthropic 兼容接口）时，ClaudeHUD 无法获取 Anthropic 的速率限制百分比。此脚本通过 `balance_label` 字段显示 DeepSeek 余额。
+**Purpose:** When Claude Code uses DeepSeek as its API provider (via Anthropic-compatible endpoint), claude-hud can't get Anthropic-style rate limit percentages. This script bridges the gap by displaying prepaid balance via the `balance_label` field.
 
-**使用：**
+**Usage:**
 ```bash
 DEEPSEEK_API_KEY=sk-your-key node scripts/deepseek-balance.js --output /path/to/snapshot.json
 ```
 
-**配置 claude-hud：**
+**Output format:**
+```json
+{
+  "updated_at": 1779356358855,
+  "balance_label": "Balance ¥108.50",
+  "five_hour": null,
+  "seven_day": null
+}
+```
+
+**claude-hud config:**
 ```json
 {
   "display": {
@@ -142,8 +152,9 @@ DEEPSEEK_API_KEY=sk-your-key node scripts/deepseek-balance.js --output /path/to/
 }
 ```
 
-**定时刷新（macOS launchd）：**
-将 `com.deepseek-balance.plist` 复制到 `~/Library/LaunchAgents/`，修改 API Key，然后：
+**Periodic refresh (macOS launchd):**
+Copy `scripts/com.deepseek-balance.plist` to `~/Library/LaunchAgents/`, edit the API key and paths, then:
 ```bash
 launchctl load ~/Library/LaunchAgents/com.deepseek-balance.plist
+```
 ```

--- a/README.md
+++ b/README.md
@@ -299,13 +299,13 @@ DEEPSEEK_API_KEY=sk-your-key node scripts/deepseek-balance.js --output /path/to/
 ```json
 {
   "updated_at": 1779356358855,
-  "balance_label": "余额 ¥108.50",
+  "balance_label": "Balance ¥108.50",
   "five_hour": null,
   "seven_day": null
 }
 ```
 
-在 `~/.claude/plugins/claude-hud/config.json` 中配置外部用量路径：
+In your claude-hud config (`~/.claude/plugins/claude-hud/config.json`):
 
 ```json
 {
@@ -316,7 +316,7 @@ DEEPSEEK_API_KEY=sk-your-key node scripts/deepseek-balance.js --output /path/to/
 }
 ```
 
-HUD 将显示 `Usage: 余额 ¥108.50`。建议配合 launchd 或 crontab 每 5-10 分钟刷新一次。
+The HUD will display `Usage: Balance ¥108.50`. For automatic refresh, use launchd or crontab every 5-10 minutes.
 
 ### Example Configuration
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,41 @@ Example fallback snapshot:
 }
 ```
 
+### DeepSeek 余额显示 / DeepSeek Balance
+
+如果你使用 **DeepSeek** 作为 Claude Code 的 API Provider（通过 Anthropic 兼容接口），ClaudeHUD 无法获取用量百分比。但可以通过外部快照显示 DeepSeek 账户余额。
+
+项目提供了一个 companion 脚本 `scripts/deepseek-balance.js`：
+
+```bash
+# 获取余额并写入文件
+DEEPSEEK_API_KEY=sk-your-key node scripts/deepseek-balance.js --output /path/to/balance.json
+```
+
+脚本输出格式：
+
+```json
+{
+  "updated_at": 1779356358855,
+  "balance_label": "余额 ¥108.50",
+  "five_hour": null,
+  "seven_day": null
+}
+```
+
+在 `~/.claude/plugins/claude-hud/config.json` 中配置外部用量路径：
+
+```json
+{
+  "display": {
+    "externalUsagePath": "/path/to/balance.json",
+    "externalUsageFreshnessMs": 600000
+  }
+}
+```
+
+HUD 将显示 `Usage: 余额 ¥108.50`。建议配合 launchd 或 crontab 每 5-10 分钟刷新一次。
+
 ### Example Configuration
 
 ```json

--- a/README.zh.md
+++ b/README.zh.md
@@ -273,7 +273,7 @@ DEEPSEEK_API_KEY=sk-your-key node scripts/deepseek-balance.js --output /path/to/
 ```json
 {
   "updated_at": 1779356358855,
-  "balance_label": "余额 ¥108.50",
+  "balance_label": "Balance ¥108.50",
   "five_hour": null,
   "seven_day": null
 }
@@ -290,7 +290,7 @@ DEEPSEEK_API_KEY=sk-your-key node scripts/deepseek-balance.js --output /path/to/
 }
 ```
 
-HUD 将显示 `Usage: 余额 ¥108.50`。建议配合 launchd 或 crontab 每 5-10 分钟刷新一次。
+HUD 将显示 `Usage: Balance ¥108.50`。建议配合 launchd 或 crontab 每 5-10 分钟刷新一次。
 
 ### 配置示例
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -257,6 +257,41 @@ ClaudeHUD 优先使用官方 statusline stdin 负载中的使用率数据。如�
 }
 ```
 
+### DeepSeek 余额显示
+
+如果你使用 **DeepSeek** 作为 Claude Code 的 API Provider（通过 Anthropic 兼容接口），ClaudeHUD 无法获取用量百分比。但可以通过外部快照显示 DeepSeek 账户余额。
+
+项目提供了一个 companion 脚本 `scripts/deepseek-balance.js`：
+
+```bash
+# 获取余额并写入文件
+DEEPSEEK_API_KEY=sk-your-key node scripts/deepseek-balance.js --output /path/to/balance.json
+```
+
+脚本输出格式：
+
+```json
+{
+  "updated_at": 1779356358855,
+  "balance_label": "余额 ¥108.50",
+  "five_hour": null,
+  "seven_day": null
+}
+```
+
+在 `~/.claude/plugins/claude-hud/config.json` 中配置外部用量路径：
+
+```json
+{
+  "display": {
+    "externalUsagePath": "/path/to/balance.json",
+    "externalUsageFreshnessMs": 600000
+  }
+}
+```
+
+HUD 将显示 `Usage: 余额 ¥108.50`。建议配合 launchd 或 crontab 每 5-10 分钟刷新一次。
+
 ### 配置示例
 
 ```json

--- a/scripts/com.deepseek-balance.plist
+++ b/scripts/com.deepseek-balance.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.deepseek-balance</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/node</string>
+        <string>/path/to/claude-hud/scripts/deepseek-balance.js</string>
+        <string>--output</string>
+        <string>/path/to/.claude/plugins/claude-hud/deepseek-balance.json</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>DEEPSEEK_API_KEY</key>
+        <string>sk-your-key-here</string>
+    </dict>
+    <key>StartInterval</key>
+    <integer>600</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/path/to/.claude/plugins/claude-hud/deepseek-balance.log</string>
+    <key>StandardErrorPath</key>
+    <string>/path/to/.claude/plugins/claude-hud/deepseek-balance.log</string>
+    <key>KeepAlive</key>
+    <false/>
+</dict>
+</plist>

--- a/scripts/deepseek-balance.js
+++ b/scripts/deepseek-balance.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const DEEPSEEK_API_URL = 'https://api.deepseek.com/user/balance';
+
+function printHelp() {
+  process.stdout.write(`Usage: deepseek-balance.js [options]
+
+Fetch DeepSeek account balance and output as an ExternalUsageSnapshot JSON
+for use with claude-hud's display.externalUsagePath.
+
+Options:
+  --output <path>  Write JSON to file instead of stdout
+  --help           Show this help message
+
+Environment Variables:
+  DEEPSEEK_API_KEY         DeepSeek API key (primary)
+  ANTHROPIC_AUTH_TOKEN     Fallback if DEEPSEEK_API_KEY is not set
+
+Output format:
+  {
+    "updated_at": 1779356358855,
+    "balance_label": "余额 ¥108.50",
+    "five_hour": null,
+    "seven_day": null
+  }
+
+Exit codes:
+  0  Success
+  1  Error (missing key, network failure, unexpected response)
+`);
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let outputPath = null;
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--help':
+        printHelp();
+        process.exit(0);
+      case '--output':
+        i++;
+        if (i >= args.length) {
+          console.error('Error: --output requires a path argument');
+          process.exit(1);
+        }
+        outputPath = args[i];
+        break;
+      default:
+        if (args[i].startsWith('--')) {
+          console.error(`Error: Unknown option: ${args[i]}`);
+        } else {
+          console.error(`Error: Unexpected argument: ${args[i]}`);
+        }
+        console.error('Use --help for usage information.');
+        process.exit(1);
+    }
+  }
+
+  return { outputPath };
+}
+
+function getApiKey() {
+  const key = process.env.DEEPSEEK_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN;
+  if (!key || typeof key !== 'string' || !key.trim()) {
+    console.error(
+      'Error: No API key found.\n' +
+      'Set the DEEPSEEK_API_KEY environment variable.\n' +
+      '(ANTHROPIC_AUTH_TOKEN is also accepted as a fallback.)',
+    );
+    process.exit(1);
+  }
+  return key.trim();
+}
+
+function formatBalanceLabel(totalBalance, currency) {
+  let symbol;
+  switch (currency) {
+    case 'RMB':
+    case 'CNY':
+      symbol = '¥';
+      break;
+    case 'USD':
+      symbol = '$';
+      break;
+    default:
+      symbol = `${currency} `;
+  }
+
+  const formatted = Number(totalBalance).toFixed(2);
+  return `余额 ${symbol}${formatted}`;
+}
+
+async function fetchBalance(apiKey) {
+  let response;
+  try {
+    response = await fetch(DEEPSEEK_API_URL, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json',
+      },
+    });
+  } catch (cause) {
+    throw new Error(`Network error while calling DeepSeek API: ${cause.message}`);
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    const snippet = body ? `: ${body.replace(/[\x00-\x1f]/g, ' ').slice(0, 200)}` : '';
+    throw new Error(`DeepSeek API returned HTTP ${response.status}${snippet}`);
+  }
+
+  let data;
+  try {
+    data = await response.json();
+  } catch (cause) {
+    throw new Error(`Failed to parse DeepSeek API response: ${cause.message}`);
+  }
+
+  if (!data || typeof data !== 'object') {
+    throw new Error('DeepSeek API returned non-object response');
+  }
+
+  if (!Array.isArray(data.balance_infos) || data.balance_infos.length === 0) {
+    const snippet = JSON.stringify(data).slice(0, 200);
+    throw new Error(`Unexpected API response (missing balance_infos): ${snippet}`);
+  }
+
+  const balanceInfo = data.balance_infos[0];
+  if (!balanceInfo || typeof balanceInfo !== 'object') {
+    throw new Error('Invalid balance entry in API response');
+  }
+
+  const totalBalance = balanceInfo.total_balance;
+  if (totalBalance == null) {
+    throw new Error('Missing total_balance in API response');
+  }
+
+  const numericBalance = Number(totalBalance);
+  if (!Number.isFinite(numericBalance)) {
+    throw new Error(`Invalid total_balance value: ${JSON.stringify(totalBalance)}`);
+  }
+
+  const currency = typeof balanceInfo.currency === 'string' && balanceInfo.currency
+    ? balanceInfo.currency
+    : 'RMB';
+
+  return {
+    updated_at: Date.now(),
+    balance_label: formatBalanceLabel(numericBalance, currency),
+    five_hour: null,
+    seven_day: null,
+  };
+}
+
+async function main() {
+  const { outputPath } = parseArgs();
+  const apiKey = getApiKey();
+  const snapshot = await fetchBalance(apiKey);
+  const json = JSON.stringify(snapshot, null, 2) + '\n';
+
+  if (outputPath) {
+    const dir = path.dirname(outputPath);
+    if (dir) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(outputPath, json, 'utf8');
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+main().catch((err) => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/deepseek-balance.js
+++ b/scripts/deepseek-balance.js
@@ -22,7 +22,7 @@ Environment Variables:
 Output format:
   {
     "updated_at": 1779356358855,
-    "balance_label": "余额 ¥108.50",
+    "balance_label": "Balance ¥108.50",
     "five_hour": null,
     "seven_day": null
   }
@@ -92,7 +92,7 @@ function formatBalanceLabel(totalBalance, currency) {
   }
 
   const formatted = Number(totalBalance).toFixed(2);
-  return `余额 ${symbol}${formatted}`;
+  return `Balance ${symbol}${formatted}`;
 }
 
 async function fetchBalance(apiKey) {


### PR DESCRIPTION
## Summary

This PR adds a standalone companion script `scripts/deepseek-balance.js` for DeepSeek API users who run Claude Code via the Anthropic-compatible endpoint.

## Background

ClaudeHUD already supports displaying external usage data via `display.externalUsagePath` (JSON snapshot with `balance_label`). DeepSeek uses a prepaid balance model rather than Anthropic-style rate limits (5h/7d percentages). This script bridges that gap.

## Changes

### New files
- **`scripts/deepseek-balance.js`** — Node.js script that:
  - Reads `DEEPSEEK_API_KEY` (or `ANTHROPIC_AUTH_TOKEN` fallback)
  - Calls `GET https://api.deepseek.com/user/balance`
  - Outputs `ExternalUsageSnapshot` JSON with `balance_label` (e.g. `"余额 ¥108.50"`)
  - Supports `--output <path>` flag for file-based periodic refresh
  - Handles errors gracefully (missing key, network failure, malformed response)
- **`scripts/com.deepseek-balance.plist`** — Example macOS launchd config for auto-refresh every 10 minutes

### Documentation
- `CLAUDE.md` — Added companion script section with usage instructions
- `README.md` — Added "DeepSeek Balance" section in External Usage area
- `README.zh.md` — Same section in Chinese

### How it works

No changes to claude-hud core. The `external-usage.ts` mechanism already supports `balance_label` — when present, `usage.ts` renders it directly instead of percentage bars. This script simply provides the data in the expected format.

## Testing

```bash
DEEPSEEK_API_KEY=sk-your-key node scripts/deepseek-balance.js
# Output: {"updated_at": ..., "balance_label": "余额 ¥108.50", "five_hour": null, "seven_day": null}
```

Configure claude-hud:
```json
{
  "display": {
    "externalUsagePath": "/path/to/balance.json",
    "externalUsageFreshnessMs": 600000
  }
}
```