### PR TITLE
feat: add showSkills / showMcp HUD display elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `pathLevels` | 1-3 | 1 | Directory levels to show in project path |
 | `maxWidth` | number \| `null` | `null` | Optional fallback width used only when terminal width detection fails completely |
 | `forceMaxWidth` | boolean | false | Always use `maxWidth` when it is set, even if terminal width detection returns a smaller value |
-| `elementOrder` | string[] | `["project","context","usage","promptCache","memory","environment","tools","agents","todos","sessionTime"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. Existing configs keep their explicit order until updated. |
+| `elementOrder` | string[] | `["project","addedDirs","context","usage","promptCache","memory","environment","tools","skills","mcp","agents","todos","sessionTime"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. Existing configs keep their explicit order until updated. |
 | `display.mergeGroups` | string[][] | `[["context","usage"]]` | Expanded-mode groups that should share a line when adjacent. Set `[]` to disable merged lines. |
 | `gitStatus.enabled` | boolean | true | Show git branch in HUD |
 | `gitStatus.showDirty` | boolean | true | Show `*` for uncommitted changes |
@@ -193,6 +193,8 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.externalUsageFreshnessMs` | number | `300000` | Maximum allowed age for the external usage snapshot before it is ignored |
 | `display.showTokenBreakdown` | boolean | true | Show token details at high context (85%+) |
 | `display.showTools` | boolean | false | Show tools activity line |
+| `display.showSkills` | boolean | false | Show active Skills detected from `Skill` tool invocations |
+| `display.showMcp` | boolean | false | Show active MCP servers detected from `mcp__server__tool` invocations |
 | `display.toolNameMaxLength` | number | `0` | Maximum displayed tool-name length. `0` keeps full names; MCP names may shorten to their final segment when truncating |
 | `display.toolsMaxVisible` | number | `4` | Maximum completed tools shown on the tools line. `0` means unlimited |
 | `display.showAgents` | boolean | false | Show agents activity line |
@@ -299,7 +301,7 @@ Example fallback snapshot:
   "language": "zh",
   "lineLayout": "expanded",
   "pathLevels": 2,
-  "elementOrder": ["project", "tools", "context", "usage", "memory", "environment", "agents", "todos", "sessionTime"],
+  "elementOrder": ["project", "tools", "skills", "mcp", "context", "usage", "memory", "environment", "agents", "todos", "sessionTime"],
   "gitStatus": {
     "enabled": true,
     "showDirty": true,
@@ -308,6 +310,8 @@ Example fallback snapshot:
   },
   "display": {
     "showTools": true,
+    "showSkills": true,
+    "showMcp": true,
     "showAgents": true,
     "showTodos": true,
     "showConfigCounts": true,
@@ -357,8 +361,8 @@ Example fallback snapshot:
 - Verify you're in a git repository
 - Check `gitStatus.enabled` is not `false` in config
 
-**Tool/agent/todo lines missing?**
-- These are hidden by default — enable with `showTools`, `showAgents`, `showTodos` in config
+**Tool/skill/MCP/agent/todo lines missing?**
+- These are hidden by default — enable with `showTools`, `showSkills`, `showMcp`, `showAgents`, `showTodos` in config
 - They also only appear when there's activity to show
 
 **HUD not appearing after setup?**

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,20 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
 export type ModelFormatMode = 'full' | 'compact' | 'short';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both' | 'elapsed' | 'elapsedAndAbsolute';
 export type CustomLinePosition = 'first' | 'last';
-export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos' | 'sessionTime';
+export type HudElement =
+  | 'project'
+  | 'addedDirs'
+  | 'context'
+  | 'usage'
+  | 'promptCache'
+  | 'memory'
+  | 'environment'
+  | 'tools'
+  | 'skills'
+  | 'mcp'
+  | 'agents'
+  | 'todos'
+  | 'sessionTime';
 
 export type AddedDirsLayout = 'inline' | 'line';
 export type HudColorName =
@@ -62,6 +75,8 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'memory',
   'environment',
   'tools',
+  'skills',
+  'mcp',
   'agents',
   'todos',
   'sessionTime',
@@ -108,6 +123,8 @@ export interface HudConfig {
     showResetLabel: boolean;
     usageCompact: boolean;
     showTools: boolean;
+    showSkills: boolean;
+    showMcp: boolean;
     toolNameMaxLength: number;
     toolsMaxVisible: number;
     showAgents: boolean;
@@ -185,6 +202,8 @@ export const DEFAULT_CONFIG: HudConfig = {
     showResetLabel: true,
     usageCompact: false,
     showTools: false,
+    showSkills: false,
+    showMcp: false,
     toolNameMaxLength: 0,
     toolsMaxVisible: 4,
     showAgents: false,
@@ -571,6 +590,12 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showTools: typeof migrated.display?.showTools === 'boolean'
       ? migrated.display.showTools
       : DEFAULT_CONFIG.display.showTools,
+    showSkills: typeof migrated.display?.showSkills === 'boolean'
+      ? migrated.display.showSkills
+      : DEFAULT_CONFIG.display.showSkills,
+    showMcp: typeof migrated.display?.showMcp === 'boolean'
+      ? migrated.display.showMcp
+      : DEFAULT_CONFIG.display.showMcp,
     toolNameMaxLength: validateNonNegativeInteger(
       migrated.display?.toolNameMaxLength,
       DEFAULT_CONFIG.display.toolNameMaxLength,

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -3,6 +3,7 @@ import { DEFAULT_ELEMENT_ORDER, DEFAULT_MERGE_GROUPS } from '../config.js';
 import type { RenderContext } from '../types.js';
 import { renderSessionLine } from './session-line.js';
 import { renderToolsLine } from './tools-line.js';
+import { renderSkillsLine, renderMcpLine } from './skills-mcp-line.js';
 import { renderAgentsLine } from './agents-line.js';
 import { renderTodosLine } from './todos-line.js';
 import {
@@ -306,7 +307,7 @@ function makeSeparator(length: number): string {
   return dim('─'.repeat(repeats));
 }
 
-const ACTIVITY_ELEMENTS = new Set<HudElement>(['tools', 'agents', 'todos']);
+const ACTIVITY_ELEMENTS = new Set<HudElement>(['tools', 'skills', 'mcp', 'agents', 'todos']);
 
 function buildMergeGroupLookup(mergeGroups: HudElement[][]): Map<HudElement, Set<HudElement>> {
   const lookup = new Map<HudElement, Set<HudElement>>();
@@ -353,6 +354,20 @@ function collectActivityLines(ctx: RenderContext): string[] {
     }
   }
 
+  if (display?.showSkills === true) {
+    const skillsLine = renderSkillsLine(ctx);
+    if (skillsLine) {
+      activityLines.push(skillsLine);
+    }
+  }
+
+  if (display?.showMcp === true) {
+    const mcpLine = renderMcpLine(ctx);
+    if (mcpLine) {
+      activityLines.push(mcpLine);
+    }
+  }
+
   if (display?.showAgents !== false) {
     const agentsLine = renderAgentsLine(ctx);
     if (agentsLine) {
@@ -395,6 +410,10 @@ function renderElementLine(
       return renderEnvironmentLine(ctx);
     case 'tools':
       return display?.showTools === false ? null : renderToolsLine(ctx);
+    case 'skills':
+      return display?.showSkills === true ? renderSkillsLine(ctx) : null;
+    case 'mcp':
+      return display?.showMcp === true ? renderMcpLine(ctx) : null;
     case 'agents':
       return display?.showAgents === false ? null : renderAgentsLine(ctx);
     case 'todos':

--- a/src/render/skills-mcp-line.ts
+++ b/src/render/skills-mcp-line.ts
@@ -3,6 +3,15 @@ import type { RenderContext } from '../types.js';
 import { cyan, green, label } from './colors.js';
 
 const MAX_ITEMS_SHOWN = 4;
+const ACTIVITY_NAME_MAX_LEN = 64;
+const DISPLAY_CONTROL_PATTERN = new RegExp(
+  '[' +
+  '\\u0000-\\u001F\\u007F-\\u009F' +
+  '\\u061C\\u200E\\u200F' +
+  '\\u202A-\\u202E\\u2066-\\u2069\\u206A-\\u206F' +
+  ']',
+  'g',
+);
 
 export function renderSkillsLine(ctx: RenderContext): string | null {
   if (ctx.config?.display?.showSkills !== true) {
@@ -25,15 +34,35 @@ function renderNameListLine(
   names: string[],
   colors?: Partial<HudColorOverrides>,
 ): string | null {
-  if (names.length === 0) {
+  const safeNames = names.map(safeActivityName).filter((name): name is string => Boolean(name));
+  if (safeNames.length === 0) {
     return null;
   }
 
-  const visibleNames = names.slice(0, MAX_ITEMS_SHOWN).map(name => cyan(name));
-  const hiddenCount = names.length - visibleNames.length;
+  const visibleNames = safeNames.slice(0, MAX_ITEMS_SHOWN).map(name => cyan(name));
+  const hiddenCount = safeNames.length - visibleNames.length;
   if (hiddenCount > 0) {
     visibleNames.push(label(`+${hiddenCount} more`, colors));
   }
 
-  return `${green('✓')} ${title} ${label(`(${names.length})`, colors)}: ${visibleNames.join(', ')}`;
+  return `${green('✓')} ${title} ${label(`(${safeNames.length})`, colors)}: ${visibleNames.join(', ')}`;
+}
+
+function safeActivityName(value: string): string | null {
+  const sanitized = value
+    .replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\x1B\][^\x07\x1B]*(?:\x07|\x1B\\)/g, '')
+    .replace(/\x1B[@-Z\\-_]/g, '')
+    .replace(DISPLAY_CONTROL_PATTERN, '')
+    .trim();
+
+  if (!sanitized) {
+    return null;
+  }
+
+  if (sanitized.length <= ACTIVITY_NAME_MAX_LEN) {
+    return sanitized;
+  }
+
+  return `${sanitized.slice(0, ACTIVITY_NAME_MAX_LEN - 1)}…`;
 }

--- a/src/render/skills-mcp-line.ts
+++ b/src/render/skills-mcp-line.ts
@@ -1,0 +1,39 @@
+import type { HudColorOverrides } from '../config.js';
+import type { RenderContext } from '../types.js';
+import { cyan, green, label } from './colors.js';
+
+const MAX_ITEMS_SHOWN = 4;
+
+export function renderSkillsLine(ctx: RenderContext): string | null {
+  if (ctx.config?.display?.showSkills !== true) {
+    return null;
+  }
+
+  return renderNameListLine('Skills', ctx.transcript.skills ?? [], ctx.config?.colors);
+}
+
+export function renderMcpLine(ctx: RenderContext): string | null {
+  if (ctx.config?.display?.showMcp !== true) {
+    return null;
+  }
+
+  return renderNameListLine('MCPs', ctx.transcript.mcpServers ?? [], ctx.config?.colors);
+}
+
+function renderNameListLine(
+  title: string,
+  names: string[],
+  colors?: Partial<HudColorOverrides>,
+): string | null {
+  if (names.length === 0) {
+    return null;
+  }
+
+  const visibleNames = names.slice(0, MAX_ITEMS_SHOWN).map(name => cyan(name));
+  const hiddenCount = names.length - visibleNames.length;
+  if (hiddenCount > 0) {
+    visibleNames.push(label(`+${hiddenCount} more`, colors));
+  }
+
+  return `${green('✓')} ${title} ${label(`(${names.length})`, colors)}: ${visibleNames.join(', ')}`;
+}

--- a/src/render/tools-line.ts
+++ b/src/render/tools-line.ts
@@ -21,7 +21,10 @@ export function shortenToolName(name: string, maxLen: number): string {
 }
 
 export function renderToolsLine(ctx: RenderContext): string | null {
-  const { tools } = ctx.transcript;
+  const hideSkillTools = ctx.config?.display?.showSkills === true;
+  const tools = hideSkillTools
+    ? ctx.transcript.tools.filter((tool) => tool.name !== 'Skill')
+    : ctx.transcript.tools;
   const colors = ctx.config?.colors;
   const toolNameMaxLength = ctx.config?.display?.toolNameMaxLength ?? 0;
   const toolsMaxVisible = ctx.config?.display?.toolsMaxVisible ?? 4;

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -82,6 +82,15 @@ interface TranscriptCacheFile {
 
 const TRANSCRIPT_CACHE_VERSION = 8;
 const MCP_TOOL_NAME_PATTERN = /^mcp__(.+?)__(.+)$/;
+const ACTIVITY_NAME_MAX_LEN = 64;
+const DISPLAY_CONTROL_PATTERN = new RegExp(
+  '[' +
+  '\\u0000-\\u001F\\u007F-\\u009F' +
+  '\\u061C\\u200E\\u200F' +
+  '\\u202A-\\u202E\\u2066-\\u2069\\u206A-\\u206F' +
+  ']',
+  'g',
+);
 
 // Hard cap on the advisor model ID captured from the transcript. Real Claude
 // model IDs (e.g. "claude-haiku-4-5-20251001") fit comfortably under this; the
@@ -121,10 +130,7 @@ function normalizeNameList(value: unknown): string[] {
   const seen = new Set<string>();
   const names: string[] = [];
   for (const item of value) {
-    if (typeof item !== 'string') {
-      continue;
-    }
-    const name = item.trim();
+    const name = normalizeActivityName(item);
     if (!name || seen.has(name)) {
       continue;
     }
@@ -133,6 +139,29 @@ function normalizeNameList(value: unknown): string[] {
   }
 
   return names;
+}
+
+function normalizeActivityName(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const sanitized = value
+    .replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\x1B\][^\x07\x1B]*(?:\x07|\x1B\\)/g, '')
+    .replace(/\x1B[@-Z\\-_]/g, '')
+    .replace(DISPLAY_CONTROL_PATTERN, '')
+    .trim();
+
+  if (!sanitized) {
+    return undefined;
+  }
+
+  if (sanitized.length <= ACTIVITY_NAME_MAX_LEN) {
+    return sanitized;
+  }
+
+  return `${sanitized.slice(0, ACTIVITY_NAME_MAX_LEN - 1)}…`;
 }
 
 function getTranscriptCachePath(transcriptPath: string, homeDir: string): string {
@@ -599,11 +628,7 @@ function extractTarget(toolName: string, input?: Record<string, unknown>): strin
 }
 
 function normalizeSkillName(value: unknown): string | undefined {
-  if (typeof value !== 'string') {
-    return undefined;
-  }
-  const skillName = value.trim();
-  return skillName.length > 0 ? skillName : undefined;
+  return normalizeActivityName(value);
 }
 
 function extractMcpServerName(toolName: string): string | undefined {
@@ -612,8 +637,7 @@ function extractMcpServerName(toolName: string): string | undefined {
     return undefined;
   }
 
-  const serverName = match[1].trim();
-  return serverName.length > 0 ? serverName : undefined;
+  return normalizeActivityName(match[1]);
 }
 
 function resolveTaskIndex(

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -60,6 +60,8 @@ interface SerializedAgentEntry extends Omit<AgentEntry, 'startTime' | 'endTime'>
 
 interface SerializedTranscriptData {
   tools: SerializedToolEntry[];
+  skills: string[];
+  mcpServers: string[];
   agents: SerializedAgentEntry[];
   todos: TodoItem[];
   sessionStart?: string;
@@ -78,7 +80,8 @@ interface TranscriptCacheFile {
   data: SerializedTranscriptData;
 }
 
-const TRANSCRIPT_CACHE_VERSION = 7;
+const TRANSCRIPT_CACHE_VERSION = 8;
+const MCP_TOOL_NAME_PATTERN = /^mcp__(.+?)__(.+)$/;
 
 // Hard cap on the advisor model ID captured from the transcript. Real Claude
 // model IDs (e.g. "claude-haiku-4-5-20251001") fit comfortably under this; the
@@ -108,6 +111,28 @@ function normalizeSessionTokens(tokens: unknown): SessionTokenUsage | undefined 
     cacheCreationTokens: normalizeTokenCount(raw.cacheCreationTokens),
     cacheReadTokens: normalizeTokenCount(raw.cacheReadTokens),
   };
+}
+
+function normalizeNameList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const item of value) {
+    if (typeof item !== 'string') {
+      continue;
+    }
+    const name = item.trim();
+    if (!name || seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    names.push(name);
+  }
+
+  return names;
 }
 
 function getTranscriptCachePath(transcriptPath: string, homeDir: string): string {
@@ -145,6 +170,8 @@ function serializeTranscriptData(data: TranscriptData): SerializedTranscriptData
       startTime: tool.startTime.toISOString(),
       endTime: tool.endTime?.toISOString(),
     })),
+    skills: [...data.skills],
+    mcpServers: [...data.mcpServers],
     agents: data.agents.map((agent) => ({
       ...agent,
       startTime: agent.startTime.toISOString(),
@@ -168,6 +195,8 @@ function deserializeTranscriptData(data: SerializedTranscriptData): TranscriptDa
       startTime: new Date(tool.startTime),
       endTime: tool.endTime ? new Date(tool.endTime) : undefined,
     })),
+    skills: normalizeNameList(data.skills),
+    mcpServers: normalizeNameList(data.mcpServers),
     agents: data.agents.map((agent) => ({
       ...agent,
       startTime: new Date(agent.startTime),
@@ -227,6 +256,8 @@ function writeTranscriptCache(transcriptPath: string, state: TranscriptFileState
 export async function parseTranscript(transcriptPath: string): Promise<TranscriptData> {
   const result: TranscriptData = {
     tools: [],
+    skills: [],
+    mcpServers: [],
     agents: [],
     todos: [],
   };
@@ -251,6 +282,8 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   }
 
   const toolMap = new Map<string, ToolEntry>();
+  const skillSet = new Set<string>();
+  const mcpServerSet = new Set<string>();
   const agentMap = new Map<string, AgentEntry>();
   let latestTodos: TodoItem[] = [];
   const taskIdToIndex = new Map<string, number>();
@@ -348,7 +381,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
             }
           }
         }
-        processEntry(entry, toolMap, agentMap, taskIdToIndex, latestTodos, result);
+        processEntry(entry, toolMap, skillSet, mcpServerSet, agentMap, taskIdToIndex, latestTodos, result);
       } catch {
         lastUsageKey = undefined;
         // Skip malformed lines
@@ -376,6 +409,8 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
     }
   }
   result.tools = Array.from(toolMap.values()).slice(-20);
+  result.skills = Array.from(skillSet.values());
+  result.mcpServers = Array.from(mcpServerSet.values());
   result.agents = Array.from(agentMap.values()).slice(-10);
   result.todos = latestTodos;
   result.sessionName = customTitle ?? latestSlug;
@@ -397,6 +432,8 @@ export function _setCreateReadStreamForTests(impl: typeof fs.createReadStream | 
 function processEntry(
   entry: TranscriptLine,
   toolMap: Map<string, ToolEntry>,
+  skillSet: Set<string>,
+  mcpServerSet: Set<string>,
   agentMap: Map<string, AgentEntry>,
   taskIdToIndex: Map<string, number>,
   latestTodos: TodoItem[],
@@ -418,6 +455,18 @@ function processEntry(
 
   for (const block of content) {
     if (block.type === 'tool_use' && block.id && block.name) {
+      const skillName = block.name === 'Skill'
+        ? normalizeSkillName(block.input?.skill)
+        : undefined;
+      if (skillName) {
+        skillSet.add(skillName);
+      }
+
+      const mcpServerName = extractMcpServerName(block.name);
+      if (mcpServerName) {
+        mcpServerSet.add(mcpServerName);
+      }
+
       const toolEntry: ToolEntry = {
         id: block.id,
         name: block.name,
@@ -541,14 +590,30 @@ function extractTarget(toolName: string, input?: Record<string, unknown>): strin
     case 'Grep':
       return input.pattern as string;
     case 'Skill':
-      return typeof input.skill === 'string' && input.skill.trim().length > 0
-        ? input.skill
-        : undefined;
+      return normalizeSkillName(input.skill);
     case 'Bash':
       const cmd = input.command as string;
       return cmd?.slice(0, 30) + (cmd?.length > 30 ? '...' : '');
   }
   return undefined;
+}
+
+function normalizeSkillName(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const skillName = value.trim();
+  return skillName.length > 0 ? skillName : undefined;
+}
+
+function extractMcpServerName(toolName: string): string | undefined {
+  const match = MCP_TOOL_NAME_PATTERN.exec(toolName);
+  if (!match) {
+    return undefined;
+  }
+
+  const serverName = match[1].trim();
+  return serverName.length > 0 ? serverName : undefined;
 }
 
 function resolveTaskIndex(

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,8 @@ export interface SessionTokenUsage {
 
 export interface TranscriptData {
   tools: ToolEntry[];
+  skills: string[];
+  mcpServers: string[];
   agents: AgentEntry[];
   todos: TodoItem[];
   sessionStart?: Date;

--- a/tests/fixtures/transcript-render.jsonl
+++ b/tests/fixtures/transcript-render.jsonl
@@ -1,6 +1,11 @@
 {"message":{"content":[{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"/tmp/example.txt"}}]}}
 {"message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","is_error":false}]}}
 {"message":{"content":[{"type":"tool_use","id":"tool-2","name":"Edit","input":{"file_path":"/tmp/very/long/path/to/authentication.ts"}}]}}
+{"message":{"content":[{"type":"tool_use","id":"skill-1","name":"Skill","input":{"skill":"frontend-design"}}]}}
+{"message":{"content":[{"type":"tool_use","id":"skill-2","name":"Skill","input":{"skill":"frontend-design"}}]}}
+{"message":{"content":[{"type":"tool_use","id":"mcp-1","name":"mcp__linear__list_issues","input":{}}]}}
+{"message":{"content":[{"type":"tool_use","id":"mcp-2","name":"mcp__linear__get_issue","input":{}}]}}
+{"message":{"content":[{"type":"tool_use","id":"mcp-3","name":"mcp__slack__search_messages","input":{}}]}}
 {"message":{"content":[{"type":"tool_use","id":"agent-1","name":"Task","input":{"subagent_type":"explore","model":"haiku","description":"Finding auth code"}}]}}
 {"message":{"content":[{"type":"tool_result","tool_use_id":"agent-1","is_error":false}]}}
 {"message":{"content":[{"type":"tool_use","id":"todo-1","name":"TodoWrite","input":{"todos":[{"content":"Fix auth bug","status":"completed"},{"content":"Add tests","status":"in_progress"}]}}]}}

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1330,6 +1330,34 @@ test('parseTranscript detects active skills and distinct MCP servers from tool_u
   assert.deepEqual(result.mcpServers, ['linear', 'slack']);
 });
 
+test('parseTranscript sanitizes and caps active skill and MCP names', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-'));
+  const filePath = path.join(dir, 'unsafe-activity.jsonl');
+  const longSkill = `skill-${'x'.repeat(100)}`;
+  const lines = [
+    JSON.stringify({
+      message: {
+        content: [
+          { type: 'tool_use', id: 'skill-1', name: 'Skill', input: { skill: `\x1b[31m${longSkill}\x1b[0m\u202E` } },
+          { type: 'tool_use', id: 'mcp-1', name: 'mcp__bad\x1b]8;;https://evil.example\x07server\u202E__tool', input: {} },
+        ],
+      },
+    }),
+  ];
+
+  await writeFile(filePath, lines.join('\n'), 'utf8');
+
+  try {
+    const result = await parseTranscript(filePath);
+    assert.equal(result.skills.length, 1);
+    assert.equal(result.skills[0].length, 64);
+    assert.equal(result.skills[0], `${longSkill.slice(0, 63)}…`);
+    assert.deepEqual(result.mcpServers, ['badserver']);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('renderSkillsLine and renderMcpLine show counts and names when enabled', () => {
   const ctx = baseContext();
   ctx.config.display.showSkills = true;
@@ -1344,6 +1372,21 @@ test('renderSkillsLine and renderMcpLine show counts and names when enabled', ()
   assert.equal(mcpLine, '✓ MCPs (2): linear, slack');
 });
 
+test('renderSkillsLine and renderMcpLine sanitize direct transcript names before display', () => {
+  const ctx = baseContext();
+  ctx.config.display.showSkills = true;
+  ctx.config.display.showMcp = true;
+  ctx.transcript.skills = ['\x1b[31mfrontend-design\x1b[0m\u202E', '\x07'];
+  ctx.transcript.mcpServers = [`linear-${'x'.repeat(100)}`];
+
+  const skillsLine = stripAnsi(renderSkillsLine(ctx) ?? '');
+  const mcpLine = stripAnsi(renderMcpLine(ctx) ?? '');
+
+  assert.equal(skillsLine, '✓ Skills (1): frontend-design');
+  assert.ok(!skillsLine.includes('\u202E'), 'bidi control must not render');
+  assert.equal(mcpLine, `✓ MCPs (1): ${`linear-${'x'.repeat(100)}`.slice(0, 63)}…`);
+});
+
 test('renderSkillsLine and renderMcpLine return null with no data even when enabled', () => {
   const ctx = baseContext();
   ctx.config.display.showSkills = true;
@@ -1351,6 +1394,24 @@ test('renderSkillsLine and renderMcpLine return null with no data even when enab
 
   assert.equal(renderSkillsLine(ctx), null);
   assert.equal(renderMcpLine(ctx), null);
+});
+
+test('renderToolsLine suppresses generic Skill entries when the Skills line is enabled', () => {
+  const ctx = baseContext();
+  ctx.config.display.showSkills = true;
+  ctx.transcript.tools = [
+    { id: 'tool-1', name: 'Skill', target: 'frontend-design', status: 'completed', startTime: new Date(0), endTime: new Date(0) },
+    { id: 'tool-2', name: 'Read', status: 'completed', startTime: new Date(0), endTime: new Date(0) },
+  ];
+
+  const line = stripAnsi(renderToolsLine(ctx) ?? '');
+  assert.ok(!line.includes('Skill'), `Skill tool should be suppressed: ${line}`);
+  assert.ok(line.includes('Read'), `other tools should remain visible: ${line}`);
+
+  ctx.transcript.tools = [
+    { id: 'tool-1', name: 'Skill', target: 'frontend-design', status: 'completed', startTime: new Date(0), endTime: new Date(0) },
+  ];
+  assert.equal(renderToolsLine(ctx), null);
 });
 
 test('skills and MCP activity lines stay hidden by default', () => {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -4,12 +4,15 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 import { render } from '../dist/render/index.js';
 import { mergeConfig } from '../dist/config.js';
+import { parseTranscript } from '../dist/transcript.js';
 import { renderSessionLine } from '../dist/render/session-line.js';
 import { renderProjectLine, renderGitFilesLine } from '../dist/render/lines/project.js';
 import { renderPromptCacheLine } from '../dist/render/lines/prompt-cache.js';
 import { renderToolsLine, shortenToolName } from '../dist/render/tools-line.js';
+import { renderSkillsLine, renderMcpLine } from '../dist/render/skills-mcp-line.js';
 import { renderAgentsLine } from '../dist/render/agents-line.js';
 import { renderTodosLine } from '../dist/render/todos-line.js';
 import { renderUsageLine } from '../dist/render/lines/usage.js';
@@ -42,7 +45,7 @@ function baseContext() {
         },
       },
     },
-    transcript: { tools: [], agents: [], todos: [], sessionTokens: undefined },
+    transcript: { tools: [], skills: [], mcpServers: [], agents: [], todos: [], sessionTokens: undefined },
     claudeMdCount: 0,
     rulesCount: 0,
     mcpCount: 0,
@@ -55,9 +58,9 @@ function baseContext() {
       lineLayout: 'compact',
       showSeparators: false,
       pathLevels: 1,
-      elementOrder: ['project', 'context', 'usage', 'promptCache', 'memory', 'environment', 'tools', 'agents', 'todos'],
+      elementOrder: ['project', 'context', 'usage', 'promptCache', 'memory', 'environment', 'tools', 'skills', 'mcp', 'agents', 'todos'],
       gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, branchOverflow: 'truncate', pushWarningThreshold: 0, pushCriticalThreshold: 0 },
-      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageValue: 'percent', usageBarEnabled: false, showResetLabel: true, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showPromptCache: false, promptCacheTtlSeconds: 300, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
+      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageValue: 'percent', usageBarEnabled: false, showResetLabel: true, showTools: true, showSkills: false, showMcp: false, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showPromptCache: false, promptCacheTtlSeconds: 300, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
       colors: {
         context: 'green',
         usage: 'brightBlue',
@@ -714,6 +717,8 @@ test('label color overrides apply across shared secondary text surfaces', () => 
   ctx.transcript.tools = [
     { id: 'tool-1', name: 'Read', target: 'src/index.ts', status: 'running', startTime: new Date(0) },
   ];
+  ctx.transcript.skills = ['frontend-design'];
+  ctx.transcript.mcpServers = ['linear'];
   ctx.transcript.agents = [
     { id: 'agent-1', type: 'planner', model: 'haiku', description: 'Inspecting', status: 'running', startTime: new Date(0) },
   ];
@@ -721,6 +726,8 @@ test('label color overrides apply across shared secondary text surfaces', () => 
     { content: 'Ship it', status: 'in_progress' },
     { content: 'Done', status: 'completed' },
   ];
+  ctx.config.display.showSkills = true;
+  ctx.config.display.showMcp = true;
 
   const expected = '\x1b[38;2;171;205;239m';
   assert.ok(renderIdentityLine(ctx).includes(`${expected}Context\x1b[0m`));
@@ -729,6 +736,8 @@ test('label color overrides apply across shared secondary text surfaces', () => 
   assert.ok(renderEnvironmentLine(ctx)?.includes(`${expected}2 CLAUDE.md | 1 rules\x1b[0m`));
   assert.ok(renderMemoryLine({ ...ctx, config: { ...ctx.config, lineLayout: 'expanded', display: { ...ctx.config.display, showMemoryUsage: true } } })?.includes(`${expected}Approx RAM\x1b[0m`));
   assert.ok(renderToolsLine(ctx)?.includes(`${expected}: src/index.ts\x1b[0m`));
+  assert.ok(renderSkillsLine(ctx)?.includes(`${expected}(1)\x1b[0m`));
+  assert.ok(renderMcpLine(ctx)?.includes(`${expected}(1)\x1b[0m`));
   assert.ok(renderAgentsLine(ctx)?.includes(`${expected}[haiku]\x1b[0m`));
   assert.ok(renderTodosLine(ctx)?.includes(`${expected}(1/2)\x1b[0m`));
 });
@@ -1310,6 +1319,76 @@ test('renderTodosLine returns null when no todos exist', () => {
 test('renderToolsLine returns null when no tools exist', () => {
   const ctx = baseContext();
   assert.equal(renderToolsLine(ctx), null);
+});
+
+test('parseTranscript detects active skills and distinct MCP servers from tool_use blocks', async () => {
+  const fixturePath = fileURLToPath(new URL('./fixtures/transcript-render.jsonl', import.meta.url));
+
+  const result = await parseTranscript(fixturePath);
+
+  assert.deepEqual(result.skills, ['frontend-design']);
+  assert.deepEqual(result.mcpServers, ['linear', 'slack']);
+});
+
+test('renderSkillsLine and renderMcpLine show counts and names when enabled', () => {
+  const ctx = baseContext();
+  ctx.config.display.showSkills = true;
+  ctx.config.display.showMcp = true;
+  ctx.transcript.skills = ['frontend-design'];
+  ctx.transcript.mcpServers = ['linear', 'slack'];
+
+  const skillsLine = stripAnsi(renderSkillsLine(ctx) ?? '');
+  const mcpLine = stripAnsi(renderMcpLine(ctx) ?? '');
+
+  assert.equal(skillsLine, '✓ Skills (1): frontend-design');
+  assert.equal(mcpLine, '✓ MCPs (2): linear, slack');
+});
+
+test('renderSkillsLine and renderMcpLine return null with no data even when enabled', () => {
+  const ctx = baseContext();
+  ctx.config.display.showSkills = true;
+  ctx.config.display.showMcp = true;
+
+  assert.equal(renderSkillsLine(ctx), null);
+  assert.equal(renderMcpLine(ctx), null);
+});
+
+test('skills and MCP activity lines stay hidden by default', () => {
+  const ctx = baseContext();
+  ctx.config = mergeConfig({
+    lineLayout: 'expanded',
+    elementOrder: ['project', 'skills', 'mcp'],
+  });
+  ctx.transcript.skills = ['frontend-design'];
+  ctx.transcript.mcpServers = ['linear', 'slack'];
+
+  const output = captureRenderLines(ctx).join('\n');
+
+  assert.ok(!output.includes('Skills'), 'skills line should be default-off');
+  assert.ok(!output.includes('MCPs (2)'), 'MCP activity line should be default-off');
+});
+
+test('mergeConfig validates skill and MCP display options', () => {
+  const enabled = mergeConfig({
+    display: {
+      showSkills: true,
+      showMcp: true,
+    },
+  });
+  assert.equal(enabled.display.showSkills, true);
+  assert.equal(enabled.display.showMcp, true);
+
+  const sanitized = mergeConfig({
+    elementOrder: ['skills', 'unknown', 'mcp', 'project', 'skills'],
+    display: {
+      showSkills: 'yes',
+      showMcp: 1,
+    },
+  });
+
+  assert.deepEqual(sanitized.elementOrder, ['skills', 'mcp', 'project']);
+  assert.equal(sanitized.display.showSkills, false);
+  assert.equal(sanitized.display.showMcp, false);
 });
 
 // Usage display tests
@@ -2256,6 +2335,8 @@ test('render expanded layout honors custom elementOrder including activity place
   ctx.transcript.tools = [
     { id: 'tool-1', name: 'Read', status: 'completed', startTime: new Date(0), endTime: new Date(0), duration: 0 },
   ];
+  ctx.transcript.skills = ['frontend-design'];
+  ctx.transcript.mcpServers = ['linear'];
   ctx.transcript.agents = [
     { id: 'agent-1', type: 'planner', status: 'running', startTime: new Date(0) },
   ];
@@ -2263,10 +2344,14 @@ test('render expanded layout honors custom elementOrder including activity place
     { content: 'todo-marker', status: 'in_progress' },
   ];
   ctx.config.display.showMemoryUsage = true;
-  ctx.config.elementOrder = ['tools', 'project', 'usage', 'context', 'memory', 'environment', 'agents', 'todos'];
+  ctx.config.display.showSkills = true;
+  ctx.config.display.showMcp = true;
+  ctx.config.elementOrder = ['tools', 'skills', 'mcp', 'project', 'usage', 'context', 'memory', 'environment', 'agents', 'todos'];
 
   const lines = withTerminal(120, () => captureRenderLines(ctx));
   const toolIndex = lines.findIndex(line => line.includes('Read'));
+  const skillsIndex = lines.findIndex(line => line.includes('Skills'));
+  const mcpIndex = lines.findIndex(line => line.includes('MCPs'));
   const projectIndex = lines.findIndex(line => line.includes('my-project'));
   const combinedIndex = lines.findIndex(line => line.includes('Usage') && line.includes('Context'));
   const memoryIndex = lines.findIndex(line => line.includes('Approx RAM'));
@@ -2275,11 +2360,14 @@ test('render expanded layout honors custom elementOrder including activity place
   const todoIndex = lines.findIndex(line => line.includes('todo-marker'));
 
   assert.deepEqual(
-    [toolIndex, projectIndex, combinedIndex, memoryIndex, environmentIndex, agentIndex, todoIndex].every(index => index >= 0),
+    [toolIndex, skillsIndex, mcpIndex, projectIndex, combinedIndex, memoryIndex, environmentIndex, agentIndex, todoIndex].every(index => index >= 0),
     true,
     'expected all configured elements to render'
   );
   assert.ok(toolIndex < projectIndex, 'tool line should move ahead of project');
+  assert.ok(toolIndex < skillsIndex, 'skills line should follow tools line');
+  assert.ok(skillsIndex < mcpIndex, 'MCP line should follow skills line');
+  assert.ok(mcpIndex < projectIndex, 'project line should follow MCP line');
   assert.ok(projectIndex < combinedIndex, 'combined usage/context line should follow project');
   assert.ok(combinedIndex < memoryIndex, 'memory line should follow combined usage/context');
   assert.ok(memoryIndex < environmentIndex, 'environment line should follow memory');
@@ -2462,14 +2550,20 @@ test('render compact layout keeps activity lines even when elementOrder omits th
   ctx.transcript.tools = [
     { id: 'tool-1', name: 'Read', status: 'completed', startTime: new Date(0), endTime: new Date(0), duration: 0 },
   ];
+  ctx.transcript.skills = ['frontend-design'];
+  ctx.transcript.mcpServers = ['linear'];
   ctx.transcript.todos = [
     { content: 'todo-marker', status: 'in_progress' },
   ];
   ctx.config.elementOrder = ['project'];
+  ctx.config.display.showSkills = true;
+  ctx.config.display.showMcp = true;
 
   const output = captureRenderLines(ctx).join('\n');
 
   assert.ok(output.includes('Read'), 'compact mode should keep tools visible');
+  assert.ok(output.includes('Skills'), 'compact mode should keep skills visible');
+  assert.ok(output.includes('MCPs'), 'compact mode should keep MCPs visible');
   assert.ok(output.includes('todo-marker'), 'compact mode should keep todos visible');
 });
 


### PR DESCRIPTION
## Summary

Adds `skills` and `mcp` as displayable HUD elements, requested in #527. When enabled via `display.showSkills` / `display.showMcp`, the HUD shows which Skills and MCP servers are active in the current session, alongside the existing `tools`, `agents`, and `todos` elements. Both default to off, so existing configs render exactly as before.

Skill and MCP activity is detected from the transcript (`src/transcript.ts`): Skill tool invocations populate the skills line, and `mcp__server__tool` calls are aggregated per server for the MCP line. Rendering follows the same overflow rules as the tools line (`src/render/skills-mcp-line.ts`), and the new elements participate in `elementOrder` like every other HudElement.

`mergeConfig` migration handles configs written before these fields existed (missing booleans fall back to defaults), and the README documents both options.

AI was used for assistance.

## Testing

- [x] `npm test` (659 tests, 658 pass, 1 skipped; includes new render + transcript cases for skills/MCP extraction, ordering, overflow, and config migration)
- [ ] `npm run test:coverage`

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed

Fixes #527
