### PR TITLE
feat(usage): render external balance_label alongside stdin rate_limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showResetLabel` | boolean | true | Show the `resets in` prefix before usage countdowns |
 | `display.timeFormat` | `relative` \| `absolute` \| `both` \| `elapsed` \| `elapsedAndAbsolute` | `relative` | How usage-window time is shown: countdown only (`resets in 2h 30m`), wall-clock reset (`resets at 14:30`), both, elapsed window percentage (`53% elapsed`), or elapsed plus wall-clock reset |
 | `display.sevenDayThreshold` | 0-100 | 80 | Show 7-day usage when >= threshold (0 = always) |
-| `display.externalUsagePath` | string | `""` | Optional path to a local usage snapshot file used only when stdin `rate_limits` are missing |
+| `display.externalUsagePath` | string | `""` | Optional path to a local usage snapshot file. When stdin `rate_limits` are present, only `balance_label` is appended; when they are missing, valid usage windows can be used as a fallback |
 | `display.externalUsageWritePath` | string | `""` | Optional absolute `.json` path in an existing directory. When stdin `rate_limits` exists, ClaudeHUD writes a private snapshot for other local tools. Relative paths, non-json files, and missing parent directories are ignored |
 | `display.externalUsageFreshnessMs` | number | `300000` | Maximum allowed age for the external usage snapshot before it is ignored |
 | `display.showTokenBreakdown` | boolean | true | Show token details at high context (85%+) |
@@ -236,7 +236,7 @@ Usage display is **enabled by default** when Claude Code provides subscriber `ra
 
 Set `display.usageValue` to `remaining` to show quota left instead of quota used. Warning colors and 7-day threshold checks still use the underlying used percentage.
 
-ClaudeHUD prefers the official statusline stdin payload. If `rate_limits` are missing, you can opt into a local sidecar fallback by setting `display.externalUsagePath` to a JSON snapshot written by another tool such as a proxy. Stdin still wins whenever both sources exist.
+ClaudeHUD prefers the official statusline stdin payload for rate-limit windows. If `display.externalUsagePath` points to a fresh local sidecar snapshot, ClaudeHUD can append its `balance_label` alongside stdin windows. If stdin `rate_limits` are missing, the same snapshot can provide fallback usage windows.
 
 The fallback snapshot must be fresh enough (`display.externalUsageFreshnessMs`) and include valid `updated_at`, plus a `five_hour` window, `seven_day` window, or `balance_label`. `balance_label` is optional text for prepaid provider balances; it is trimmed, length-limited, and sanitized before display. Invalid JSON, stale files, or invalid timestamps are ignored quietly.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,11 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       usageData = stdinUsage;
       if (!usageData) {
         usageData = deps.getUsageFromExternalSnapshot(config, deps.now());
+      } else if (config.display.externalUsagePath) {
+        const ext = deps.getUsageFromExternalSnapshot(config, deps.now());
+        if (ext?.balanceLabel != null) {
+          usageData = { ...usageData, balanceLabel: ext.balanceLabel };
+        }
       }
     }
 

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -32,9 +32,11 @@ export function renderUsageLine(
   }
 
   const usageLabel = progressLabel("label.usage", colors, alignLabels);
+  const balanceLabel = ctx.usageData.balanceLabel ?? null;
+  const hasWindowData = ctx.usageData.fiveHour !== null || ctx.usageData.sevenDay !== null;
 
-  if (ctx.usageData.balanceLabel) {
-    return `${usageLabel} ${ctx.usageData.balanceLabel}`;
+  if (balanceLabel && !hasWindowData) {
+    return `${usageLabel} ${balanceLabel}`;
   }
 
   const timeFormat = normalizeTimeFormat(display?.timeFormat);
@@ -50,14 +52,14 @@ export function renderUsageLine(
         ? formatResetTime(ctx.usageData.fiveHourResetAt, limitTimeFormat)
         : formatResetTime(ctx.usageData.sevenDayResetAt, limitTimeFormat);
     if (usageCompact) {
-      return critical(`⚠ Limit${resetTime ? ` (${resetTime})` : ""}`, colors);
+      return appendBalance(critical(`⚠ Limit${resetTime ? ` (${resetTime})` : ""}`, colors), balanceLabel);
     }
     const resetSuffix = resetTime
       ? showResetLabel
         ? ` (${t(resetsKey)} ${resetTime})`
         : ` (${resetTime})`
       : "";
-    return `${usageLabel} ${critical(`⚠ ${t("status.limitReached")}${resetSuffix}`, colors)}`;
+    return appendBalance(`${usageLabel} ${critical(`⚠ ${t("status.limitReached")}${resetSuffix}`, colors)}`, balanceLabel);
   }
 
   const threshold = display?.usageThreshold ?? 0;
@@ -66,7 +68,7 @@ export function renderUsageLine(
 
   const effectiveUsage = Math.max(fiveHour ?? 0, sevenDay ?? 0);
   if (effectiveUsage < threshold) {
-    return null;
+    return balanceLabel ? `${usageLabel} ${balanceLabel}` : null;
   }
 
   const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
@@ -80,9 +82,10 @@ export function renderUsageLine(
       : null;
 
     if (fiveHourPart && sevenDayPart) {
-      return `${fiveHourPart} | ${sevenDayPart}`;
+      return appendBalance(`${fiveHourPart} | ${sevenDayPart}`, balanceLabel);
     }
-    return fiveHourPart ?? sevenDayPart ?? null;
+    const compactLine = fiveHourPart ?? sevenDayPart;
+    return compactLine ? appendBalance(compactLine, balanceLabel) : null;
   }
 
   const usageBarEnabled = display?.usageBarEnabled ?? true;
@@ -104,7 +107,7 @@ export function renderUsageLine(
       alignLabels,
       usageValueMode,
     });
-    return `${usageLabel} ${weeklyOnlyPart}`;
+    return appendBalance(`${usageLabel} ${weeklyOnlyPart}`, balanceLabel);
   }
 
   const fiveHourPart = formatUsageWindowPart({
@@ -136,10 +139,14 @@ export function renderUsageLine(
       alignLabels,
       usageValueMode,
     });
-    return `${usageLabel} ${fiveHourPart} | ${sevenDayPart}`;
+    return appendBalance(`${usageLabel} ${fiveHourPart} | ${sevenDayPart}`, balanceLabel);
   }
 
-  return `${usageLabel} ${fiveHourPart}`;
+  return appendBalance(`${usageLabel} ${fiveHourPart}`, balanceLabel);
+}
+
+function appendBalance(line: string, balanceLabel: string | null): string {
+  return balanceLabel ? `${line} | ${balanceLabel}` : line;
 }
 
 function formatCompactWindowPart(

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -264,13 +264,13 @@ export function renderSessionLine(ctx: RenderContext): string {
           }
         }
       }
+    }
 
-      if (ctx.usageData.balanceLabel) {
-        if (!hasWindowData) {
-          parts.push(`${label(t('label.usage'), colors)} ${ctx.usageData.balanceLabel}`);
-        } else {
-          parts.push(ctx.usageData.balanceLabel);
-        }
+    if (ctx.usageData.balanceLabel) {
+      if (!hasWindowData) {
+        parts.push(`${label(t('label.usage'), colors)} ${ctx.usageData.balanceLabel}`);
+      } else {
+        parts.push(ctx.usageData.balanceLabel);
       }
     }
   }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -176,9 +176,8 @@ export function renderSessionLine(ctx: RenderContext): string {
     const showResetLabel = display?.showResetLabel ?? true;
     const usageValueMode = display?.usageValue ?? 'percent';
 
-    if (ctx.usageData.balanceLabel) {
-      parts.push(`${label(t('label.usage'), colors)} ${ctx.usageData.balanceLabel}`);
-    } else if (isLimitReached(ctx.usageData)) {
+    const hasWindowData = ctx.usageData.fiveHour !== null || ctx.usageData.sevenDay !== null;
+    if (isLimitReached(ctx.usageData)) {
       const resetTime = ctx.usageData.fiveHour === 100
         ? formatResetTime(ctx.usageData.fiveHourResetAt, timeFormat)
         : formatResetTime(ctx.usageData.sevenDayResetAt, timeFormat);
@@ -198,7 +197,7 @@ export function renderSessionLine(ctx: RenderContext): string {
       const sevenDay = ctx.usageData.sevenDay;
       const effectiveUsage = Math.max(fiveHour ?? 0, sevenDay ?? 0);
 
-      if (effectiveUsage >= usageThreshold) {
+      if ((hasWindowData || !ctx.usageData.balanceLabel) && effectiveUsage >= usageThreshold) {
         const usageBarEnabled = display?.usageBarEnabled ?? true;
         if (usageCompact) {
           const fiveHourPart = fiveHour !== null
@@ -263,6 +262,14 @@ export function renderSessionLine(ctx: RenderContext): string {
           } else {
             parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
           }
+        }
+      }
+
+      if (ctx.usageData.balanceLabel) {
+        if (!hasWindowData) {
+          parts.push(`${label(t('label.usage'), colors)} ${ctx.usageData.balanceLabel}`);
+        } else {
+          parts.push(ctx.usageData.balanceLabel);
         }
       }
     }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -389,6 +389,48 @@ test("main prefers stdin usage over external usage fallback", async () => {
   });
 });
 
+test("main appends external balance label to stdin usage when snapshot path is configured", async () => {
+  let renderedContext;
+  let externalCalls = 0;
+
+  await main({
+    readStdin: async () => makeStdin({
+      rate_limits: {
+        five_hour: { used_percentage: 21.9, resets_at: 1710000000 },
+        seven_day: { used_percentage: 55.2, resets_at: 1710600000 },
+      },
+    }),
+    parseTranscript: async () => makeTranscript(),
+    countConfigs: async () => makeCounts(),
+    loadConfig: async () => makeConfig({
+      display: { externalUsagePath: "/tmp/usage.json" },
+    }),
+    getGitStatus: async () => null,
+    getUsageFromExternalSnapshot: () => {
+      externalCalls += 1;
+      return {
+        fiveHour: 99,
+        sevenDay: 99,
+        fiveHourResetAt: null,
+        sevenDayResetAt: null,
+        balanceLabel: "$12.34 / $20.00",
+      };
+    },
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.equal(externalCalls, 1);
+  assert.deepEqual(renderedContext?.usageData, {
+    fiveHour: 22,
+    sevenDay: 55,
+    fiveHourResetAt: new Date(1710000000 * 1000),
+    sevenDayResetAt: new Date(1710600000 * 1000),
+    balanceLabel: "$12.34 / $20.00",
+  });
+});
+
 test("main skips all usage loading when usage display is disabled", async () => {
   let renderedContext;
   let externalCalls = 0;

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1510,6 +1510,54 @@ test('renderSessionLine displays balance label alongside rate-limit windows', ()
   assert.ok(line.includes('$1,256 / $1,800'), `should show balance label alongside windows: ${line}`);
 });
 
+test('renderSessionLine displays balance label alongside limit reached warnings', () => {
+  const ctx = baseContext();
+  ctx.usageData = {
+    planName: 'Max',
+    fiveHour: 100,
+    sevenDay: null,
+    fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+    sevenDayResetAt: null,
+    balanceLabel: '$1,256 / $1,800',
+  };
+
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('Limit reached'), `should show limit warning: ${line}`);
+  assert.ok(line.includes('$1,256 / $1,800'), `should show balance label alongside limit warning: ${line}`);
+});
+
+test('renderUsageLine displays balance label alongside rate-limit windows', () => {
+  const ctx = baseContext();
+  ctx.usageData = {
+    planName: 'Max',
+    fiveHour: 25,
+    sevenDay: null,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    balanceLabel: '$1,256 / $1,800',
+  };
+
+  const line = stripAnsi(renderUsageLine(ctx) ?? '');
+  assert.ok(line.includes('5h'), `should show 5h window alongside balance: ${line}`);
+  assert.ok(line.includes('$1,256 / $1,800'), `should show balance label alongside windows: ${line}`);
+});
+
+test('renderUsageLine displays balance label alongside limit reached warnings', () => {
+  const ctx = baseContext();
+  ctx.usageData = {
+    planName: 'Max',
+    fiveHour: 100,
+    sevenDay: null,
+    fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+    sevenDayResetAt: null,
+    balanceLabel: '$1,256 / $1,800',
+  };
+
+  const line = stripAnsi(renderUsageLine(ctx) ?? '');
+  assert.ok(line.includes('Limit reached'), `should show limit warning: ${line}`);
+  assert.ok(line.includes('$1,256 / $1,800'), `should show balance label alongside limit warning: ${line}`);
+});
+
 test('renderSessionLine supports remaining-based usage display', () => {
   const ctx = baseContext();
   ctx.config.display.usageValue = 'remaining';

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1494,6 +1494,21 @@ test('renderSessionLine displays external balance labels', () => {
   assert.ok(line.includes('Usage ¥6.35'), `should show balance label in compact layout: ${line}`);
   assert.ok(!line.includes('5h'), `should bypass percentage window rendering: ${line}`);
 });
+test('renderSessionLine displays balance label alongside rate-limit windows', () => {
+  const ctx = baseContext();
+  ctx.usageData = {
+    planName: 'Max',
+    fiveHour: 25,
+    sevenDay: null,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    balanceLabel: '$1,256 / $1,800',
+  };
+
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('5h'), `should show 5h window alongside balance: ${line}`);
+  assert.ok(line.includes('$1,256 / $1,800'), `should show balance label alongside windows: ${line}`);
+});
 
 test('renderSessionLine supports remaining-based usage display', () => {
   const ctx = baseContext();


### PR DESCRIPTION
## Summary

`balance_label` from an external snapshot (`externalUsagePath`) is currently shown **only when stdin `rate_limits` are absent** — the two sources are mutually exclusive. Rate-limit windows (5h/7d) and a prepaid/metered dollar balance are complementary data; both should be visible when available.

## Problem to Solve

The two usage sources are exclusive at two layers:

**Merge layer** (`src/index.ts`) — stdin wins entirely; external snapshot never read when `rate_limits` present:
```js
usageData = getUsageFromStdin(stdin);
if (!usageData) {
  usageData = getUsageFromExternalSnapshot(config, now);
}
```

**Render layer** (`src/render/session-line.ts`) — `balance_label` suppresses windows entirely:
```js
if (ctx.usageData.balanceLabel) {
  parts.push(`Usage ${ctx.usageData.balanceLabel}`);
} else if (isLimitReached) { ... }
else { /* 5h / 7d windows */ }
```

Result: accounts that receive `rate_limits` on stdin can never see `balance_label`; accounts without `rate_limits` see only the balance.

## Proposed Solution

Keep stdin `rate_limits` as authoritative for 5h/7d windows. After resolving window data from stdin, also read the external snapshot for `balance_label` (only when `externalUsagePath` is configured) and render it as an additional segment:

**Before:** `Usage ████░░░░░░ 42% (5h)`
**After:** `Usage ████░░░░░░ 42% (5h)  $1,256 / $1,800`

Standalone balance (no window data) and balance-only accounts preserve existing behaviour exactly.

## Alternatives Considered

- **Re-adding in-plugin credential/OAuth fetching** — ruled out; the CHANGELOG removal was intentional and this PR does not revisit it.
- **`display.showBalance` opt-in flag** — possible, but `externalUsagePath` is already an explicit opt-in (empty by default), so additive-by-default seems consistent with user intent.

## Additional Context

- Zero cost for users without `externalUsagePath` configured — `getUsageFromExternalSnapshot` is not called at all when stdin wins and no path is set
- `UsageData` already carries `balanceLabel?: string | null` — no type changes needed
- 654 tests passing; new test added for the combined windows + balance case
- Relevant files: `src/index.ts`, `src/render/session-line.ts`, `tests/render.test.js`

Fixes #598
