### PR TITLE
fix(windows): hide console flash on child_process spawns

### DIFF
--- a/src/extra-cmd.ts
+++ b/src/extra-cmd.ts
@@ -81,6 +81,7 @@ export async function runExtraCmd(cmd: string, timeout: number = TIMEOUT_MS): Pr
     const { stdout } = await execAsync(cmd, {
       timeout,
       maxBuffer: MAX_BUFFER,
+      windowsHide: true,
     });
     const data: unknown = JSON.parse(stdout.trim());
     if (

--- a/src/git.ts
+++ b/src/git.ts
@@ -40,7 +40,7 @@ export async function getGitBranch(cwd?: string): Promise<string | null> {
     const { stdout } = await execFileAsync(
       'git',
       ['rev-parse', '--abbrev-ref', 'HEAD'],
-      { cwd, timeout: 1000, encoding: 'utf8' }
+      { cwd, timeout: 1000, encoding: 'utf8', windowsHide: true }
     );
     return stdout.trim() || null;
   } catch {
@@ -56,7 +56,7 @@ export async function getGitStatus(cwd?: string): Promise<GitStatus | null> {
     const { stdout: branchOut } = await execFileAsync(
       'git',
       ['rev-parse', '--abbrev-ref', 'HEAD'],
-      { cwd, timeout: 1000, encoding: 'utf8' }
+      { cwd, timeout: 1000, encoding: 'utf8', windowsHide: true }
     );
     const branch = branchOut.trim();
     if (!branch) return null;
@@ -69,7 +69,7 @@ export async function getGitStatus(cwd?: string): Promise<GitStatus | null> {
       const { stdout: statusOut } = await execFileAsync(
         'git',
         ['-c', 'core.quotePath=false', '--no-optional-locks', 'status', '--porcelain'],
-        { cwd, timeout: 1000, encoding: 'utf8' }
+        { cwd, timeout: 1000, encoding: 'utf8', windowsHide: true }
       );
       const trimmed = statusOut.trim();
       isDirty = trimmed.length > 0;
@@ -86,7 +86,7 @@ export async function getGitStatus(cwd?: string): Promise<GitStatus | null> {
         const { stdout: numstatOut } = await execFileAsync(
           'git',
           ['-c', 'core.quotePath=false', 'diff', '--numstat', 'HEAD'],
-          { cwd, timeout: 2000, encoding: 'utf8' }
+          { cwd, timeout: 2000, encoding: 'utf8', windowsHide: true }
         );
         const trackedPaths = new Set(fileStats?.trackedFiles.map((file) => file.fullPath) ?? []);
         const { totalDiff, perFileDiff } = parseNumstat(numstatOut, trackedPaths);
@@ -106,7 +106,7 @@ export async function getGitStatus(cwd?: string): Promise<GitStatus | null> {
       const { stdout: revOut } = await execFileAsync(
         'git',
         ['rev-list', '--left-right', '--count', '@{upstream}...HEAD'],
-        { cwd, timeout: 1000, encoding: 'utf8' }
+        { cwd, timeout: 1000, encoding: 'utf8', windowsHide: true }
       );
       const parts = revOut.trim().split(/\s+/);
       if (parts.length === 2) {
@@ -123,7 +123,7 @@ export async function getGitStatus(cwd?: string): Promise<GitStatus | null> {
       const { stdout: remoteOut } = await execFileAsync(
         'git',
         ['remote', 'get-url', 'origin'],
-        { cwd, timeout: 1000, encoding: 'utf8' }
+        { cwd, timeout: 1000, encoding: 'utf8', windowsHide: true }
       );
       const remote = remoteOut.trim();
       const httpsBase = remote

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,6 +15,7 @@ type ExecFileImpl = (
   options: {
     timeout: number;
     encoding: BufferEncoding;
+    windowsHide?: boolean;
   }
 ) => Promise<ExecFileResult>;
 
@@ -263,6 +264,7 @@ export async function getClaudeCodeVersion(): Promise<string | undefined> {
     const { stdout } = await execFileImpl(invocation.file, invocation.args, {
       timeout: 2000,
       encoding: 'utf8',
+      windowsHide: true,
     });
     cachedVersion = _parseClaudeCodeVersion(stdout);
   } catch {


### PR DESCRIPTION
## Summary

On Windows, every status-line refresh causes brief `conhost.exe` window flashes that visibly flicker on screen while Claude Code is streaming a response or running tools. Root cause: Node's `child_process.exec` / `execFile` defaults `windowsHide` to **`false`**, so each `git` / `claude --version` invocation paints a console window even though stdout is being piped back to the parent.

This patch adds `windowsHide: true` to all 8 child_process option literals in claude-hud's source. No behavior change on Linux/macOS — `windowsHide` is a Windows-only flag and is silently ignored on other platforms.

## Affected sites

| File | Calls | What runs |
|------|-------|-----------|
| `src/git.ts` | 6 × `execFileAsync` | branch lookup, `status --porcelain`, `diff --numstat`, `rev-list` ahead/behind, `remote get-url` |
| `src/extra-cmd.ts` | 1 × `execAsync` | user `--extra-cmd` label fetcher |
| `src/version.ts` | 1 × `execFileImpl` | `claude --version`. The custom `ExecFileImpl` options type was also widened to accept the optional property. |

POSIX-only spawn sites (`memory.ts:vm_stat`, `effort.ts:ps`) are intentionally untouched — those binaries don't exist on Windows so the code paths never run there.

## Reproduction

On Windows 11 with Git Bash + Claude Code, with claude-hud configured as the `statusLine`:

1. Open Claude Code in any git-tracked project
2. Submit a prompt that takes more than a couple seconds to stream
3. Observe `conhost.exe` windows briefly flashing on the desktop every few hundred milliseconds while the response streams or while `git` is queried by the status-line render

After this patch, the flashes stop entirely.

## Test plan

- [x] `tsc --noEmit` passes (type check; the `ExecFileImpl` widening is required for `version.ts`)
- [x] Manual verification on Windows 11 — the same patch applied directly to the installed plugin's source files stopped the flashing immediately on next status-line render (no Claude Code restart needed since the statusLine runner re-imports source on each invocation)
- [ ] `npm test` — deferred to CI. The change is additive (one optional property per options literal); existing tests don't assert on the options object shape

## Why this is safe

`windowsHide: true` is the appropriate default for any tool that pipes a child process's stdout back to its parent — which is what every claude-hud spawn does. The flag has been a stable, documented option since Node 12, and on non-Windows platforms the property is silently ignored. The behavior delta on POSIX is exactly zero.