### PR TITLE
release: 0.1.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hud",
   "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,27 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-09
+
+### Added
+- Add default-off Skills and MCP activity lines, with sanitized active names and Skill-tool suppression when the Skills line is enabled (#527, #595).
+- Add optional advisor model display with sanitized transcript-derived and override labels (#573).
+- Add `display.autoCompactWindow` support for context denominator calculations, including token-display denominator handling (#589).
+
 ### Fixed
+- Render external `balance_label` values alongside stdin `rate_limits` instead of treating them as mutually exclusive (#598, #599).
 - Preserve inherited terminal width in setup-generated statusline commands before probing `/dev/tty`, fixing narrow-pane wrapping/flicker in terminals without a controlling TTY (#581).
 - Use a lightweight Windows Node launcher for PowerShell/cmd setup instead of a PowerShell wrapper on every statusline refresh, reducing Windows render-time overhead while preserving update discovery (#555).
 - Collapse whitespace in multiline Bash tool targets before truncation so the tools line stays single-line (#594).
+- Harden advisor, Skills, and MCP labels against control characters, terminal escapes, bidi controls, and oversized activity names (#573, #595).
+- Validate `autoCompactWindow` as an integer before using it in context calculations (#589).
+
+### Changed
+- Clarify in release docs that `.claude-plugin/plugin.json` is the Claude Code update/cache version source (#591).
+
+### Dependencies
+- Bump `@types/node` from 25.9.1 to 25.9.2 (#593).
+- Refresh the lockfile to clear the transitive `brace-expansion` audit advisory.
 
 ## [0.1.0] - 2026-06-03
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hud",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hud",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hud",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Real-time statusline HUD for Claude Code",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump `.claude-plugin/plugin.json`, `package.json`, and `package-lock.json` to 0.1.1
- add the 2026-06-09 changelog section for changes merged since v0.1.0

## Verification
- npm ci
- npm run build
- npm test (667 pass, 1 skipped)
- npm run test:coverage (667 pass, 1 skipped; 93.66% statements)
- git diff --check
- subagent release review: version metadata and changelog safe; no hidden dist concern