### PR TITLE
feat: add optional autoCompactWindow context denominator (#540)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.addedDirsLayout` | `inline` \| `line` | `inline` | `inline` puts dirs next to the project name with a `+name` prefix per dir; `line` renders them on a separate `Added dirs: name1, name2` line (no `+` prefix, comma-separated) |
 | `display.showContextBar` | boolean | true | Show visual context bar `████░░░░░░` |
 | `display.contextValue` | `percent` \| `tokens` \| `remaining` \| `both` | `percent` | Context display format (`45%`, `45k/200k`, `55%` remaining, or `45% (45k/200k)`) |
+| `display.autoCompactWindow` | number \| `null` | `null` | When set to a positive number such as `200000`, compute the context percentage against this auto-compact window instead of the full model context window, matching the `/context` figure. Leave unset or `null` to preserve default full-window behavior. |
 | `display.showConfigCounts` | boolean | false | Show CLAUDE.md, rules, MCPs, hooks counts |
 | `display.showCost` | boolean | false | Show session cost using Claude Code's native `cost.total_cost_usd` when available, with a local estimate fallback for direct Anthropic sessions |
 | `display.showOutputStyle` | boolean | false | Show the active Claude Code `outputStyle` from settings files as `style: <name>` |

--- a/src/config.ts
+++ b/src/config.ts
@@ -444,10 +444,10 @@ function validateNonNegativeInteger(value: unknown, fallback: number): number {
 }
 
 function validateAutoCompactWindow(value: unknown): number | null {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
     return null;
   }
-  return Math.floor(value);
+  return value;
 }
 
 function validateOptionalPath(value: unknown): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -137,6 +137,7 @@ export interface HudConfig {
     customLine: string;
     customLinePosition: CustomLinePosition;
     timeFormat: TimeFormatMode;
+    autoCompactWindow: number | null;
   };
   colors: HudColorOverrides;
 }
@@ -205,6 +206,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     customLine: '',
     customLinePosition: 'last',
     timeFormat: 'relative',
+    autoCompactWindow: null,
   },
   colors: {
     context: 'green',
@@ -441,6 +443,13 @@ function validateNonNegativeInteger(value: unknown, fallback: number): number {
   return value;
 }
 
+function validateAutoCompactWindow(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return Math.floor(value);
+}
+
 function validateOptionalPath(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
@@ -630,6 +639,7 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     timeFormat: validateTimeFormat(migrated.display?.timeFormat)
       ? migrated.display.timeFormat
       : DEFAULT_CONFIG.display.timeFormat,
+    autoCompactWindow: validateAutoCompactWindow(migrated.display?.autoCompactWindow),
   };
 
   const colors = {

--- a/src/render/lines/identity.ts
+++ b/src/render/lines/identity.ts
@@ -16,8 +16,9 @@ export function renderIdentityLine(
   ctx: RenderContext,
   alignLabels = false,
 ): string {
-  const rawPercent = getContextPercent(ctx.stdin);
-  const bufferedPercent = getBufferedPercent(ctx.stdin);
+  const autoCompactWindow = ctx.config?.display?.autoCompactWindow ?? null;
+  const rawPercent = getContextPercent(ctx.stdin, autoCompactWindow);
+  const bufferedPercent = getBufferedPercent(ctx.stdin, autoCompactWindow);
   const autocompactMode = ctx.config?.display?.autocompactBuffer ?? "enabled";
   const percent = autocompactMode === "disabled" ? rawPercent : bufferedPercent;
   const colors = ctx.config?.colors;

--- a/src/render/lines/identity.ts
+++ b/src/render/lines/identity.ts
@@ -77,7 +77,14 @@ function formatContextValue(
   mode: "percent" | "tokens" | "remaining" | "both",
 ): string {
   const totalTokens = getTotalTokens(ctx.stdin);
-  const size = ctx.stdin.context_window?.context_window_size ?? 0;
+  const autoCompactWindow = ctx.config?.display?.autoCompactWindow ?? null;
+  // When an explicit auto-compact window is configured, use it as the token
+  // denominator so the tokens/both displays match the percentage (and /context),
+  // rather than the full model context window.
+  const size =
+    typeof autoCompactWindow === "number" && autoCompactWindow > 0
+      ? autoCompactWindow
+      : ctx.stdin.context_window?.context_window_size ?? 0;
 
   if (mode === "tokens") {
     if (size > 0) {

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -337,7 +337,14 @@ function formatTokens(n: number): string {
 
 function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent' | 'tokens' | 'remaining' | 'both'): string {
   const totalTokens = getTotalTokens(ctx.stdin);
-  const size = ctx.stdin.context_window?.context_window_size ?? 0;
+  const autoCompactWindow = ctx.config?.display?.autoCompactWindow ?? null;
+  // When an explicit auto-compact window is configured, use it as the token
+  // denominator so the tokens/both displays match the percentage (and /context),
+  // rather than the full model context window.
+  const size =
+    typeof autoCompactWindow === 'number' && autoCompactWindow > 0
+      ? autoCompactWindow
+      : ctx.stdin.context_window?.context_window_size ?? 0;
 
   if (mode === 'tokens') {
     if (size > 0) {

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -20,8 +20,9 @@ const DEBUG = process.env.DEBUG?.includes('claude-hud') || process.env.DEBUG ===
 export function renderSessionLine(ctx: RenderContext): string {
   const model = formatModelName(getModelName(ctx.stdin), ctx.config?.display?.modelFormat, ctx.config?.display?.modelOverride);
 
-  const rawPercent = getContextPercent(ctx.stdin);
-  const bufferedPercent = getBufferedPercent(ctx.stdin);
+  const autoCompactWindow = ctx.config?.display?.autoCompactWindow ?? null;
+  const rawPercent = getContextPercent(ctx.stdin, autoCompactWindow);
+  const bufferedPercent = getBufferedPercent(ctx.stdin, autoCompactWindow);
   const autocompactMode = ctx.config?.display?.autocompactBuffer ?? 'enabled';
   const percent = autocompactMode === 'disabled' ? rawPercent : bufferedPercent;
 

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -158,7 +158,12 @@ function getNativePercent(stdin: StdinData): number | null {
   return null;
 }
 
-export function getContextPercent(stdin: StdinData): number {
+export function getContextPercent(stdin: StdinData, autoCompactWindow?: number | null): number {
+  if (typeof autoCompactWindow === 'number' && autoCompactWindow > 0) {
+    const totalTokens = getTotalTokens(stdin);
+    return Math.min(100, Math.round((totalTokens / autoCompactWindow) * 100));
+  }
+
   // Prefer native percentage (v2.1.6+) - accurate and matches /context
   const native = getNativePercent(stdin);
   if (native !== null) {
@@ -175,7 +180,12 @@ export function getContextPercent(stdin: StdinData): number {
   return Math.min(100, Math.round((totalTokens / size) * 100));
 }
 
-export function getBufferedPercent(stdin: StdinData): number {
+export function getBufferedPercent(stdin: StdinData, autoCompactWindow?: number | null): number {
+  if (typeof autoCompactWindow === 'number' && autoCompactWindow > 0) {
+    const totalTokens = getTotalTokens(stdin);
+    return Math.min(100, Math.round((totalTokens / autoCompactWindow) * 100));
+  }
+
   // Prefer native percentage (v2.1.6+) so the HUD matches Claude Code's
   // own context output. The buffered fallback only approximates older versions.
   const native = getNativePercent(stdin);

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -158,6 +158,22 @@ test('renderSessionLine suppresses token breakdown below raised contextCriticalT
   assert.ok(!line.includes('in:'), 'expected no token breakdown at 90% when critical threshold is 95');
 });
 
+test('renderSessionLine token display uses autoCompactWindow as denominator when set', () => {
+  const ctx = baseContext();
+  ctx.config = mergeConfig({
+    lineLayout: 'compact',
+    display: { contextValue: 'both', autoCompactWindow: 200000, showTokenBreakdown: false },
+  });
+  // 70.6k tokens against a 1M model window, but auto-compact window is 200k.
+  ctx.stdin.context_window.context_window_size = 1000000;
+  ctx.stdin.context_window.current_usage.input_tokens = 70600;
+  const line = stripAnsi(renderSessionLine(ctx));
+  // Should match /context: 35% (71k/200k), not 7% (71k/1.0M).
+  assert.ok(line.includes('35%'), `expected 35% in: ${line}`);
+  assert.ok(line.includes('/200k'), `expected /200k denominator in: ${line}`);
+  assert.ok(!line.includes('/1.0M'), `expected full window not shown in: ${line}`);
+});
+
 test('renderIdentityLine token breakdown honours contextCriticalThreshold', () => {
   const ctx = baseContext();
   ctx.config.display.contextCriticalThreshold = 50;

--- a/tests/stdin.test.js
+++ b/tests/stdin.test.js
@@ -135,7 +135,7 @@ test('context percents clamp autoCompactWindow usage to 100', () => {
 });
 
 test('mergeConfig validates display.autoCompactWindow', () => {
-  for (const value of [0, -5, Number.NaN, 'abc']) {
+  for (const value of [0, -5, 0.5, 200000.5, Number.NaN, 'abc']) {
     assert.equal(mergeConfig({ display: { autoCompactWindow: value } }).display.autoCompactWindow, null);
   }
 

--- a/tests/stdin.test.js
+++ b/tests/stdin.test.js
@@ -1,7 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { PassThrough } from 'node:stream';
-import { readStdin, getProviderLabel } from '../dist/stdin.js';
+import { readStdin, getProviderLabel, getContextPercent, getBufferedPercent } from '../dist/stdin.js';
+import { mergeConfig } from '../dist/config.js';
 
 test('readStdin returns null for TTY input', async () => {
   const originalIsTTY = process.stdin.isTTY;
@@ -93,6 +94,64 @@ test('readStdin returns null when stdin payload exceeds the safety limit', async
 
   const result = await resultPromise;
   assert.equal(result, null);
+});
+
+test('context percents preserve default behavior when autoCompactWindow is omitted or null', () => {
+  const stdin = {
+    context_window: {
+      current_usage: { input_tokens: 70600 },
+      context_window_size: 1000000,
+    },
+  };
+
+  assert.equal(getContextPercent(stdin), 7);
+  assert.equal(getContextPercent(stdin, null), 7);
+  assert.equal(getBufferedPercent(stdin), 8);
+  assert.equal(getBufferedPercent(stdin, null), 8);
+});
+
+test('context percents use autoCompactWindow as denominator when configured', () => {
+  const stdin = {
+    context_window: {
+      current_usage: { input_tokens: 70600 },
+      context_window_size: 1000000,
+    },
+  };
+
+  assert.equal(getContextPercent(stdin, 200000), 35);
+  assert.equal(getBufferedPercent(stdin, 200000), 35);
+});
+
+test('context percents clamp autoCompactWindow usage to 100', () => {
+  const stdin = {
+    context_window: {
+      current_usage: { input_tokens: 250000 },
+      context_window_size: 1000000,
+    },
+  };
+
+  assert.equal(getContextPercent(stdin, 200000), 100);
+  assert.equal(getBufferedPercent(stdin, 200000), 100);
+});
+
+test('mergeConfig validates display.autoCompactWindow', () => {
+  for (const value of [0, -5, Number.NaN, 'abc']) {
+    assert.equal(mergeConfig({ display: { autoCompactWindow: value } }).display.autoCompactWindow, null);
+  }
+
+  assert.equal(mergeConfig({ display: { autoCompactWindow: 200000 } }).display.autoCompactWindow, 200000);
+});
+
+test('autoCompactWindow overrides native used_percentage', () => {
+  const stdin = {
+    context_window: {
+      used_percentage: 7,
+      current_usage: { input_tokens: 70600 },
+      context_window_size: 1000000,
+    },
+  };
+
+  assert.equal(getContextPercent(stdin, 200000), 35);
 });
 
 // getProviderLabel tests


### PR DESCRIPTION
## Summary

Adds an optional `display.autoCompactWindow` config (default `null`). When set to a positive number (e.g. `200000`), the HUD computes the context percentage and token display against the configured auto-compact window instead of the full model context window. When unset/null, behavior is unchanged.

## Why this matters

Issue #540: with a 1M model window but an effective 200k auto-compact threshold, the HUD reported ~7% (70.6k/1M) while `/context` reported 35% (70.6k/200k). The full-window figure hides how close a session is to triggering auto-compaction.

Per @jarrodwatts's guidance on the issue, this preserves current defaults and uses an explicit HUD config rather than broad implicit reads of Claude settings. As @truffle-dev confirmed, Claude Code's statusline stdin does not expose an `autoCompactWindow` field, so the override has to short-circuit the native `used_percentage` path rather than feed through the existing fallback.

Behavior:
- `null` (default): today's path unchanged (prefer native `used_percentage`, fall back to `context_window_size`).
- positive number: ignore the native percentage and use `min(100, round(totalTokens / autoCompactWindow * 100))` in both `getContextPercent` and `getBufferedPercent`. The token / `both` displays use the same denominator so the bar, the percent, and the token figure all agree with `/context` (e.g. `35% (71k/200k)`).
- invalid values (`0`, negative, `NaN`, non-numeric) coerce to `null`.

## Testing

- `npm test` (build + `node --test`): 629 passing, 1 pre-existing skip.
- New coverage in `tests/stdin.test.js`: null-default regression, 200k denominator → 35%, over-window clamp to 100, config validation of invalid values, and native-percentage override.
- New render test in `tests/render.test.js`: compact `both` mode shows `35% (71k/200k)` not `7% (71k/1.0M)`.
- `dist/` is intentionally left for the existing build-dist CI step to regenerate post-merge.

Fixes #540

AI was used for assistance.
