### PR TITLE
feat: add Skills line — detect manually-loaded skills, no double-display (re: #527, #595)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.toolsMaxVisible` | number | `4` | Maximum completed tools shown on the tools line. `0` means unlimited |
 | `display.showAgents` | boolean | false | Show agents activity line |
 | `display.showTodos` | boolean | false | Show todos progress line |
+| `display.showSkills` | boolean | false | Show a `⚡ Skills:` line listing skills used this session. Detected from `Skill` tool calls and from the `Base directory for this skill:` load marker (so user-invoked `/skill` and auto-loaded skills are included), deduped to bare names. When on, the `Skill` tool is omitted from the tools line so each skill appears once. |
 | `display.showSessionName` | boolean | false | Show session slug or custom title from `/rename` |
 | `display.showAdvisor` | boolean | false | Inline the model configured via Claude Code's `/advisor` on the project line, e.g. `Advisor: Opus 4.7`. Read from the `advisorModel` field that Claude Code stamps on each assistant transcript record; sanitised and capped at 64 chars before rendering |
 | `display.advisorOverride` | string | `""` | Optional manual override for the displayed advisor label. When non-empty, replaces transcript-driven detection. Also sanitised and capped at 64 chars |

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
 export type ModelFormatMode = 'full' | 'compact' | 'short';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both' | 'elapsed' | 'elapsedAndAbsolute';
 export type CustomLinePosition = 'first' | 'last';
-export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos' | 'sessionTime';
+export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos' | 'skills' | 'sessionTime';
 
 export type AddedDirsLayout = 'inline' | 'line';
 export type HudColorName =
@@ -64,6 +64,7 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'tools',
   'agents',
   'todos',
+  'skills',
   'sessionTime',
 ];
 
@@ -112,6 +113,7 @@ export interface HudConfig {
     toolsMaxVisible: number;
     showAgents: boolean;
     showTodos: boolean;
+    showSkills: boolean;
     showSessionName: boolean;
     showClaudeCodeVersion: boolean;
     showEffortLevel: boolean;
@@ -189,6 +191,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     toolsMaxVisible: 4,
     showAgents: false,
     showTodos: false,
+    showSkills: false,
     showSessionName: false,
     showClaudeCodeVersion: false,
     showEffortLevel: false,
@@ -495,6 +498,7 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     : null;
 
   const elementOrder = validateElementOrder(migrated.elementOrder);
+  let resolvedElementOrder = elementOrder;
   const forceMaxWidth = typeof (migrated as Record<string, unknown>).forceMaxWidth === 'boolean'
     ? (migrated as Record<string, unknown>).forceMaxWidth as boolean
     : DEFAULT_CONFIG.forceMaxWidth;
@@ -585,6 +589,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showTodos: typeof migrated.display?.showTodos === 'boolean'
       ? migrated.display.showTodos
       : DEFAULT_CONFIG.display.showTodos,
+    showSkills: typeof migrated.display?.showSkills === 'boolean'
+      ? migrated.display.showSkills
+      : DEFAULT_CONFIG.display.showSkills,
     showSessionName: typeof migrated.display?.showSessionName === 'boolean'
       ? migrated.display.showSessionName
       : DEFAULT_CONFIG.display.showSessionName,
@@ -658,6 +665,13 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     autoCompactWindow: validateAutoCompactWindow(migrated.display?.autoCompactWindow),
   };
 
+  // If the skills element is enabled but a custom elementOrder omits it (e.g. a config
+  // saved before this feature), append it so an enabled skills line is never silently
+  // dropped in expanded mode while the Skill tool is suppressed from the tools line.
+  if (display.showSkills && !resolvedElementOrder.includes('skills')) {
+    resolvedElementOrder = [...resolvedElementOrder, 'skills'];
+  }
+
   const colors = {
     context: validateColorValue(migrated.colors?.context)
       ? migrated.colors.context
@@ -700,7 +714,7 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
       : DEFAULT_CONFIG.colors.barEmpty,
   };
 
-  return { language, lineLayout, showSeparators, pathLevels, maxWidth, forceMaxWidth, elementOrder, gitStatus, display, colors };
+  return { language, lineLayout, showSeparators, pathLevels, maxWidth, forceMaxWidth, elementOrder: resolvedElementOrder, gitStatus, display, colors };
 }
 
 export async function loadConfig(): Promise<HudConfig> {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -15,6 +15,7 @@ export const en: Messages = {
   "label.sessionStarted": "Started",
   "label.lastReply": "Last reply",
   "label.advisor": "Advisor",
+  "label.skills": "Skills",
 
   // Status
   "status.limitReached": "Limit reached",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -13,6 +13,7 @@ export type MessageKey =
   | "label.sessionStarted"
   | "label.lastReply"
   | "label.advisor"
+  | "label.skills"
   // Status
   | "status.limitReached"
   | "status.allTodosComplete"

--- a/src/i18n/zh-Hans.ts
+++ b/src/i18n/zh-Hans.ts
@@ -15,6 +15,7 @@ export const zhHans: Messages = {
   "label.sessionStarted": "开始",
   "label.lastReply": "上次回复",
   "label.advisor": "顾问",
+  "label.skills": "技能",
 
   // Status
   "status.limitReached": "已达上限",

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -5,6 +5,7 @@ import { renderSessionLine } from './session-line.js';
 import { renderToolsLine } from './tools-line.js';
 import { renderAgentsLine } from './agents-line.js';
 import { renderTodosLine } from './todos-line.js';
+import { renderSkillsLine } from './skills-line.js';
 import {
   renderIdentityLine,
   renderProjectLine,
@@ -306,7 +307,7 @@ function makeSeparator(length: number): string {
   return dim('─'.repeat(repeats));
 }
 
-const ACTIVITY_ELEMENTS = new Set<HudElement>(['tools', 'agents', 'todos']);
+const ACTIVITY_ELEMENTS = new Set<HudElement>(['tools', 'agents', 'todos', 'skills']);
 
 function buildMergeGroupLookup(mergeGroups: HudElement[][]): Map<HudElement, Set<HudElement>> {
   const lookup = new Map<HudElement, Set<HudElement>>();
@@ -367,6 +368,13 @@ function collectActivityLines(ctx: RenderContext): string[] {
     }
   }
 
+  if (display?.showSkills !== false) {
+    const skillsLine = renderSkillsLine(ctx);
+    if (skillsLine) {
+      activityLines.push(skillsLine);
+    }
+  }
+
   return activityLines;
 }
 
@@ -399,6 +407,8 @@ function renderElementLine(
       return display?.showAgents === false ? null : renderAgentsLine(ctx);
     case 'todos':
       return display?.showTodos === false ? null : renderTodosLine(ctx);
+    case 'skills':
+      return display?.showSkills === false ? null : renderSkillsLine(ctx);
     case 'sessionTime':
       return renderSessionTimeLine(ctx);
   }

--- a/src/render/skills-line.ts
+++ b/src/render/skills-line.ts
@@ -1,0 +1,22 @@
+import type { RenderContext } from "../types.js";
+import { cyan, label } from "./colors.js";
+import { t } from "../i18n/index.js";
+
+const MAX_SKILLS_SHOWN = 5;
+
+export function renderSkillsLine(ctx: RenderContext): string | null {
+  const { skills } = ctx.transcript;
+  const colors = ctx.config?.colors;
+
+  if (!skills || skills.length === 0) {
+    return null;
+  }
+
+  const shown = skills.slice(0, MAX_SKILLS_SHOWN);
+  const remaining = skills.length - shown.length;
+
+  const names = shown.map((skill) => cyan(skill)).join(label(", ", colors));
+  const more = remaining > 0 ? label(` +${remaining} more`, colors) : "";
+
+  return `${cyan("⚡")} ${label(`${t("label.skills")}:`, colors)} ${names}${more}`;
+}

--- a/src/render/tools-line.ts
+++ b/src/render/tools-line.ts
@@ -21,10 +21,17 @@ export function shortenToolName(name: string, maxLen: number): string {
 }
 
 export function renderToolsLine(ctx: RenderContext): string | null {
-  const { tools } = ctx.transcript;
   const colors = ctx.config?.colors;
   const toolNameMaxLength = ctx.config?.display?.toolNameMaxLength ?? 0;
   const toolsMaxVisible = ctx.config?.display?.toolsMaxVisible ?? 4;
+
+  // When the dedicated skills line is enabled, skills are surfaced there — drop the
+  // Skill tool from the tools line so each skill appears in exactly one place. Tied to
+  // the same condition that renders the skills line (see render/index.ts).
+  const skillsLineEnabled = ctx.config?.display?.showSkills !== false;
+  const tools = skillsLineEnabled
+    ? ctx.transcript.tools.filter((t) => t.name !== 'Skill')
+    : ctx.transcript.tools;
 
   if (tools.length === 0) {
     return null;

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -12,6 +12,7 @@ interface TranscriptLine {
   subtype?: string;
   operation?: string;
   content?: string;
+  isMeta?: boolean;
   slug?: string;
   customTitle?: string;
   // Top-level field stamped onto every assistant record after `/advisor` is
@@ -38,6 +39,7 @@ interface ContentBlock {
   type: string;
   id?: string;
   name?: string;
+  text?: string;
   input?: Record<string, unknown>;
   tool_use_id?: string;
   is_error?: boolean;
@@ -62,6 +64,7 @@ interface SerializedTranscriptData {
   tools: SerializedToolEntry[];
   agents: SerializedAgentEntry[];
   todos: TodoItem[];
+  skills: string[];
   sessionStart?: string;
   sessionName?: string;
   lastAssistantResponseAt?: string;
@@ -78,7 +81,7 @@ interface TranscriptCacheFile {
   data: SerializedTranscriptData;
 }
 
-const TRANSCRIPT_CACHE_VERSION = 7;
+const TRANSCRIPT_CACHE_VERSION = 8;
 
 // Hard cap on the advisor model ID captured from the transcript. Real Claude
 // model IDs (e.g. "claude-haiku-4-5-20251001") fit comfortably under this; the
@@ -151,6 +154,7 @@ function serializeTranscriptData(data: TranscriptData): SerializedTranscriptData
       endTime: agent.endTime?.toISOString(),
     })),
     todos: data.todos.map((todo) => ({ ...todo })),
+    skills: [...data.skills],
     sessionStart: data.sessionStart?.toISOString(),
     sessionName: data.sessionName,
     lastAssistantResponseAt: data.lastAssistantResponseAt?.toISOString(),
@@ -174,6 +178,7 @@ function deserializeTranscriptData(data: SerializedTranscriptData): TranscriptDa
       endTime: agent.endTime ? new Date(agent.endTime) : undefined,
     })),
     todos: data.todos.map((todo) => ({ ...todo })),
+    skills: Array.isArray(data.skills) ? [...data.skills] : [],
     sessionStart: data.sessionStart ? new Date(data.sessionStart) : undefined,
     sessionName: data.sessionName,
     lastAssistantResponseAt: data.lastAssistantResponseAt ? new Date(data.lastAssistantResponseAt) : undefined,
@@ -229,6 +234,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
     tools: [],
     agents: [],
     todos: [],
+    skills: [],
   };
 
   if (!transcriptPath || !fs.existsSync(transcriptPath)) {
@@ -349,6 +355,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
           }
         }
         processEntry(entry, toolMap, agentMap, taskIdToIndex, latestTodos, result);
+        detectSkillLoad(entry, result);
       } catch {
         lastUsageKey = undefined;
         // Skip malformed lines
@@ -377,6 +384,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   }
   result.tools = Array.from(toolMap.values()).slice(-20);
   result.agents = Array.from(agentMap.values()).slice(-10);
+  result.skills = result.skills.slice(-20);
   result.todos = latestTodos;
   result.sessionName = customTitle ?? latestSlug;
   result.sessionTokens = sessionTokens;
@@ -392,6 +400,48 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
 
 export function _setCreateReadStreamForTests(impl: typeof fs.createReadStream | null): void {
   createReadStreamImpl = impl ?? fs.createReadStream;
+}
+
+// The harness prefixes a loaded skill's body with this line; the trailing token is the
+// skill's directory, whose basename is the skill name. Detection is gated on `isMeta` user
+// messages (see detectSkillLoad) — that gate is what excludes ordinary tool output and prose;
+// the `^` anchor additionally avoids matching the marker quoted later inside such a message.
+const SKILL_BASEDIR_PATTERN = /^Base directory for this skill:\s*(\S+)/;
+
+function getEntryText(content: ContentBlock[] | string | undefined): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content.map((block) => (block && typeof block.text === 'string' ? block.text : '')).join('');
+  }
+  return '';
+}
+
+/**
+ * Normalizes a skill identifier to its bare name so the two detection signals dedupe:
+ * the Skill tool reports `superpowers:brainstorming`, the load marker reports a path
+ * `.../skills/brainstorming`. Both reduce to `brainstorming`. Backslashes are normalized first
+ * so Windows marker paths (`C:\...\skills\brainstorming`) resolve correctly.
+ */
+function bareSkillName(raw: string): string {
+  const normalized = raw.replace(/\\/g, '/');
+  const segment = normalized.replace(/\/+$/, '').split('/').pop() ?? normalized;
+  return (segment.split(':').pop() ?? segment).trim();
+}
+
+/**
+ * Detects a skill load via the `Base directory for this skill: <path>` marker the harness
+ * injects as an `isMeta` user message when a folder-backed skill loads — observed for both
+ * model- (Skill tool) and user- (slash command) invoked loads. Robust: one explicit string
+ * + the path basename, no ordering/threshold heuristics.
+ */
+function detectSkillLoad(entry: TranscriptLine, result: TranscriptData): void {
+  if (entry.type !== 'user' || entry.isMeta !== true) return;
+  const match = SKILL_BASEDIR_PATTERN.exec(getEntryText(entry.message?.content).trimStart());
+  if (!match) return;
+  const name = bareSkillName(match[1]);
+  if (name && !result.skills.includes(name)) {
+    result.skills.push(name);
+  }
 }
 
 function processEntry(
@@ -425,6 +475,17 @@ function processEntry(
         status: 'running',
         startTime: timestamp,
       };
+
+      // Capture a model-invoked skill into the dedicated skills list (in addition to
+      // the tool entry below). The tools-line render suppresses the Skill tool when
+      // the skills element is enabled, so it shows in one place.
+      if (block.name === 'Skill') {
+        const raw = (block.input as { skill?: unknown })?.skill;
+        const skillName = typeof raw === 'string' ? bareSkillName(raw) : '';
+        if (skillName && !result.skills.includes(skillName)) {
+          result.skills.push(skillName);
+        }
+      }
 
       if (block.name === 'Task' || block.name === 'Agent') {
         const input = block.input as Record<string, unknown>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,7 @@ export interface TranscriptData {
   tools: ToolEntry[];
   agents: AgentEntry[];
   todos: TodoItem[];
+  skills: string[];
   sessionStart?: Date;
   sessionName?: string;
   lastAssistantResponseAt?: Date;

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -858,3 +858,30 @@ test('mergeConfig rejects non-string advisorOverride and non-boolean showAdvisor
   assert.equal(config.display.showAdvisor, false);
   assert.equal(config.display.advisorOverride, '');
 });
+
+test('mergeConfig defaults showSkills to false', () => {
+  assert.equal(mergeConfig({}).display.showSkills, false);
+});
+
+test('mergeConfig preserves explicit showSkills=true', () => {
+  assert.equal(mergeConfig({ display: { showSkills: true } }).display.showSkills, true);
+});
+
+test('mergeConfig falls back to default for non-boolean showSkills', () => {
+  assert.equal(mergeConfig({ display: { showSkills: 'yes' } }).display.showSkills, false);
+});
+
+test('mergeConfig keeps skills as a recognized element in elementOrder', () => {
+  const config = mergeConfig({ elementOrder: ['skills', 'project'] });
+  assert.deepEqual(config.elementOrder, ['skills', 'project']);
+});
+
+test('mergeConfig appends skills to a custom elementOrder when showSkills is enabled but skills is missing', () => {
+  const config = mergeConfig({ display: { showSkills: true }, elementOrder: ['project', 'tools'] });
+  assert.ok(config.elementOrder.includes('skills'), 'skills should be appended so an enabled skills line is never dropped');
+});
+
+test('mergeConfig does not append skills when showSkills is off', () => {
+  const config = mergeConfig({ elementOrder: ['project', 'tools'] });
+  assert.ok(!config.elementOrder.includes('skills'), 'skills should not be force-added when disabled');
+});

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -998,6 +998,65 @@ test('parseTranscript leaves Skill target empty when input.skill is missing or i
   }
 });
 
+test('parseTranscript records a model-invoked Skill into skills (bare name) and as a tool', async () => {
+  const result = await parseTempTranscript('skill-tool.jsonl', [
+    { message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'Skill', input: { skill: 'superpowers:brainstorming' } }] } },
+  ]);
+  assert.deepEqual(result.skills, ['brainstorming']);
+  assert.ok(result.tools.some((tool) => tool.name === 'Skill'), 'Skill is still recorded as a tool');
+});
+
+test('parseTranscript counts a skill load from the Base directory marker (start-anchored, isMeta user)', async () => {
+  const result = await parseTempTranscript('skill-marker.jsonl', [
+    { type: 'user', isMeta: true, message: { content: 'Base directory for this skill: /home/x/.claude/skills/frontend-design\n\n# Frontend Design\nbody' } },
+  ]);
+  assert.deepEqual(result.skills, ['frontend-design']);
+});
+
+test('parseTranscript counts a skill load when the marker is in a text-block array', async () => {
+  const result = await parseTempTranscript('skill-marker-array.jsonl', [
+    { type: 'user', isMeta: true, message: { content: [{ type: 'text', text: 'Base directory for this skill: /x/skills/prd-development\n# PRD' }] } },
+  ]);
+  assert.deepEqual(result.skills, ['prd-development']);
+});
+
+test('parseTranscript ignores the marker string when not at the start of the message (quoted in prose)', async () => {
+  const result = await parseTempTranscript('skill-marker-quoted.jsonl', [
+    { type: 'user', isMeta: true, message: { content: 'The output said "Base directory for this skill: /x/skills/frontend-design"' } },
+  ]);
+  assert.deepEqual(result.skills, []);
+});
+
+test('parseTranscript ignores the marker on a non-meta user message', async () => {
+  const result = await parseTempTranscript('skill-marker-nonmeta.jsonl', [
+    { type: 'user', message: { content: 'Base directory for this skill: /x/skills/frontend-design' } },
+  ]);
+  assert.deepEqual(result.skills, []);
+});
+
+test('parseTranscript ignores the marker on a non-user entry', async () => {
+  const result = await parseTempTranscript('skill-marker-assistant.jsonl', [
+    { type: 'assistant', isMeta: true, message: { content: 'Base directory for this skill: /x/skills/writing-plans' } },
+  ]);
+  assert.deepEqual(result.skills, []);
+});
+
+test('parseTranscript dedupes the same skill seen via both the Skill tool and the load marker', async () => {
+  const result = await parseTempTranscript('skill-dedup.jsonl', [
+    { message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'Skill', input: { skill: 'superpowers:brainstorming' } }] } },
+    { type: 'user', isMeta: true, message: { content: 'Base directory for this skill: /x/skills/brainstorming\n# body' } },
+  ]);
+  assert.deepEqual(result.skills, ['brainstorming']);
+});
+
+test('parseTranscript resolves bare skill name from bundled-skills and trailing-slash marker paths', async () => {
+  const result = await parseTempTranscript('skill-bundled.jsonl', [
+    { type: 'user', isMeta: true, message: { content: 'Base directory for this skill: /private/tmp/claude/bundled-skills/2.1.158/abc123/run\n# body' } },
+    { type: 'user', isMeta: true, message: { content: 'Base directory for this skill: /x/skills/writing-plans/\n# body' } },
+  ]);
+  assert.deepEqual(result.skills, ['run', 'writing-plans']);
+});
+
 test('parseTranscript truncates long bash commands in targets', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-'));
   const filePath = path.join(dir, 'bash.jsonl');
@@ -1423,6 +1482,59 @@ test('parseTranscript invalidates transcript cache entries from older cache vers
     assert.equal(result.sessionName, undefined);
     assert.equal(result.tools.length, 1);
     assert.equal(result.lastAssistantResponseAt?.toISOString(), '2024-01-01T00:00:00.000Z');
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('parseTranscript round-trips skills through the transcript cache', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-skills-cache-'));
+  const configDir = path.join(dir, '.claude-test');
+  const transcriptPath = path.join(dir, 'skills-roundtrip.jsonl');
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  await writeFile(transcriptPath, `${JSON.stringify({
+    type: 'user', isMeta: true,
+    message: { content: 'Base directory for this skill: /x/skills/devcontainer\n# body' },
+  })}\n`, 'utf8');
+
+  try {
+    const first = await parseTranscript(transcriptPath);   // computes + writes cache
+    assert.deepEqual(first.skills, ['devcontainer']);
+    const second = await parseTranscript(transcriptPath);  // served from cache
+    assert.deepEqual(second.skills, ['devcontainer']);
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('parseTranscript tolerates a cache entry missing the skills field', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-skills-missing-'));
+  const configDir = path.join(dir, '.claude-test');
+  const transcriptPath = path.join(dir, 'skills-missing.jsonl');
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  // Empty transcript so the result is skills:[] whether the cache hits or is recomputed.
+  await writeFile(transcriptPath, `${JSON.stringify({ type: 'assistant', timestamp: '2024-01-01T00:00:00.000Z', message: { content: [] } })}\n`, 'utf8');
+  fs.utimesSync(transcriptPath, 1710000300, 1710000300);
+
+  try {
+    const stat = fs.statSync(transcriptPath);
+    const cachePath = path.join(configDir, 'plugins', 'claude-hud', 'transcript-cache',
+      `${createHash('sha256').update(path.resolve(transcriptPath)).digest('hex')}.json`);
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    // Cache at the current version but with no `skills` field (Array.isArray guard).
+    await writeFile(cachePath, JSON.stringify({
+      version: 8,
+      transcriptPath: path.resolve(transcriptPath),
+      transcriptState: { mtimeMs: stat.mtimeMs, size: stat.size },
+      data: { tools: [], agents: [], todos: [] },
+    }), 'utf8');
+
+    const result = await parseTranscript(transcriptPath);
+    assert.deepEqual(result.skills, []);
   } finally {
     restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
     await rm(dir, { recursive: true, force: true });

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -12,6 +12,7 @@ import { renderPromptCacheLine } from '../dist/render/lines/prompt-cache.js';
 import { renderToolsLine, shortenToolName } from '../dist/render/tools-line.js';
 import { renderAgentsLine } from '../dist/render/agents-line.js';
 import { renderTodosLine } from '../dist/render/todos-line.js';
+import { renderSkillsLine } from '../dist/render/skills-line.js';
 import { renderUsageLine } from '../dist/render/lines/usage.js';
 import { renderMemoryLine } from '../dist/render/lines/memory.js';
 import { renderIdentityLine } from '../dist/render/lines/identity.js';
@@ -2855,4 +2856,66 @@ test('renderSessionLine renders advisor inline on the same row (compact layout)'
   assert.ok(plain.includes('Advisor: Opus 4.7'), `advisor segment missing: ${plain}`);
   assert.ok(plain.includes('[Opus]'), 'model badge must still render first');
   assert.ok(!plain.includes('\n'), 'compact session line must remain one row');
+});
+
+test('renderSkillsLine returns null when there are no skills', () => {
+  const ctx = baseContext();
+  ctx.transcript.skills = [];
+  assert.equal(renderSkillsLine(ctx), null);
+  // also when the field is absent entirely
+  delete ctx.transcript.skills;
+  assert.equal(renderSkillsLine(ctx), null);
+});
+
+test('renderSkillsLine renders the lightning marker, label, and names', () => {
+  const ctx = baseContext();
+  ctx.transcript.skills = ['brainstorming', 'frontend-design', 'writing-plans'];
+  const line = stripAnsi(renderSkillsLine(ctx));
+  assert.ok(line.includes('⚡'), `expected lightning marker: ${line}`);
+  assert.ok(line.includes('Skills:'), `expected Skills label: ${line}`);
+  assert.ok(line.includes('brainstorming, frontend-design, writing-plans'), `expected names: ${line}`);
+});
+
+test('renderSkillsLine caps at 5 names with a +N more suffix', () => {
+  const ctx = baseContext();
+  ctx.transcript.skills = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+  const line = stripAnsi(renderSkillsLine(ctx));
+  assert.ok(line.includes('a, b, c, d, e'), `expected first 5 names: ${line}`);
+  assert.ok(line.includes('+2 more'), `expected overflow indicator: ${line}`);
+  assert.ok(!line.includes('f') && !line.includes('g'), `should not show overflowed names: ${line}`);
+});
+
+test('renderSkillsLine shows no overflow suffix at exactly 5 names', () => {
+  const ctx = baseContext();
+  ctx.transcript.skills = ['a', 'b', 'c', 'd', 'e'];
+  const line = stripAnsi(renderSkillsLine(ctx));
+  assert.ok(!line.includes('more'), `expected no overflow suffix: ${line}`);
+});
+
+test('renderToolsLine suppresses the Skill tool when showSkills is enabled', () => {
+  const now = new Date();
+  const tools = [
+    { id: '1', name: 'Skill', target: 'brainstorming', status: 'completed', startTime: now, endTime: now },
+    { id: '2', name: 'Read', target: '/x', status: 'completed', startTime: now, endTime: now },
+  ];
+  const ctx = baseContext();
+  ctx.transcript.tools = tools;
+  ctx.config.display.showSkills = true;
+  const line = stripAnsi(renderToolsLine(ctx));
+  assert.ok(line.includes('Read'), `expected Read tool: ${line}`);
+  assert.ok(!line.includes('Skill'), `Skill should be suppressed when showSkills is on: ${line}`);
+});
+
+test('renderToolsLine keeps the Skill tool when showSkills is off', () => {
+  const now = new Date();
+  const tools = [
+    { id: '1', name: 'Skill', target: 'brainstorming', status: 'completed', startTime: now, endTime: now },
+    { id: '2', name: 'Read', target: '/x', status: 'completed', startTime: now, endTime: now },
+  ];
+  const ctx = baseContext();
+  ctx.transcript.tools = tools;
+  ctx.config.display.showSkills = false;
+  const line = stripAnsi(renderToolsLine(ctx));
+  assert.ok(line.includes('Skill'), `Skill should remain when showSkills is off: ${line}`);
+  assert.ok(line.includes('Read'), `expected Read tool: ${line}`);
 });


### PR DESCRIPTION
### Why

I started using the `showSkills` element and ran into two things I wanted to fix:

1. **It only listed skills the _model_ invoked** via the `Skill` tool. Skills I loaded **myself** by typing `/skill-name`, or that got pulled in automatically, never showed up — even though they were active in the session.
2. **With both the tools line and the skills line enabled, a skill showed up twice** — once on the Skills line and again as `✓ Skill` on the tools line.

I wanted the line to reflect *every* skill active in my session, however it loaded, and to show each skill exactly once. That's the motivation for this PR.

I saw **#595** already adds `showSkills`/`showMcp` from `Skill` tool calls (thanks @mvanhorn) — this isn't a replacement (it's skills-only and focused on the two gaps above). Glad to fold it into #595 or close if you'd prefer that approach.

### Demo
<img width="799" height="110" alt="Screenshot 2026-06-07 at 19 47 54" src="https://github.com/user-attachments/assets/cb0da7bc-0965-4f53-a421-15cd21cdf0f3" />

<!-- screenshot -->
_Screenshot: the `⚡ Skills:` line showing skills loaded different ways (model-invoked, user `/skill`, auto) — note the tools line directly above has **no** duplicate `Skill` entry._

### How it works

- **Detection:** alongside the `Skill` tool signal, it reads the `Base directory for this skill:` line the harness writes whenever a folder-backed skill loads. That line appears no matter how the skill was triggered — model, a user-typed `/skill`, auto-load, or sub-agent — so manual/auto loads finally show up. Both signals normalize to the bare skill name and dedupe, so a skill seen twice still lists once.
- **No duplicate display:** when `showSkills` is on, the `Skill` tool is dropped from the tools line, so each skill appears in exactly one place.

### Design notes from #527

- **Reliable source, not reminder-scraping:** the marker is matched only on `isMeta` user messages and is start-anchored (`^`), so it keys off the harness's actual skill-load record — not `<system-reminder>` text or prose.
- **Avoid duplicating existing lines (#527):** the tools-line suppression above.
- **Default-off:** `display.showSkills` defaults `false`; existing configs render unchanged.
- **Tests/fixtures:** transcript detection + anchoring (incl. a quoted-string negative case), two-signal dedup, cache round-trip, render cap/overflow, tools-line suppression, and config.

### Tradeoff

Catching user-invoked skills means reading that injected load marker — there's no structured tool call for them. I aimed for reliable rather than brittle, but it's a different data-source choice than #595's tool-call-only approach. Open to discussion.

Skills-only by design; #595's MCP work is complementary.
