### PR TITLE
feat: add fallback speed estimation via transcript file growth

### DIFF
--- a/src/speed-tracker.ts
+++ b/src/speed-tracker.ts
@@ -77,6 +77,36 @@ function writeCache(homeDir: string, transcriptPath: string, cache: SpeedCache):
   }
 }
 
+function readFileSizeCache(cachePath: string): FileSizeCache | null {
+  try {
+    if (!fs.existsSync(cachePath)) return null;
+    const parsed = JSON.parse(fs.readFileSync(cachePath, 'utf8')) as FileSizeCache;
+    if (
+      typeof parsed.fileSize !== 'number'
+      || !Number.isFinite(parsed.fileSize)
+      || typeof parsed.timestamp !== 'number'
+      || !Number.isFinite(parsed.timestamp)
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeFileSizeCache(cachePath: string, cache: FileSizeCache): void {
+  try {
+    const cacheDir = path.dirname(cachePath);
+    if (!fs.existsSync(cacheDir)) {
+      fs.mkdirSync(cacheDir, { recursive: true });
+    }
+    fs.writeFileSync(cachePath, JSON.stringify(cache), 'utf8');
+  } catch {
+    // Ignore cache write failures
+  }
+}
+
 // Remove the pre-0.x global cache file once, if present. It has no owner
 // session so leaving it around only wastes disk.
 function removeLegacyCache(homeDir: string): void {
@@ -105,21 +135,16 @@ function getTranscriptSpeed(
   now: number,
 ): number | null {
   try {
-    if (!fs.existsSync(transcriptPath)) return null;
-    const fileSize = fs.statSync(transcriptPath).size;
+    const stat = fs.statSync(transcriptPath);
+    if (!stat.isFile()) return null;
 
-    const cachePath = getCachePath(homeDir, transcriptPath) + '.fs';
-    let prev: FileSizeCache | null = null;
-    try {
-      if (fs.existsSync(cachePath)) {
-        prev = JSON.parse(fs.readFileSync(cachePath, 'utf8')) as FileSizeCache;
-      }
-    } catch {
-      /* ignore corrupt cache */
-    }
+    const canonicalTranscriptPath = fs.realpathSync(transcriptPath);
+    const fileSize = stat.size;
+    const cachePath = getCachePath(homeDir, canonicalTranscriptPath) + '.fs';
+    const prev = readFileSizeCache(cachePath);
 
-    if (!prev || typeof prev.fileSize !== 'number') {
-      fs.writeFileSync(cachePath, JSON.stringify({ fileSize, timestamp: now }), 'utf8');
+    if (!prev) {
+      writeFileSizeCache(cachePath, { fileSize, timestamp: now });
       return null;
     }
 
@@ -127,12 +152,14 @@ function getTranscriptSpeed(
     const deltaMs = now - prev.timestamp;
 
     if (deltaMs > SPEED_WINDOW_MS || deltaMs < MIN_DELTA_MS || deltaBytes <= 0) {
-      fs.writeFileSync(cachePath, JSON.stringify({ fileSize, timestamp: now }), 'utf8');
+      if (deltaMs >= MIN_DELTA_MS) {
+        writeFileSizeCache(cachePath, { fileSize, timestamp: now });
+      }
       return null;
     }
 
     const estimatedTokens = deltaBytes / BYTES_PER_TOKEN;
-    fs.writeFileSync(cachePath, JSON.stringify({ fileSize, timestamp: now }), 'utf8');
+    writeFileSizeCache(cachePath, { fileSize, timestamp: now });
     return estimatedTokens / (deltaMs / 1000);
   } catch {
     return null;

--- a/src/speed-tracker.ts
+++ b/src/speed-tracker.ts
@@ -14,9 +14,18 @@ const MIN_DELTA_MS = 500;
 
 const CACHE_DIRNAME = 'speed-cache';
 const LEGACY_CACHE_FILENAME = '.speed-cache.json';
+// Fallback: approximate bytes-per-token ratio for transcript file growth estimation.
+// Claude's JSONL transcript is mostly ASCII with some overhead; ~4 bytes/token is a
+// reasonable ballpark that avoids wild over/under-estimates.
+const BYTES_PER_TOKEN = 4;
 
 interface SpeedCache {
   outputTokens: number;
+  timestamp: number;
+}
+
+interface FileSizeCache {
+  fileSize: number;
   timestamp: number;
 }
 
@@ -81,12 +90,56 @@ function removeLegacyCache(homeDir: string): void {
   }
 }
 
-export function getOutputSpeed(stdin: StdinData, overrides: Partial<SpeedTrackerDeps> = {}): number | null {
-  const outputTokens = stdin.context_window?.current_usage?.output_tokens;
-  if (typeof outputTokens !== 'number' || !Number.isFinite(outputTokens)) {
+/**
+ * Fallback speed estimation when output_tokens is unavailable.
+ *
+ * Measures the transcript file's byte-size growth between successive
+ * render calls and converts the delta to an approximate token/s rate
+ * using the BYTES_PER_TOKEN heuristic. This allows the HUD to show a
+ * speed reading even when the model provider (e.g. a non-standard
+ * proxy) does not populate `context_window.current_usage.output_tokens`.
+ */
+function getTranscriptSpeed(
+  transcriptPath: string,
+  homeDir: string,
+  now: number,
+): number | null {
+  try {
+    if (!fs.existsSync(transcriptPath)) return null;
+    const fileSize = fs.statSync(transcriptPath).size;
+
+    const cachePath = getCachePath(homeDir, transcriptPath) + '.fs';
+    let prev: FileSizeCache | null = null;
+    try {
+      if (fs.existsSync(cachePath)) {
+        prev = JSON.parse(fs.readFileSync(cachePath, 'utf8')) as FileSizeCache;
+      }
+    } catch {
+      /* ignore corrupt cache */
+    }
+
+    if (!prev || typeof prev.fileSize !== 'number') {
+      fs.writeFileSync(cachePath, JSON.stringify({ fileSize, timestamp: now }), 'utf8');
+      return null;
+    }
+
+    const deltaBytes = fileSize - prev.fileSize;
+    const deltaMs = now - prev.timestamp;
+
+    if (deltaMs > SPEED_WINDOW_MS || deltaMs < MIN_DELTA_MS || deltaBytes <= 0) {
+      fs.writeFileSync(cachePath, JSON.stringify({ fileSize, timestamp: now }), 'utf8');
+      return null;
+    }
+
+    const estimatedTokens = deltaBytes / BYTES_PER_TOKEN;
+    fs.writeFileSync(cachePath, JSON.stringify({ fileSize, timestamp: now }), 'utf8');
+    return estimatedTokens / (deltaMs / 1000);
+  } catch {
     return null;
   }
+}
 
+export function getOutputSpeed(stdin: StdinData, overrides: Partial<SpeedTrackerDeps> = {}): number | null {
   const transcriptPath = stdin.transcript_path?.trim();
   if (!transcriptPath) {
     // Without a stable session key we cannot safely isolate cache entries
@@ -100,38 +153,44 @@ export function getOutputSpeed(stdin: StdinData, overrides: Partial<SpeedTracker
 
   removeLegacyCache(homeDir);
 
-  const previous = readCache(homeDir, transcriptPath);
+  // Primary: use output_tokens when the provider supplies it.
+  const outputTokens = stdin.context_window?.current_usage?.output_tokens;
+  if (typeof outputTokens === 'number' && Number.isFinite(outputTokens)) {
+    const previous = readCache(homeDir, transcriptPath);
 
-  if (!previous) {
+    if (!previous) {
+      writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
+      return null;
+    }
+
+    if (outputTokens < previous.outputTokens) {
+      writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
+      return null;
+    }
+
+    const deltaTokens = outputTokens - previous.outputTokens;
+    const deltaMs = now - previous.timestamp;
+
+    if (deltaMs > SPEED_WINDOW_MS) {
+      writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
+      return null;
+    }
+
+    if (deltaTokens <= 0) {
+      writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
+      return null;
+    }
+
+    if (deltaMs < MIN_DELTA_MS) {
+      return null;
+    }
+
+    const speed = deltaTokens / (deltaMs / 1000);
     writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
-    return null;
+    return speed;
   }
 
-  if (outputTokens < previous.outputTokens) {
-    writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
-    return null;
-  }
-
-  let speed: number | null = null;
-  const deltaTokens = outputTokens - previous.outputTokens;
-  const deltaMs = now - previous.timestamp;
-
-  if (deltaMs > SPEED_WINDOW_MS) {
-    writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
-    return null;
-  }
-
-  if (deltaTokens <= 0) {
-    writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
-    return null;
-  }
-
-  if (deltaMs < MIN_DELTA_MS) {
-    return null;
-  }
-
-  speed = deltaTokens / (deltaMs / 1000);
-
-  writeCache(homeDir, transcriptPath, { outputTokens, timestamp: now });
-  return speed;
+  // Fallback: estimate from transcript file byte-size growth when the
+  // provider does not expose output_tokens (e.g. non-standard proxies).
+  return getTranscriptSpeed(transcriptPath, homeDir, now);
 }

--- a/tests/speed-tracker.test.js
+++ b/tests/speed-tracker.test.js
@@ -39,6 +39,143 @@ test('getOutputSpeed returns null when output tokens are missing', () => {
   assert.equal(speed, null);
 });
 
+test('getOutputSpeed estimates speed from transcript growth when output tokens are missing', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = await createTranscript(tempHome);
+
+  try {
+    const base = { homeDir: () => tempHome };
+    const first = getOutputSpeed(
+      { transcript_path: transcriptPath, context_window: { current_usage: { input_tokens: 10 } } },
+      { ...base, now: () => 1000 }
+    );
+    assert.equal(first, null);
+
+    await writeFile(transcriptPath, 'x'.repeat(40), 'utf8');
+    const second = getOutputSpeed(
+      { transcript_path: transcriptPath, context_window: { current_usage: { input_tokens: 10 } } },
+      { ...base, now: () => 1500 }
+    );
+    assert.ok(second !== null);
+    assert.ok(Math.abs(second - 20) < 0.01);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('getOutputSpeed accumulates short transcript-growth windows until the fallback sample matures', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = await createTranscript(tempHome);
+
+  try {
+    const base = { homeDir: () => tempHome };
+    const stdin = { transcript_path: transcriptPath, context_window: { current_usage: { input_tokens: 10 } } };
+
+    getOutputSpeed(stdin, { ...base, now: () => 1000 });
+
+    await writeFile(transcriptPath, 'x'.repeat(40), 'utf8');
+    assert.equal(getOutputSpeed(stdin, { ...base, now: () => 1200 }), null);
+
+    await writeFile(transcriptPath, 'x'.repeat(80), 'utf8');
+    assert.equal(getOutputSpeed(stdin, { ...base, now: () => 1400 }), null);
+
+    await writeFile(transcriptPath, 'x'.repeat(120), 'utf8');
+    const matured = getOutputSpeed(stdin, { ...base, now: () => 1600 });
+    assert.ok(matured !== null);
+    assert.ok(Math.abs(matured - 50) < 0.01);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('getOutputSpeed ignores fallback samples without transcript growth', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = await createTranscript(tempHome);
+
+  try {
+    const base = { homeDir: () => tempHome };
+    const stdin = { transcript_path: transcriptPath, context_window: { current_usage: { input_tokens: 10 } } };
+
+    getOutputSpeed(stdin, { ...base, now: () => 1000 });
+    const idle = getOutputSpeed(stdin, { ...base, now: () => 1500 });
+    assert.equal(idle, null);
+
+    await writeFile(transcriptPath, 'x'.repeat(40), 'utf8');
+    const afterIdle = getOutputSpeed(stdin, { ...base, now: () => 2000 });
+    assert.ok(afterIdle !== null);
+    assert.ok(Math.abs(afterIdle - 20) < 0.01);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('getOutputSpeed ignores stale fallback windows', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = await createTranscript(tempHome);
+
+  try {
+    const base = { homeDir: () => tempHome };
+    const stdin = { transcript_path: transcriptPath, context_window: { current_usage: { input_tokens: 10 } } };
+
+    getOutputSpeed(stdin, { ...base, now: () => 1000 });
+
+    await writeFile(transcriptPath, 'x'.repeat(40), 'utf8');
+    const stale = getOutputSpeed(stdin, { ...base, now: () => 8000 });
+    assert.equal(stale, null);
+
+    await writeFile(transcriptPath, 'x'.repeat(80), 'utf8');
+    const fresh = getOutputSpeed(stdin, { ...base, now: () => 8500 });
+    assert.ok(fresh !== null);
+    assert.ok(Math.abs(fresh - 20) < 0.01);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('getOutputSpeed creates fallback cache under CLAUDE_CONFIG_DIR by default', async () => {
+  const tempHome = await createTempHome();
+  const customConfigDir = path.join(tempHome, '.claude-alt');
+  const originalHome = process.env.HOME;
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.HOME = tempHome;
+  process.env.CLAUDE_CONFIG_DIR = customConfigDir;
+
+  try {
+    const transcriptPath = await createTranscript(tempHome);
+    const speed = getOutputSpeed(
+      { transcript_path: transcriptPath, context_window: { current_usage: { input_tokens: 10 } } },
+      { now: () => 1000 }
+    );
+    assert.equal(speed, null);
+
+    const customCacheDir = path.join(customConfigDir, 'plugins', 'claude-hud', 'speed-cache');
+    const defaultCacheDir = path.join(tempHome, '.claude', 'plugins', 'claude-hud', 'speed-cache');
+    assert.equal(existsSync(customCacheDir), true);
+    assert.equal(existsSync(defaultCacheDir), false);
+  } finally {
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('getOutputSpeed ignores fallback tracking for non-file transcript paths', async () => {
+  const tempHome = await createTempHome();
+
+  try {
+    const speed = getOutputSpeed(
+      { transcript_path: tempHome, context_window: { current_usage: { input_tokens: 10 } } },
+      { homeDir: () => tempHome, now: () => 1000 }
+    );
+    assert.equal(speed, null);
+
+    const cacheDir = path.join(tempHome, '.claude', 'plugins', 'claude-hud', 'speed-cache');
+    assert.equal(existsSync(cacheDir), false);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
 test('getOutputSpeed returns null when transcript_path is missing', async () => {
   const tempHome = await createTempHome();
 


### PR DESCRIPTION
## Problem

When the model provider does not return `output_tokens` in `context_window.current_usage` (e.g. non-standard API proxies), the HUD shows no token/s speed reading at all — `getOutputSpeed()` returns `null` early and the speed label never appears.

## Solution

Add a **fallback speed estimation** based on transcript file byte-size growth:

- When `output_tokens` is available → original logic (unchanged)
- When `output_tokens` is unavailable → estimate speed from transcript file growth using a ~4 bytes/token heuristic

### Details

- New `getTranscriptSpeed()` function uses the same session-scoped cache path (with `.fs` suffix) to track file size between renders
- Reuses `SPEED_WINDOW_MS` (2s) and `MIN_DELTA_MS` (500ms) thresholds from the primary path
- `FileSizeCache` interface and `BYTES_PER_TOKEN` constant are the only new exports at module level
- Zero impact on the primary path — all original code paths are preserved exactly

## Testing

- `showSpeed: true` with a provider that returns `output_tokens` → works as before
- With a provider that omits `output_tokens` → speed is now estimated from transcript file growth