### PR TITLE
fix: stabilize context fallback and todo rendering

### DIFF
--- a/src/context-cache.ts
+++ b/src/context-cache.ts
@@ -205,9 +205,9 @@ function isAllUsageZero(usage: ContextWindow["current_usage"]): boolean {
  * Returns true when context window data looks like a Claude Code reporting
  * glitch rather than a genuine zero-usage state.
  *
- * We only treat a zero-percent frame as suspicious when accumulated totals are
- * non-zero and `current_usage` is still empty. If `current_usage` already shows
- * non-zero token counters, keep the live frame instead of restoring stale cache.
+ * We treat a zero-percent frame as suspicious when `current_usage` is empty.
+ * Fresh sessions are protected by a cache miss; post-compact resets are
+ * protected by the compact-boundary guard in applyContextWindowFallback.
  */
 function isSuspiciousZero(contextWindow: ContextWindow): boolean {
   const usedPercentage = contextWindow.used_percentage ?? 0;
@@ -219,9 +219,7 @@ function isSuspiciousZero(contextWindow: ContextWindow): boolean {
     return false;
   }
 
-  const totalInputTokens = contextWindow.total_input_tokens ?? 0;
-  const totalOutputTokens = contextWindow.total_output_tokens ?? 0;
-  return totalInputTokens > 0 || totalOutputTokens > 0;
+  return true;
 }
 
 /**

--- a/src/render/todos-line.ts
+++ b/src/render/todos-line.ts
@@ -27,7 +27,8 @@ export function renderTodosLine(ctx: RenderContext): string | null {
   return `${yellow("▸")} ${content} ${progress}`;
 }
 
-function truncateContent(content: string, maxLen: number = 50): string {
+function truncateContent(content: string | null | undefined, maxLen: number = 50): string {
+  if (!content) return "";
   if (content.length <= maxLen) return content;
   return content.slice(0, maxLen - 3) + "...";
 }

--- a/tests/context-cache.test.js
+++ b/tests/context-cache.test.js
@@ -607,7 +607,41 @@ test('applyContextWindowFallback restores cache for zero-percent frames with non
   }
 });
 
-test('applyContextWindowFallback keeps legitimate zero/reset frames unchanged', async () => {
+test('applyContextWindowFallback restores cache for zero-percent streaming frames without token totals', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+
+  try {
+    applyContextWindowFallback(
+      makeHealthyFrame(transcriptPath),
+      makeDeps(tempHome, 1_000_000),
+    );
+
+    const variants = [
+      { current_usage: null },
+      { current_usage: undefined },
+      { current_usage: {} },
+    ];
+
+    for (const variant of variants) {
+      const stdin = makeSuspiciousFrame({
+        total_input_tokens: undefined,
+        total_output_tokens: undefined,
+        ...variant,
+      });
+      stdin.transcript_path = transcriptPath;
+
+      applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
+
+      assert.equal(stdin.context_window.used_percentage, 58);
+      assert.equal(stdin.context_window.remaining_percentage, 42);
+    }
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback keeps post-compact zero/reset frames unchanged', async () => {
   const tempHome = await createTempHome();
   const transcriptPath = '/tmp/session-a.jsonl';
 
@@ -620,7 +654,12 @@ test('applyContextWindowFallback keeps legitimate zero/reset frames unchanged', 
     const stdin = makeSuspiciousFrame({ total_input_tokens: 0, total_output_tokens: 0 });
     stdin.transcript_path = transcriptPath;
 
-    applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
+    applyContextWindowFallback(
+      stdin,
+      makeDeps(tempHome, 1_100_000),
+      undefined,
+      { lastCompactBoundaryAt: new Date(1_050_000) },
+    );
 
     assert.equal(stdin.context_window.used_percentage, 0);
     assert.equal(stdin.context_window.remaining_percentage, 100);

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1275,6 +1275,16 @@ test('renderTodosLine truncates long todo content', () => {
   assert.ok(line?.includes('...'));
 });
 
+test('renderTodosLine tolerates missing in-progress todo content', () => {
+  const ctx = baseContext();
+  ctx.transcript.todos = [
+    { status: 'in_progress' },
+  ];
+
+  assert.doesNotThrow(() => renderTodosLine(ctx));
+  assert.ok(renderTodosLine(ctx)?.includes('(0/1)'));
+});
+
 test('renderTodosLine returns null when no todos exist', () => {
   const ctx = baseContext();
   assert.equal(renderTodosLine(ctx), null);


### PR DESCRIPTION
## Summary

Fixes two newly reported runtime bugs from the maintainer sweep:

- Restore cached context for streaming zero-percent frames even when Claude Code omits token totals and `current_usage` is null/empty.
- Keep post-compact zero frames protected by the compact-boundary guard.
- Prevent the todos line from crashing when malformed todo data omits `content`.

Closes #576.
Closes #577.

## Security review

Source/test-only change. No dependencies, scripts, workflows, generated artifacts, filesystem paths, network calls, subprocesses, or persistence surfaces were added. The context-cache change only broadens an existing cache read path after session-keyed cache lookup succeeds; missing cache still leaves fresh zero frames unchanged.

## Tests

- `./node_modules/.bin/tsc && node --test tests/context-cache.test.js tests/render.test.js`
- `./node_modules/.bin/tsc && node --test`