### PR TITLE
feat: add customLinePosition config to control custom line placement

### DIFF
--- a/commands/configure.md
+++ b/commands/configure.md
@@ -259,6 +259,7 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 | Session start date | `display.showSessionStartDate` |
 | Last response time | `display.showLastResponseAt` |
 | Custom line | `display.customLine` |
+| Custom line position | `display.customLinePosition` |
 
 **Always true (not configurable):**
 - `display.showModel: true`

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
  */
 export type ModelFormatMode = 'full' | 'compact' | 'short';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both' | 'elapsed' | 'elapsedAndAbsolute';
+export type CustomLinePosition = 'first' | 'last';
 export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos' | 'sessionTime';
 
 export type AddedDirsLayout = 'inline' | 'line';
@@ -134,6 +135,7 @@ export interface HudConfig {
     modelFormat: ModelFormatMode;
     modelOverride: string;
     customLine: string;
+    customLinePosition: CustomLinePosition;
     timeFormat: TimeFormatMode;
   };
   colors: HudColorOverrides;
@@ -201,6 +203,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     modelFormat: 'full',
     modelOverride: '',
     customLine: '',
+    customLinePosition: 'last',
     timeFormat: 'relative',
   },
   colors: {
@@ -263,6 +266,10 @@ function validateTimeFormat(value: unknown): value is TimeFormatMode {
     || value === 'both'
     || value === 'elapsed'
     || value === 'elapsedAndAbsolute';
+}
+
+function validateCustomLinePosition(value: unknown): value is CustomLinePosition {
+  return value === 'first' || value === 'last';
 }
 
 function validateColorName(value: unknown): value is HudColorName {
@@ -617,6 +624,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     customLine: typeof migrated.display?.customLine === 'string'
       ? migrated.display.customLine.slice(0, 80)
       : DEFAULT_CONFIG.display.customLine,
+    customLinePosition: validateCustomLinePosition(migrated.display?.customLinePosition)
+      ? migrated.display.customLinePosition
+      : DEFAULT_CONFIG.display.customLinePosition,
     timeFormat: validateTimeFormat(migrated.display?.timeFormat)
       ? migrated.display.timeFormat
       : DEFAULT_CONFIG.display.timeFormat,

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -55,6 +55,12 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   const colors = ctx.config?.colors;
   const parts: string[] = [];
 
+  const customLine = display?.customLine;
+  const customLinePosition = display?.customLinePosition ?? 'last';
+  if (customLine && customLinePosition === 'first') {
+    parts.push(customColor(customLine, colors));
+  }
+
   if (display?.showModel !== false) {
     const model = formatModelName(getModelName(ctx.stdin), ctx.config?.display?.modelFormat, ctx.config?.display?.modelOverride);
     const providerLabel = getProviderLabel(ctx.stdin);
@@ -172,8 +178,7 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     }
   }
 
-  const customLine = display?.customLine;
-  if (customLine) {
+  if (customLine && customLinePosition === 'last') {
     parts.push(customColor(customLine, colors));
   }
 

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -45,7 +45,13 @@ export function renderSessionLine(ctx: RenderContext): string {
   const contextValue = formatContextValue(ctx, percent, contextValueMode);
   const contextValueDisplay = `${getContextColor(percent, colors, contextThresholds)}${contextValue}${RESET}`;
 
-  // Model and context bar (FIRST)
+  const customLine = display?.customLine;
+  const customLinePosition = display?.customLinePosition ?? 'last';
+  if (customLine && customLinePosition === 'first') {
+    parts.push(customColor(customLine, colors));
+  }
+
+  // Model and context bar
   const providerLabel = getProviderLabel(ctx.stdin);
   const modelQualifier = providerLabel ?? undefined;
   let modelDisplay = modelQualifier ? `${model} | ${modelQualifier}` : model;
@@ -65,7 +71,7 @@ export function renderSessionLine(ctx: RenderContext): string {
     parts.push(contextValueDisplay);
   }
 
-  // Project path + git status (SECOND)
+  // Project path + git status
   let projectPart: string | null = null;
   if (display?.showProject !== false && ctx.stdin.cwd) {
     // Split by both Unix (/) and Windows (\) separators for cross-platform support
@@ -299,9 +305,7 @@ export function renderSessionLine(ctx: RenderContext): string {
     parts.push(label(ctx.extraLabel, colors));
   }
 
-  // Custom line (static user-defined text)
-  const customLine = display?.customLine;
-  if (customLine) {
+  if (customLine && customLinePosition === 'last') {
     parts.push(customColor(customLine, colors));
   }
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -254,6 +254,21 @@ test('mergeConfig preserves customLine and truncates long values', () => {
   assert.equal(config.display.customLine, customLine.slice(0, 80));
 });
 
+test('mergeConfig defaults customLinePosition to last', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.customLinePosition, 'last');
+});
+
+test('mergeConfig preserves explicit customLinePosition', () => {
+  const config = mergeConfig({ display: { customLinePosition: 'first' } });
+  assert.equal(config.display.customLinePosition, 'first');
+});
+
+test('mergeConfig falls back to last for invalid customLinePosition', () => {
+  const config = mergeConfig({ display: { customLinePosition: 'middle' } });
+  assert.equal(config.display.customLinePosition, 'last');
+});
+
 test('mergeConfig defaults modelFormat to full', () => {
   const config = mergeConfig({});
   assert.equal(config.display.modelFormat, 'full');

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -473,6 +473,28 @@ test('renderSessionLine includes customLine when configured', () => {
   assert.ok(line.includes('Ship it'));
 });
 
+test('renderSessionLine places customLine before model badge when position is first', () => {
+  const ctx = baseContext();
+  ctx.config.display.customLine = 'prod-server';
+  ctx.config.display.customLinePosition = 'first';
+  const line = stripAnsi(renderSessionLine(ctx));
+  const customIdx = line.indexOf('prod-server');
+  const modelIdx = line.indexOf('[Opus]');
+  assert.ok(customIdx >= 0, 'should include custom line');
+  assert.ok(modelIdx >= 0, 'should include model badge');
+  assert.ok(customIdx < modelIdx, `custom line (${customIdx}) should appear before model badge (${modelIdx})`);
+});
+
+test('renderSessionLine places customLine at end when position is last', () => {
+  const ctx = baseContext();
+  ctx.config.display.customLine = 'prod-server';
+  ctx.config.display.customLinePosition = 'last';
+  const line = stripAnsi(renderSessionLine(ctx));
+  const customIdx = line.indexOf('prod-server');
+  const modelIdx = line.indexOf('[Opus]');
+  assert.ok(customIdx > modelIdx, 'custom line should appear after model badge when position is last');
+});
+
 test('renderSessionLine applies modelFormat compact', () => {
   const ctx = baseContext();
   ctx.stdin.model = { display_name: 'Opus 4.6 (1M context)' };
@@ -570,6 +592,30 @@ test('renderProjectLine includes customLine when configured', () => {
   ctx.config.display.customLine = 'Stay sharp';
   const line = stripAnsi(renderProjectLine(ctx) ?? '');
   assert.ok(line.includes('Stay sharp'));
+});
+
+test('renderProjectLine places customLine before model badge when position is first', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.config.display.customLine = 'prod-server';
+  ctx.config.display.customLinePosition = 'first';
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  const customIdx = line.indexOf('prod-server');
+  const modelIdx = line.indexOf('[Opus]');
+  assert.ok(customIdx >= 0, 'should include custom line');
+  assert.ok(modelIdx >= 0, 'should include model badge');
+  assert.ok(customIdx < modelIdx, `custom line (${customIdx}) should appear before model badge (${modelIdx})`);
+});
+
+test('renderProjectLine places customLine at end when position is last', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.config.display.customLine = 'prod-server';
+  ctx.config.display.customLinePosition = 'last';
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  const customIdx = line.indexOf('prod-server');
+  const modelIdx = line.indexOf('[Opus]');
+  assert.ok(customIdx > modelIdx, 'custom line should appear after model badge when position is last');
 });
 
 test('renderProjectLine applies modelFormat compact (strips context suffix)', () => {


### PR DESCRIPTION
## Problem

`customLine` always renders at the end of the status line. When managing multiple SSH sessions across terminal tabs, users rely on `customLine` as a machine identifier (e.g. `🖥️ prod-db-01`). Placed at the end, it requires scanning to the far right to tell which session is which — especially slow when switching between tabs.

```
tab 1: [Opus] │ api-service git:(main*) │ ⏱️ 5m │ 🖥️ prod-db-01
tab 2: [Opus] │ api-service git:(deploy) │ ⏱️ 12m │ 🖥️ staging-01
       ← eyes start here                          find label here →
```

## Solution

Add `display.customLinePosition` config (`"first"` | `"last"`, default `"last"`). No change for users on default config. No manual configuration required — unset or invalid values fall back to the default.

When set to `"first"`, customLine renders at the very start of the line, before the model badge. Follows the same small-enum pattern as `addedDirsLayout`, `gitBranchOverflow`, and `toolNameOverflow`.

### SSH multi-host identification (each host has its own config)

```
tab 1: 🖥️ prod-db-01 │ [Opus] │ api-service git:(main*) │ ⏱️ 5m
tab 2: 🖥️ staging-01 │ [Opus] │ api-service git:(deploy) │ ⏱️ 12m
tab 3: 🖥️ dev-local  │ [Opus] │ api-service git:(feat/auth) │ ⏱️ 2m
       ↑ instant recognition
```

### Environment identification (each machine labeled separately)

```
prod: 🔴 PROD │ [Opus] │ my-project git:(main)
stg:  🟡 STG  │ [Opus] │ my-project git:(release/v2)
dev:  🟢 DEV  │ [Opus] │ my-project git:(feat/new-ui*)
```

### Config

```json
{
  "display": {
    "customLine": "🖥️ prod-db-01",
    "customLinePosition": "first"
  }
}
```

Note: config is global (`~/.claude/plugins/claude-hud/config.json`) — all sessions on the same machine share the same `customLine` value. The examples above apply when SSH'd into different hosts, each with its own config.

## Alternative

Moving customLine to the front by default (no config) would be simpler but changes positioning for existing users.

## Changes

- `src/config.ts` — `CustomLinePosition` type, validation, merge
- `src/render/lines/project.ts` — expanded mode position logic
- `src/render/session-line.ts` — compact mode position logic
- `commands/configure.md` — element mapping table
- `tests/config.test.js` — default, explicit, invalid fallback
- `tests/render.test.js` — first/last position in both modes

## Testing

- [x] `npm test`
- [x] `npm run build`

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed
