### PR TITLE
feat(panel): generic, cache-fed multi-line panel element

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,74 @@ Example fallback snapshot:
 
 ---
 
+## The `panel` element (fork addition)
+
+> This element is added by this fork of [jarrodwatts/claude-hud](https://github.com/jarrodwatts/claude-hud). Everything else is upstream.
+
+`panel` is a generic, brand-able, **cache-fed** multi-line block you can drop anywhere in your `elementOrder`. It renders up to three lines and degrades silently — sections with no data simply don't appear:
+
+```
+⚡ ASTRA  📚 5.4k · 🔥 3 · 💎 1 · 🎩 €2.4k 30d     ← brand + chips (from cacheFile)
+VEN 14:00 Demo call                                ← TTL headline (from calendarCacheFile)
+load 1.2 · mem 41%                                 ← portable vitals (showVitals)
+```
+
+The HUD only **reads** the cache files — *you* decide what goes in them via any feeder (a cron job, a `SessionStart` hook, a script). This keeps the element 100% generic: the "ASTRA" look above is just an example theme, not hardcoded.
+
+### Enable it
+
+`panel` is opt-in. Add it to `elementOrder` and configure the `panel` block:
+
+```json
+{
+  "elementOrder": ["project", "context", "usage", "panel", "tools"],
+  "panel": {
+    "enabled": true,
+    "brand": "⚡ ASTRA",
+    "brandColor": "#00d4aa",
+    "cacheFile": "/tmp/hud-panel",
+    "calendarCacheFile": "/tmp/hud-panel-calendar",
+    "showVitals": true
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Master switch. When false, renders nothing. |
+| `brand` | string | `""` | Label at the start of line 1 (e.g. `"⚡ ASTRA"`). Empty = no brand. |
+| `brandColor` | string\|number | `"cyan"` | Brand color: named preset, 256-color index, or `#rrggbb` hex. |
+| `cacheFile` | string | `""` | Path to chips cache (see contract below). |
+| `calendarCacheFile` | string | `""` | Path to TTL headline cache (see contract below). |
+| `showVitals` | boolean | `false` | Append a portable `load · mem%` line (Node `os`, no external scripts). |
+
+### Cache contract
+
+**`cacheFile`** — one line, pipe-delimited chips, each rendered as-is and joined by ` · `:
+
+```
+📚 5.4k|🔥 3|💎 1|🎩 €2.4k 30d
+```
+
+**`calendarCacheFile`** — `<expiry_unix>|<text>`. Once `now > expiry` the line disappears (a past event is never shown as upcoming). Without a numeric prefix, the raw text is shown:
+
+```
+1780057800|VEN 14:00 Demo call
+```
+
+### Example feeder (cron / hook)
+
+```bash
+# refresh the chips every few minutes
+printf '📚 %s|🔥 %s|💎 %s' "$(notes_count)" "$(leads)" "$(clients)" > /tmp/hud-panel
+# next event with a TTL so it self-expires
+printf '%s|%s' "$(next_event_end_unix)" "$(next_event_label)" > /tmp/hud-panel-calendar
+```
+
+> Note on vitals: on macOS `os.freemem()` under-reports free memory, so `mem %` skews high there — it's a lightweight indicator, not an exact gauge. Load average is omitted on Windows (unavailable via Node).
+
+---
+
 ## Requirements
 
 - Claude Code v1.0.80+

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
 export type ModelFormatMode = 'full' | 'compact' | 'short';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both' | 'elapsed' | 'elapsedAndAbsolute';
 export type CustomLinePosition = 'first' | 'last';
-export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos' | 'sessionTime';
+export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos' | 'sessionTime' | 'panel';
 
 export type AddedDirsLayout = 'inline' | 'line';
 export type HudColorName =
@@ -36,6 +36,34 @@ export type HudColorName =
 
 /** A color value: named preset, 256-color index (0-255), or hex string (#rrggbb). */
 export type HudColorValue = HudColorName | number | string;
+
+/**
+ * Configuration for the optional generic `panel` element — a brand-able,
+ * cache-fed multi-line block. Everything is opt-in and degrades silently:
+ * sections with no data simply don't render. Cache files are written by
+ * whatever feeder the user wires up (cron, hook, script); the HUD only reads.
+ */
+export interface HudPanelConfig {
+  /** Master switch. When false the element renders nothing. */
+  enabled: boolean;
+  /** Brand label shown at the start of line 1 (e.g. "⚡ ASTRA"). Empty = none. */
+  brand: string;
+  /** Color for the brand label (named preset, 256-index, or #rrggbb). */
+  brandColor: HudColorValue;
+  /**
+   * Path to a chips cache file. Content is a single line of pipe-delimited
+   * chips, each rendered as-is, joined by " · ". E.g. "📚 5.4k|🔥 3|💎 1".
+   */
+  cacheFile: string;
+  /**
+   * Path to a headline cache file with optional TTL. Format:
+   * "<expiry_unix>|<text>" — once expired the line disappears (a past event
+   * is never shown as upcoming). Without a numeric prefix the raw text shows.
+   */
+  calendarCacheFile: string;
+  /** Append a portable machine-vitals line (load average + memory %). */
+  showVitals: boolean;
+}
 
 export interface HudColorOverrides {
   context: HudColorValue;
@@ -71,7 +99,9 @@ export const DEFAULT_MERGE_GROUPS: HudElement[][] = [
   ['context', 'usage'],
 ];
 
-const KNOWN_ELEMENTS = new Set<HudElement>(DEFAULT_ELEMENT_ORDER);
+// `panel` is opt-in (not in DEFAULT_ELEMENT_ORDER) but must be recognized so
+// users can place it in their own elementOrder without it being filtered out.
+const KNOWN_ELEMENTS = new Set<HudElement>([...DEFAULT_ELEMENT_ORDER, 'panel']);
 
 export interface HudConfig {
   language: Language;
@@ -139,6 +169,7 @@ export interface HudConfig {
     timeFormat: TimeFormatMode;
   };
   colors: HudColorOverrides;
+  panel: HudPanelConfig;
 }
 
 export const DEFAULT_CONFIG: HudConfig = {
@@ -220,6 +251,14 @@ export const DEFAULT_CONFIG: HudConfig = {
     custom: 208,
     barFilled: '█',
     barEmpty: '░',
+  },
+  panel: {
+    enabled: false,
+    brand: '',
+    brandColor: 'cyan',
+    cacheFile: '',
+    calendarCacheFile: '',
+    showVitals: false,
   },
 };
 
@@ -674,7 +713,24 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
       : DEFAULT_CONFIG.colors.barEmpty,
   };
 
-  return { language, lineLayout, showSeparators, pathLevels, maxWidth, forceMaxWidth, elementOrder, gitStatus, display, colors };
+  const panel: HudPanelConfig = {
+    enabled: typeof migrated.panel?.enabled === 'boolean'
+      ? migrated.panel.enabled
+      : DEFAULT_CONFIG.panel.enabled,
+    brand: typeof migrated.panel?.brand === 'string'
+      ? migrated.panel.brand.slice(0, 40)
+      : DEFAULT_CONFIG.panel.brand,
+    brandColor: validateColorValue(migrated.panel?.brandColor)
+      ? migrated.panel.brandColor
+      : DEFAULT_CONFIG.panel.brandColor,
+    cacheFile: validateOptionalPath(migrated.panel?.cacheFile),
+    calendarCacheFile: validateOptionalPath(migrated.panel?.calendarCacheFile),
+    showVitals: typeof migrated.panel?.showVitals === 'boolean'
+      ? migrated.panel.showVitals
+      : DEFAULT_CONFIG.panel.showVitals,
+  };
+
+  return { language, lineLayout, showSeparators, pathLevels, maxWidth, forceMaxWidth, elementOrder, gitStatus, display, colors, panel };
 }
 
 export async function loadConfig(): Promise<HudConfig> {

--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -116,6 +116,15 @@ export function critical(text: string, colors?: Partial<HudColorOverrides>): str
   return colorize(text, resolveAnsi(colors?.critical, RED));
 }
 
+/**
+ * Paint text with an arbitrary color value (named preset, 256-color index, or
+ * #rrggbb hex). Falls back to cyan for unset/invalid values. Used by the
+ * configurable `panel` element where the color comes straight from user config.
+ */
+export function paint(text: string, value: HudColorValue | undefined): string {
+  return colorize(text, resolveAnsi(value, CYAN));
+}
+
 export interface ContextThresholds {
   warning?: number;
   critical?: number;

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -16,6 +16,7 @@ import {
   renderMemoryLine,
   renderSessionTokensLine,
   renderSessionTimeLine,
+  renderPanelLine,
 } from './lines/index.js';
 import { dim, RESET } from './colors.js';
 import { getTerminalWidth, UNKNOWN_TERMINAL_WIDTH } from '../utils/terminal.js';
@@ -401,6 +402,8 @@ function renderElementLine(
       return display?.showTodos === false ? null : renderTodosLine(ctx);
     case 'sessionTime':
       return renderSessionTimeLine(ctx);
+    case 'panel':
+      return renderPanelLine(ctx);
   }
 }
 

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -7,3 +7,4 @@ export { renderUsageLine } from './usage.js';
 export { renderMemoryLine } from './memory.js';
 export { renderSessionTokensLine } from './session-tokens.js';
 export { renderSessionTimeLine } from './session-time.js';
+export { renderPanelLine } from './panel.js';

--- a/src/render/lines/panel.ts
+++ b/src/render/lines/panel.ts
@@ -1,0 +1,114 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import type { RenderContext } from '../../types.js';
+import { dim, paint } from '../colors.js';
+
+function readCache(filePath: string): string {
+  if (!filePath) {
+    return '';
+  }
+  try {
+    return fs.readFileSync(filePath, 'utf-8').trim();
+  } catch {
+    // Missing/unreadable cache → section degrades silently.
+    return '';
+  }
+}
+
+/**
+ * Headline cache with optional TTL. Format: "<expiry_unix>|<text>".
+ * If expired → '' (a past event is never shown as upcoming). Without a numeric
+ * prefix the raw text is returned (backward-compatible plain string).
+ */
+function parseTtlText(raw: string): string {
+  if (!raw) {
+    return '';
+  }
+  const sep = raw.indexOf('|');
+  if (sep > 0) {
+    const expiry = Number(raw.slice(0, sep));
+    if (Number.isFinite(expiry) && expiry > 0) {
+      if (Date.now() / 1000 > expiry) {
+        return '';
+      }
+      return raw.slice(sep + 1).trim();
+    }
+  }
+  return raw;
+}
+
+/**
+ * Portable machine vitals via Node's built-in `os` module — no external
+ * scripts, works on any platform. Load average is unavailable on Windows
+ * (Node reports 0) so it's omitted there; memory is shown as used-percentage.
+ *
+ * Note: on macOS `os.freemem()` under-reports free memory (it counts only
+ * truly-free pages), so the memory percentage skews high there. It's a
+ * lightweight indicator, not an exact gauge.
+ */
+function machineVitals(): string {
+  const parts: string[] = [];
+
+  const load = os.loadavg()[0];
+  if (Number.isFinite(load) && load > 0) {
+    parts.push(`load ${load.toFixed(1)}`);
+  }
+
+  const total = os.totalmem();
+  const free = os.freemem();
+  if (total > 0) {
+    const usedPct = Math.round(((total - free) / total) * 100);
+    parts.push(`mem ${usedPct}%`);
+  }
+
+  return parts.join(' · ');
+}
+
+/**
+ * Generic, configurable "panel" element — a brand-able multi-line block:
+ *
+ *   1. brand + chips     (chips from a pipe-delimited cache file)
+ *   2. a TTL'd headline  (e.g. the next calendar event)
+ *   3. portable vitals   (load average + memory %)
+ *
+ * Driven entirely by `config.panel`; opt-in and silent when unconfigured.
+ * The cache files are produced by whatever feeder the user wires up — this
+ * renderer only reads them, so it stays generic and side-effect free.
+ */
+export function renderPanelLine(ctx: RenderContext): string | null {
+  const panel = ctx.config?.panel;
+  if (!panel || !panel.enabled) {
+    return null;
+  }
+
+  const lines: string[] = [];
+
+  // line 1 — brand + chips
+  const chipsRaw = readCache(panel.cacheFile);
+  const chips = chipsRaw
+    ? chipsRaw.split('|').map(chip => chip.trim()).filter(Boolean)
+    : [];
+  const brand = panel.brand ? paint(panel.brand, panel.brandColor) : '';
+  const body = chips.join(dim(' · '));
+  if (brand && body) {
+    lines.push(`${brand}  ${body}`);
+  } else if (brand || body) {
+    lines.push(brand || body);
+  }
+
+  // line 2 — TTL headline (disappears once expired)
+  const headline = parseTtlText(readCache(panel.calendarCacheFile));
+  if (headline) {
+    lines.push(headline);
+  }
+
+  // line 3 — portable machine vitals
+  if (panel.showVitals) {
+    const vitals = machineVitals();
+    if (vitals) {
+      lines.push(dim(vitals));
+    }
+  }
+
+  return lines.length > 0 ? lines.join('\n') : null;
+}

--- a/tests/panel.test.js
+++ b/tests/panel.test.js
@@ -1,0 +1,98 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { renderPanelLine } from '../dist/render/lines/panel.js';
+import { mergeConfig, DEFAULT_CONFIG } from '../dist/config.js';
+
+function stripAnsi(str) {
+  // eslint-disable-next-line no-control-regex
+  return str
+    .replace(/\x1b\[[0-9;]*m/g, '')
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
+}
+
+function ctxWith(panel) {
+  return { config: mergeConfig({ panel }) };
+}
+
+test('panel is disabled by default and renders nothing', () => {
+  assert.equal(DEFAULT_CONFIG.panel.enabled, false);
+  assert.equal(renderPanelLine({ config: DEFAULT_CONFIG }), null);
+});
+
+test('panel renders nothing when enabled but unconfigured', () => {
+  assert.equal(renderPanelLine(ctxWith({ enabled: true })), null);
+});
+
+test('panel renders brand + chips from cache file', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'panel-'));
+  try {
+    const cache = path.join(dir, 'chips');
+    await writeFile(cache, 'A 1|B 2|C 3');
+    const out = renderPanelLine(ctxWith({ enabled: true, brand: 'HUD', cacheFile: cache }));
+    const plain = stripAnsi(out);
+    assert.match(plain, /HUD/);
+    assert.match(plain, /A 1/);
+    assert.match(plain, /B 2/);
+    assert.match(plain, /C 3/);
+    // chips joined by a separator, single line for the brand row
+    assert.equal(plain.split('\n')[0].includes('A 1'), true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('panel hides a calendar headline once its TTL has expired', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'panel-'));
+  try {
+    const cal = path.join(dir, 'cal');
+    await writeFile(cal, '100|past event'); // unix 100 → long expired
+    const out = renderPanelLine(ctxWith({ enabled: true, calendarCacheFile: cal }));
+    assert.equal(out, null, 'expired headline should not render');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('panel shows a calendar headline with a future TTL', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'panel-'));
+  try {
+    const cal = path.join(dir, 'cal');
+    const future = Math.floor(Date.now() / 1000) + 3600;
+    await writeFile(cal, `${future}|next event`);
+    const out = stripAnsi(renderPanelLine(ctxWith({ enabled: true, calendarCacheFile: cal })));
+    assert.match(out, /next event/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('panel TTL is backward-compatible with plain (non-prefixed) text', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'panel-'));
+  try {
+    const cal = path.join(dir, 'cal');
+    await writeFile(cal, 'just a label');
+    const out = stripAnsi(renderPanelLine(ctxWith({ enabled: true, calendarCacheFile: cal })));
+    assert.match(out, /just a label/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("mergeConfig keeps 'panel' as a valid elementOrder entry", () => {
+  const merged = mergeConfig({ elementOrder: ['project', 'panel', 'context'] });
+  assert.deepEqual(merged.elementOrder, ['project', 'panel', 'context']);
+});
+
+test('mergeConfig validates panel fields and falls back on bad input', () => {
+  const merged = mergeConfig({
+    panel: { enabled: true, brand: 'X', brandColor: 'not-a-color', cacheFile: 42, showVitals: 'nope' },
+  });
+  assert.equal(merged.panel.enabled, true);
+  assert.equal(merged.panel.brand, 'X');
+  assert.equal(merged.panel.brandColor, DEFAULT_CONFIG.panel.brandColor); // invalid → fallback
+  assert.equal(merged.panel.cacheFile, ''); // non-string → empty
+  assert.equal(merged.panel.showVitals, DEFAULT_CONFIG.panel.showVitals); // invalid → fallback
+});


### PR DESCRIPTION
## What

Adds an opt-in `panel` HudElement — a brand-able, **cache-fed** multi-line block you can place anywhere in `elementOrder`. It renders up to three lines and degrades silently (sections with no data don't appear):

```
⚡ ASTRA  📚 5.4k · 🔥 3 · 💎 1 · 🎩 €2.4k 30d   ← brand + chips (from cacheFile)
VEN 14:00 Demo call                              ← TTL headline (from calendarCacheFile)
load 1.2 · mem 41%                               ← portable vitals (showVitals)
```

## Why

People keep wanting a small info block on the HUD (KPIs, next meeting, machine vitals) but each variation means a new bespoke element. `panel` makes that data-driven: the HUD only **reads** cache files, and the user wires whatever feeder they like (cron, a `SessionStart` hook, a script). No external scripts, no hardcoded schema — the "ASTRA" look above is just an example theme in the docs, not baked in.

## Design

- **Opt-in**: `panel` is *not* in `DEFAULT_ELEMENT_ORDER`, so default output is unchanged. It's recognized by `KNOWN_ELEMENTS` so users can add it to their own order.
- **Config-driven** via `config.panel`: `enabled`, `brand`, `brandColor` (named/256/hex), `cacheFile`, `calendarCacheFile`, `showVitals`. All validated with safe fallbacks.
- **Cache contract**:
  - `cacheFile`: one line, pipe-delimited chips rendered as-is, joined by ` · `.
  - `calendarCacheFile`: `<expiry_unix>|<text>` — disappears once expired (a past event is never shown as upcoming); plain text without a prefix is backward-compatible.
- **Portable vitals**: load average + memory % via Node `os` only (no shelling out). Load omitted on Windows; macOS `freemem()` skews high (documented).
- Adds an exported `paint()` helper in `colors.ts` to colorize with an arbitrary `HudColorValue`.

## Tests

`tests/panel.test.js` — 8 unit tests: disabled→null, brand+chips rendering, TTL expiry hides headline, future TTL shows, plain-text backward-compat, `panel` survives `elementOrder` validation, and config field validation/fallbacks. Full suite green locally (the only failing test, `loadConfig returns valid config structure`, reads the *local* installed `config.json` and is environment-specific — it passes in a clean CI checkout).

## Notes

- `dist/` intentionally **omitted** per `CONTRIBUTING.md` (CI builds it after merge).
- README updated with a `panel` section, the cache contract, and an example feeder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)