### PR TITLE
feat: show session compaction count behind opt-in showCompactions setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.advisorOverride` | string | `""` | Optional manual override for the displayed advisor label. When non-empty, replaces transcript-driven detection. Also sanitised and capped at 64 chars |
 | `display.showSessionStartDate` | boolean | false | Show the transcript session start timestamp |
 | `display.showLastResponseAt` | boolean | false | Show how long ago the last assistant response was written |
+| `display.showCompactions` | boolean | false | Show how many context compactions (manual `/compact` or auto) have occurred this session, counted from transcript `compact_boundary` entries, e.g. `Compactions: 2`. Hidden until the first compaction |
 | `display.showClaudeCodeVersion` | boolean | false | Show the installed Claude Code version, e.g. `CC v2.1.81` |
 | `display.showMemoryUsage` | boolean | false | Show an approximate system RAM usage line in expanded layout |
 | `display.showPromptCache` | boolean | false | Show a prompt cache countdown based on the last assistant response timestamp in the transcript |

--- a/README.zh.md
+++ b/README.zh.md
@@ -196,6 +196,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `display.advisorOverride` | string | `""` | 手动覆盖顾问显示文本。非空时优先于 transcript 检测，同样会做过滤和截断 |
 | `display.showSessionStartDate` | boolean | false | 显示 transcript 会话开始时间戳 |
 | `display.showLastResponseAt` | boolean | false | 显示最后一次 assistant 响应写入的时间距现在多久 |
+| `display.showCompactions` | boolean | false | 显示本会话已发生的上下文压缩次数（手动 `/compact` 或自动压缩），从 transcript 的 `compact_boundary` 记录计数，例如 `压缩次数: 2`。第一次压缩前不显示 |
 | `display.showClaudeCodeVersion` | boolean | false | 显示已安装的 Claude Code 版本，如 `CC v2.1.81` |
 | `display.showMemoryUsage` | boolean | false | 在展开布局中显示近似系统 RAM 使用行 |
 | `display.showPromptCache` | boolean | false | 根据 transcript 中最后一次 assistant 响应时间显示 prompt cache 倒计时 |

--- a/src/config.ts
+++ b/src/config.ts
@@ -139,6 +139,9 @@ export interface HudConfig {
     showOutputStyle: boolean;
     showSessionStartDate: boolean;
     showLastResponseAt: boolean;
+    // Show how many context compactions (manual /compact or auto) have
+    // occurred this session, counted from transcript compact_boundary entries.
+    showCompactions: boolean;
     mergeGroups: HudElement[][];
     autocompactBuffer: AutocompactBufferMode;
     contextWarningThreshold: number;
@@ -218,6 +221,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showOutputStyle: false,
     showSessionStartDate: false,
     showLastResponseAt: false,
+    showCompactions: false,
     mergeGroups: DEFAULT_MERGE_GROUPS.map(group => [...group]),
     autocompactBuffer: 'enabled',
     contextWarningThreshold: 70,
@@ -641,6 +645,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showLastResponseAt: typeof migrated.display?.showLastResponseAt === 'boolean'
       ? migrated.display.showLastResponseAt
       : DEFAULT_CONFIG.display.showLastResponseAt,
+    showCompactions: typeof migrated.display?.showCompactions === 'boolean'
+      ? migrated.display.showCompactions
+      : DEFAULT_CONFIG.display.showCompactions,
     mergeGroups: validateMergeGroups(migrated.display?.mergeGroups),
     autocompactBuffer: validateAutocompactBuffer(migrated.display?.autocompactBuffer)
       ? migrated.display.autocompactBuffer

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -15,6 +15,7 @@ export const en: Messages = {
   "label.sessionStarted": "Started",
   "label.lastReply": "Last reply",
   "label.advisor": "Advisor",
+  "label.compactions": "Compactions",
 
   // Status
   "status.limitReached": "Limit reached",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -13,6 +13,7 @@ export type MessageKey =
   | "label.sessionStarted"
   | "label.lastReply"
   | "label.advisor"
+  | "label.compactions"
   // Status
   | "status.limitReached"
   | "status.allTodosComplete"

--- a/src/i18n/zh-Hans.ts
+++ b/src/i18n/zh-Hans.ts
@@ -15,6 +15,7 @@ export const zhHans: Messages = {
   "label.sessionStarted": "开始",
   "label.lastReply": "上次回复",
   "label.advisor": "顾问",
+  "label.compactions": "压缩次数",
 
   // Status
   "status.limitReached": "已达上限",

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -16,6 +16,7 @@ import {
   renderUsageLine,
   renderMemoryLine,
   renderSessionTokensLine,
+  renderCompactionsLine,
   renderSessionTimeLine,
 } from './lines/index.js';
 import { dim, RESET } from './colors.js';
@@ -543,6 +544,12 @@ export function render(ctx: RenderContext): void {
       if (sessionTokensLine) {
         lines.push(sessionTokensLine);
       }
+    }
+
+    // Compaction count (opt-in, hidden until the first compaction)
+    const compactionsLine = renderCompactionsLine(ctx);
+    if (compactionsLine) {
+      lines.push(compactionsLine);
     }
 
     // Advisor is rendered inline on the project line; see renderProjectLine.

--- a/src/render/lines/compactions.ts
+++ b/src/render/lines/compactions.ts
@@ -1,0 +1,18 @@
+import type { RenderContext } from '../../types.js';
+import { label } from '../colors.js';
+import { t } from '../../i18n/index.js';
+
+export function renderCompactionsLine(ctx: RenderContext): string | null {
+  const display = ctx.config?.display;
+  if (display?.showCompactions !== true) {
+    return null;
+  }
+
+  const compactions = ctx.transcript.compactionCount ?? 0;
+  if (compactions === 0) {
+    return null;
+  }
+
+  const colors = ctx.config?.colors;
+  return label(`${t('label.compactions')}: ${compactions}`, colors);
+}

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -6,5 +6,6 @@ export { renderPromptCacheLine, formatPromptCacheCountdown } from './prompt-cach
 export { renderUsageLine } from './usage.js';
 export { renderMemoryLine } from './memory.js';
 export { renderSessionTokensLine } from './session-tokens.js';
+export { renderCompactionsLine } from './compactions.js';
 export { renderSessionTimeLine } from './session-time.js';
 export { renderAdvisorLine, prettifyAdvisorId } from './advisor.js';

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -284,6 +284,15 @@ export function renderSessionLine(ctx: RenderContext): string {
     }
   }
 
+  // Compaction count from transcript compact_boundary entries (opt-in,
+  // hidden until the first compaction)
+  if (display?.showCompactions) {
+    const compactions = ctx.transcript.compactionCount ?? 0;
+    if (compactions > 0) {
+      parts.push(label(`${t('label.compactions')}: ${compactions}`, colors));
+    }
+  }
+
   // Advisor model (when `/advisor` is configured for the session)
   if (display?.showAdvisor) {
     const advisorLine = renderAdvisorLine(ctx);

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -70,6 +70,7 @@ interface SerializedTranscriptData {
   sessionTokens?: SessionTokenUsage;
   lastCompactBoundaryAt?: string;
   lastCompactPostTokens?: number;
+  compactionCount?: number;
   advisorModel?: string;
 }
 
@@ -80,7 +81,7 @@ interface TranscriptCacheFile {
   data: SerializedTranscriptData;
 }
 
-const TRANSCRIPT_CACHE_VERSION = 8;
+const TRANSCRIPT_CACHE_VERSION = 9;
 const MCP_TOOL_NAME_PATTERN = /^mcp__(.+?)__(.+)$/;
 const ACTIVITY_NAME_MAX_LEN = 64;
 const DISPLAY_CONTROL_PATTERN = new RegExp(
@@ -213,6 +214,7 @@ function serializeTranscriptData(data: TranscriptData): SerializedTranscriptData
     sessionTokens: data.sessionTokens,
     lastCompactBoundaryAt: data.lastCompactBoundaryAt?.toISOString(),
     lastCompactPostTokens: data.lastCompactPostTokens,
+    compactionCount: data.compactionCount,
     advisorModel: data.advisorModel,
   };
 }
@@ -238,6 +240,9 @@ function deserializeTranscriptData(data: SerializedTranscriptData): TranscriptDa
     sessionTokens: normalizeSessionTokens(data.sessionTokens),
     lastCompactBoundaryAt: data.lastCompactBoundaryAt ? new Date(data.lastCompactBoundaryAt) : undefined,
     lastCompactPostTokens: typeof data.lastCompactPostTokens === 'number' ? data.lastCompactPostTokens : undefined,
+    compactionCount: typeof data.compactionCount === 'number' && Number.isFinite(data.compactionCount) && data.compactionCount >= 0
+      ? Math.trunc(data.compactionCount)
+      : undefined,
     advisorModel: typeof data.advisorModel === 'string' && data.advisorModel.length > 0
       ? data.advisorModel.slice(0, ADVISOR_MODEL_MAX_LEN)
       : undefined,
@@ -322,6 +327,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   let latestAdvisorModel: string | undefined;
   let lastCompactBoundaryAt: Date | undefined;
   let lastCompactPostTokens: number | undefined;
+  let compactionCount = 0;
   const sessionTokens: SessionTokenUsage = {
     inputTokens: 0,
     outputTokens: 0,
@@ -388,6 +394,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
         if (entry.type === 'system' && entry.subtype === 'compact_boundary') {
           const ts = entry.timestamp ? new Date(entry.timestamp) : null;
           if (ts && !Number.isNaN(ts.getTime())) {
+            compactionCount += 1;
             if (!lastCompactBoundaryAt || ts.getTime() > lastCompactBoundaryAt.getTime()) {
               lastCompactBoundaryAt = ts;
               const post = entry.compactMetadata?.postTokens;
@@ -446,6 +453,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   result.sessionTokens = sessionTokens;
   result.lastCompactBoundaryAt = lastCompactBoundaryAt;
   result.lastCompactPostTokens = lastCompactPostTokens;
+  result.compactionCount = compactionCount;
   result.advisorModel = latestAdvisorModel;
   if (parsedCleanly) {
     writeTranscriptCache(canonicalTranscriptPath, transcriptState, result);

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,6 +129,9 @@ export interface TranscriptData {
   sessionTokens?: SessionTokenUsage;
   lastCompactBoundaryAt?: Date;
   lastCompactPostTokens?: number;
+  // Number of compact_boundary entries (manual /compact or auto compaction)
+  // with a valid timestamp seen in the transcript.
+  compactionCount?: number;
   // Advisor model ID for the current session, captured from the top-level
   // `advisorModel` field that Claude Code stamps onto every assistant record
   // after `/advisor` is set (e.g. "claude-opus-4-7"). undefined when /advisor

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -834,6 +834,22 @@ test('mergeConfig defaults showAdvisor to false', () => {
   assert.equal(DEFAULT_CONFIG.display.showAdvisor, false);
 });
 
+test('mergeConfig defaults showCompactions to false', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.showCompactions, false);
+  assert.equal(DEFAULT_CONFIG.display.showCompactions, false);
+});
+
+test('mergeConfig preserves explicit showCompactions=true', () => {
+  const config = mergeConfig({ display: { showCompactions: true } });
+  assert.equal(config.display.showCompactions, true);
+});
+
+test('mergeConfig rejects non-boolean showCompactions', () => {
+  const config = mergeConfig({ display: { showCompactions: 'yes' } });
+  assert.equal(config.display.showCompactions, false);
+});
+
 test('mergeConfig preserves explicit showAdvisor=true', () => {
   const config = mergeConfig({ display: { showAdvisor: true } });
   assert.equal(config.display.showAdvisor, true);

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -646,6 +646,7 @@ test('parseTranscript records the most recent compact_boundary and postTokens', 
     const result = await parseTranscript(filePath);
     assert.equal(result.lastCompactBoundaryAt?.toISOString(), '2024-01-01T00:10:00.000Z');
     assert.equal(result.lastCompactPostTokens, 12345);
+    assert.equal(result.compactionCount, 2);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -675,6 +676,7 @@ test('parseTranscript ignores compact_boundary entries without a valid timestamp
     const result = await parseTranscript(filePath);
     assert.equal(result.lastCompactBoundaryAt, undefined);
     assert.equal(result.lastCompactPostTokens, undefined);
+    assert.equal(result.compactionCount, 0);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -1330,6 +1332,11 @@ test('parseTranscript reuses cached data when transcript state is unchanged', as
   const initialLine = `${JSON.stringify({
     timestamp: '2024-01-01T00:00:00.000Z',
     message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'Read', input: { path: '/tmp/original.txt' } }] },
+  })}\n${JSON.stringify({
+    type: 'system',
+    subtype: 'compact_boundary',
+    timestamp: '2024-01-01T00:05:00.000Z',
+    compactMetadata: { trigger: 'auto', preTokens: 170574, postTokens: 7679 },
   })}\n`;
 
   process.env.CLAUDE_CONFIG_DIR = configDir;
@@ -1340,6 +1347,7 @@ test('parseTranscript reuses cached data when transcript state is unchanged', as
     const first = await parseTranscript(transcriptPath);
     assert.equal(first.tools.length, 1);
     assert.equal(first.tools[0].target, '/tmp/original.txt');
+    assert.equal(first.compactionCount, 1);
 
     const stat = fs.statSync(transcriptPath);
     const corrupted = '#'.repeat(stat.size);
@@ -1349,6 +1357,7 @@ test('parseTranscript reuses cached data when transcript state is unchanged', as
     const second = await parseTranscript(transcriptPath);
     assert.equal(second.tools.length, 1);
     assert.equal(second.tools[0].target, '/tmp/original.txt');
+    assert.equal(second.compactionCount, 1);
   } finally {
     restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
     await rm(dir, { recursive: true, force: true });

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -20,6 +20,7 @@ import { renderMemoryLine } from '../dist/render/lines/memory.js';
 import { renderIdentityLine } from '../dist/render/lines/identity.js';
 import { renderEnvironmentLine } from '../dist/render/lines/environment.js';
 import { renderSessionTokensLine } from '../dist/render/lines/session-tokens.js';
+import { renderCompactionsLine } from '../dist/render/lines/compactions.js';
 import { renderSessionTimeLine } from '../dist/render/lines/session-time.js';
 import { renderAdvisorLine, prettifyAdvisorId } from '../dist/render/lines/advisor.js';
 import { getContextColor, getQuotaColor } from '../dist/render/colors.js';
@@ -2751,6 +2752,79 @@ test('renderSessionLine translates compact session token summary when Chinese is
   } finally {
     setLanguage('en');
   }
+});
+
+// ---------------------------------------------------------------------------
+// display.showCompactions — opt-in compaction count
+// ---------------------------------------------------------------------------
+
+test('renderCompactionsLine returns null by default', () => {
+  const ctx = baseContext();
+  ctx.transcript.compactionCount = 3;
+
+  assert.equal(renderCompactionsLine(ctx), null);
+});
+
+test('renderCompactionsLine renders the compaction count when enabled', () => {
+  const ctx = baseContext();
+  ctx.config.display.showCompactions = true;
+  ctx.transcript.compactionCount = 3;
+
+  const line = stripAnsi(renderCompactionsLine(ctx) ?? '');
+  assert.equal(line, 'Compactions: 3');
+});
+
+test('renderCompactionsLine returns null when no compaction has occurred', () => {
+  const ctx = baseContext();
+  ctx.config.display.showCompactions = true;
+  ctx.transcript.compactionCount = 0;
+
+  assert.equal(renderCompactionsLine(ctx), null);
+});
+
+test('renderSessionLine omits compaction count by default', () => {
+  const ctx = baseContext();
+  ctx.transcript.compactionCount = 3;
+
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(!line.includes('Compactions'), `compaction count should be opt-in, got: ${line}`);
+});
+
+test('renderSessionLine includes compaction count when showCompactions is enabled', () => {
+  const ctx = baseContext();
+  ctx.config.display.showCompactions = true;
+  ctx.transcript.compactionCount = 3;
+
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('Compactions: 3'), `should include compaction count, got: ${line}`);
+});
+
+test('renderSessionLine hides compaction count when no compaction has occurred', () => {
+  const ctx = baseContext();
+  ctx.config.display.showCompactions = true;
+  ctx.transcript.compactionCount = 0;
+
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(!line.includes('Compactions'), `zero compactions should render nothing, got: ${line}`);
+});
+
+test('render expanded layout includes compactions line when enabled', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.config.display.showCompactions = true;
+  ctx.transcript.compactionCount = 2;
+
+  const lines = captureRenderLines(ctx);
+  assert.ok(lines.some(line => line.includes('Compactions: 2')), `should render compactions line, got: ${lines.join(' | ')}`);
+});
+
+test('render expanded layout omits compactions line by default', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.transcript.compactionCount = 2;
+
+  const lines = captureRenderLines(ctx);
+  assert.ok(!lines.some(line => line.includes('Compactions')), `compactions line should be opt-in, got: ${lines.join(' | ')}`);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements the scoped enhancement from #603: count `compact_boundary` entries from the transcript and expose the count behind an opt-in display setting, with default output unchanged.

- `parseTranscript` now counts `compact_boundary` entries with valid timestamps (same reliability check as the existing `lastCompactBoundaryAt` handling) and carries the count through the transcript cache (version bumped to 9 so existing cached sessions pick it up on next render)
- New `display.showCompactions` setting, default `false`. When enabled and at least one compaction has occurred, the HUD shows `Compactions: N` as its own line in expanded layout and inline on the session line in compact layout
- Labels added for en and zh-Hans, README config table updated
- Tests cover the parser count, config merge validation, both render paths, expanded-layout wiring, and the cache round-trip

Only `src/`, `tests/`, and `README.md` are touched; `dist/` left for CI per CONTRIBUTING.

Tested with `npm test` (full suite green) plus a manual stdin run against a transcript containing two compact boundaries, verifying both layouts show `Compactions: 2` when enabled and that default output is byte-identical with the flag off.

Closes #603