### PR TITLE
[codex] docs: clarify plugin release versioning

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,12 +4,13 @@ This project ships as a Claude Code plugin. Releases should include compiled `di
 
 ## Release Checklist
 
-1) Update versions:
+1) Update release versions:
+   - `.claude-plugin/plugin.json` (Claude Code's update/cache key)
    - `package.json`
    - `package-lock.json`
-   - `.claude-plugin/plugin.json`
-   - `.claude-plugin/marketplace.json`
    - `CHANGELOG.md`
+
+   Keep `.claude-plugin/plugin.json` and `package.json` on the same version. The marketplace manifest is distribution metadata for this repo; the plugin update version comes from `plugin.json`.
 2) Build:
    ```bash
    npm ci
@@ -17,8 +18,9 @@ This project ships as a Claude Code plugin. Releases should include compiled `di
    npm test
    npm run test:coverage
    ```
-3) Verify plugin entrypoint:
-   - `.claude-plugin/plugin.json` points to `dist/index.js`
+3) Verify plugin package contents:
+   - `package.json` points to `dist/index.js`
+   - `.claude-plugin/plugin.json` includes the release version
 4) Commit and tag:
    - `git tag vX.Y.Z`
 5) Publish:


### PR DESCRIPTION
## Summary
- Clarify that `.claude-plugin/plugin.json` is the Claude Code update/cache key for explicit-version releases.
- Remove `.claude-plugin/marketplace.json` from the required release version bump list.
- Fix the package verification note: `package.json` points to `dist/index.js`, while `plugin.json` carries plugin metadata/version.

## Validation
- `git diff --check`

## Context
Claude Code resolves plugin versions from `.claude-plugin/plugin.json` first, then a plugin-entry marketplace version, then the git commit SHA for git sources. The `plugin.json` value wins for this repo.

Docs: https://code.claude.com/docs/en/plugins-reference#version-management