### PR TITLE
docs: sync configure.md with current config schema

### DIFF
--- a/commands/configure.md
+++ b/commands/configure.md
@@ -9,16 +9,23 @@ allowed-tools: Read, Write, AskUserQuestion
 
 Store current values and note whether config exists (determines which flow to use).
 
-## Always On (Core Features)
+## Core Features (on by default)
 
-These are always enabled and NOT configurable:
+These default to ON and are what most users keep. They ARE configurable
+(`display.showModel`, `display.showContextBar`), but the guided flow keeps them
+enabled — toggle them by editing `config.json` directly if needed:
 - Model name `[Opus]`
 - Context bar `████░░░░░░ 45%`
 
-Advanced settings such as `colors.*`, `pathLevels`, `display.timeFormat`,
-`display.usageThreshold`, `display.usageValue`, `display.environmentThreshold`,
-`display.contextWarningThreshold`, and `display.contextCriticalThreshold` are
-preserved when saving but are not edited by this guided flow.
+Advanced settings such as `colors.*`, `pathLevels`, `maxWidth`, `forceMaxWidth`,
+`elementOrder`, `display.mergeGroups`, `display.timeFormat`, `display.contextValue`,
+`display.modelFormat`, `display.modelOverride`, `display.autocompactBuffer`,
+`display.autoCompactWindow`, `display.promptCacheTtlSeconds`,
+`display.usageThreshold`, `display.sevenDayThreshold`,
+`display.environmentThreshold`, `display.contextWarningThreshold`,
+`display.contextCriticalThreshold`, `display.advisorOverride`, and the
+`display.externalUsage*` keys are preserved when saving but are not edited by
+this guided flow.
 
 ---
 
@@ -80,6 +87,14 @@ Save as `language: "en"` or `language: "zh-Hans"`.
   - "Session duration" - ⏱️ 5m
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
+  - "Reasoning level" - ◑ high (low/medium/high/xhigh/max effort)
+  - "Output style" - style: explanatory (current output style name)
+  - "Session cost" - 💰 $0.42
+  - "Skills activity" - active skills count
+  - "MCP status" - MCP server status
+  - "Memory usage" - process memory footprint
+  - "Prompt cache" - cache TTL countdown
+  - "Claude Code version" - the running CC version
   - "Advisor model" - Advisor: Opus 4.7 (when /advisor is configured)
 
 ### Q5: Turn On (based on chosen preset)
@@ -118,6 +133,14 @@ If user chooses "Enter custom text", use AskUserQuestion to get their text. Save
   - "Git status" - git:(main*) branch indicator
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
+  - "Reasoning level" - ◑ high (low/medium/high/xhigh/max effort)
+  - "Output style" - style: explanatory (current output style name)
+  - "Session cost" - 💰 $0.42
+  - "Skills activity" - active skills count
+  - "MCP status" - MCP server status
+  - "Memory usage" - process memory footprint
+  - "Prompt cache" - cache TTL countdown
+  - "Claude Code version" - the running CC version
   - "Advisor model" - Advisor: Opus 4.7 (when /advisor is configured)
   - "Usage bar style" - ██░░ 25% visual bar (only if usageBarEnabled is true)
   - "Compact usage" - 5h: 25% (1h 30m) shorter format (only if usageCompact is false)
@@ -139,6 +162,14 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
   - "Session duration" - ⏱️ 5m
+  - "Reasoning level" - ◑ high (low/medium/high/xhigh/max effort)
+  - "Output style" - style: explanatory (current output style name)
+  - "Session cost" - 💰 $0.42
+  - "Skills activity" - active skills count
+  - "MCP status" - MCP server status
+  - "Memory usage" - process memory footprint
+  - "Prompt cache" - cache TTL countdown
+  - "Claude Code version" - the running CC version
   - "Advisor model" - Advisor: Opus 4.7 (when /advisor is configured)
 
 ### Q3: Git Style (only if Git is currently enabled)
@@ -194,8 +225,8 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 ## Preset Definitions
 
 **Full** (everything ON):
-- Activity: Tools ON, Agents ON, Todos ON
-- Info: Counts ON, Tokens ON, Usage ON, Duration ON, Session Name ON, Session Tokens ON, Advisor ON
+- Activity: Tools ON, Skills ON, MCP ON, Agents ON, Todos ON
+- Info: Counts ON, Tokens ON, Usage ON, Cost ON, Duration ON, Session Name ON, Session Tokens ON, Reasoning Level ON, Output Style ON, Memory ON, Prompt Cache ON, CC Version ON, Advisor ON
 - Git: ON (with dirty indicator, no ahead/behind)
 
 **Essential** (activity + git):
@@ -244,30 +275,42 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 
 | Element | Config Key |
 |---------|------------|
+| Model name | `display.showModel` |
+| Context bar | `display.showContextBar` |
 | Tools activity | `display.showTools` |
+| Skills activity | `display.showSkills` |
+| MCP status | `display.showMcp` |
 | Agents status | `display.showAgents` |
 | Todo progress | `display.showTodos` |
 | Project name | `display.showProject` |
+| Added directories | `display.showAddedDirs` (layout via `display.addedDirsLayout`) |
 | Git status | `gitStatus.enabled` |
 | Config counts | `display.showConfigCounts` |
 | Token breakdown | `display.showTokenBreakdown` |
 | Output speed | `display.showSpeed` |
+| Session cost | `display.showCost` |
 | Usage limits | `display.showUsage` |
 | Usage bar style | `display.usageBarEnabled` |
 | Compact usage | `display.usageCompact` |
 | Usage value | `display.usageValue` |
+| Usage reset label | `display.showResetLabel` |
 | Session name | `display.showSessionName` |
 | Session duration | `display.showDuration` |
 | Session tokens | `display.showSessionTokens` |
 | Session start date | `display.showSessionStartDate` |
 | Last response time | `display.showLastResponseAt` |
-| Advisor model | `display.showAdvisor` |
+| Reasoning level | `display.showEffortLevel` |
+| Output style | `display.showOutputStyle` |
+| Memory usage | `display.showMemoryUsage` |
+| Prompt cache | `display.showPromptCache` (TTL via `display.promptCacheTtlSeconds`) |
+| Claude Code version | `display.showClaudeCodeVersion` |
+| Advisor model | `display.showAdvisor` (override via `display.advisorOverride`) |
 | Custom line | `display.customLine` |
 | Custom line position | `display.customLinePosition` |
 
-**Always true (not configurable):**
-- `display.showModel: true`
-- `display.showContextBar: true`
+**Defaults to ON (configurable booleans, kept enabled by the guided flow):**
+- `display.showModel` (default `true`)
+- `display.showContextBar` (default `true`)
 
 ---
 

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -78,11 +78,13 @@ Save as `language: "en"` or `language: "zh-Hans"`.
   - "Agents status" - ◐ explore [haiku]: Finding code
   - "Todo progress" - ▸ Fix bug (2/5 tasks)
   - "Project name" - my-project path display
+  - "Added directories" - +repo +shared workspace directories from /add-dir
   - "Git status" - git:(main*) branch indicator
   - "Config counts" - 2 CLAUDE.md | 4 rules
   - "Token breakdown" - (in: 45k, cache: 12k)
   - "Output speed" - out: 42.1 tok/s
   - "Usage limits" - 5h: 25% | 7d: 10%
+  - "Usage reset label" - show or hide the `resets in` prefix
   - "Compact usage" - 5h: 25% (1h 30m) shorter format
   - "Session duration" - ⏱️ 5m
   - "Session name" - fix-auth-bug (session slug or custom title)
@@ -95,6 +97,7 @@ Save as `language: "en"` or `language: "zh-Hans"`.
   - "Memory usage" - process memory footprint
   - "Prompt cache" - cache TTL countdown
   - "Claude Code version" - the running CC version
+  - "Compaction count" - Compactions: 2 after /compact or auto-compaction
   - "Advisor model" - Advisor: Opus 4.7 (when /advisor is configured)
 
 ### Q5: Turn On (based on chosen preset)
@@ -130,6 +133,7 @@ If user chooses "Enter custom text", use AskUserQuestion to get their text. Save
   - "Agents status" - ◐ explore [haiku]: Finding code
   - "Todo progress" - ▸ Fix bug (2/5 tasks)
   - "Project name" - my-project path display
+  - "Added directories" - +repo +shared workspace directories from /add-dir
   - "Git status" - git:(main*) branch indicator
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
@@ -141,8 +145,10 @@ If user chooses "Enter custom text", use AskUserQuestion to get their text. Save
   - "Memory usage" - process memory footprint
   - "Prompt cache" - cache TTL countdown
   - "Claude Code version" - the running CC version
+  - "Compaction count" - Compactions: 2 after /compact or auto-compaction
   - "Advisor model" - Advisor: Opus 4.7 (when /advisor is configured)
   - "Usage bar style" - ██░░ 25% visual bar (only if usageBarEnabled is true)
+  - "Usage reset label" - show or hide the `resets in` prefix
   - "Compact usage" - 5h: 25% (1h 30m) shorter format (only if usageCompact is false)
 
 If more than 4 items ON, show Activity items (Tools, Agents, Todos, Project, Git) first.
@@ -158,7 +164,9 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
   - "Output speed" - out: 42.1 tok/s
   - "Usage limits" - 5h: 25% | 7d: 10%
   - "Usage bar style" - ██░░ 25% visual bar (only if usageBarEnabled is false)
+  - "Usage reset label" - show or hide the `resets in` prefix
   - "Compact usage" - 5h: 25% (1h 30m) shorter format (only if usageCompact is false)
+  - "Added directories" - +repo +shared workspace directories from /add-dir
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
   - "Session duration" - ⏱️ 5m
@@ -170,6 +178,7 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
   - "Memory usage" - process memory footprint
   - "Prompt cache" - cache TTL countdown
   - "Claude Code version" - the running CC version
+  - "Compaction count" - Compactions: 2 after /compact or auto-compaction
   - "Advisor model" - Advisor: Opus 4.7 (when /advisor is configured)
 
 ### Q3: Git Style (only if Git is currently enabled)
@@ -226,7 +235,7 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 
 **Full** (everything ON):
 - Activity: Tools ON, Skills ON, MCP ON, Agents ON, Todos ON
-- Info: Counts ON, Tokens ON, Usage ON, Cost ON, Duration ON, Session Name ON, Session Tokens ON, Reasoning Level ON, Output Style ON, Memory ON, Prompt Cache ON, CC Version ON, Advisor ON
+- Info: Added Dirs ON, Counts ON, Tokens ON, Usage ON, Reset Label ON, Cost ON, Duration ON, Session Name ON, Session Tokens ON, Reasoning Level ON, Output Style ON, Memory ON, Prompt Cache ON, CC Version ON, Compactions ON, Advisor ON
 - Git: ON (with dirty indicator, no ahead/behind)
 
 **Essential** (activity + git):
@@ -299,6 +308,7 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 | Session tokens | `display.showSessionTokens` |
 | Session start date | `display.showSessionStartDate` |
 | Last response time | `display.showLastResponseAt` |
+| Compaction count | `display.showCompactions` |
 | Reasoning level | `display.showEffortLevel` |
 | Output style | `display.showOutputStyle` |
 | Memory usage | `display.showMemoryUsage` |


### PR DESCRIPTION
## Problem

The `/configure` guided command doc (`commands/configure.md`) has drifted from the actual config schema in `src/config.ts`. Several `display.*` elements were added to the schema — and are rendered by the HUD — but were never surfaced in the configure flow. Users have no guided way to toggle them, and the **Element Mapping** table is incomplete.

Root cause: feature commits that touched `src/config.ts` (e.g. `feat: add showSkills / showMcp HUD display elements`) did not update `commands/configure.md`. There's nothing binding the two, so the doc silently rots with each new element.

## What this PR does

Documentation/UX sync only — **no renderer behavior change**.

Adds the missing elements to the Element Mapping table and the Turn On / Turn Off option lists:

- `showEffortLevel` (reasoning level: low/medium/high/xhigh/max)
- `showOutputStyle` (current output style name)
- `showCost` (session cost)
- `showSkills`, `showMcp`
- `showMemoryUsage`
- `showPromptCache` (+ `promptCacheTtlSeconds`)
- `showClaudeCodeVersion`
- `showAddedDirs` (+ `addedDirsLayout`)
- `showResetLabel`

Also:

- Element Mapping table now lists **every** `show*` boolean in the schema, including `showModel` / `showContextBar` (previously labeled "not configurable" — they're configurable booleans that just default to `true`).
- Removed an internal contradiction: `usageValue` was listed both as an un-edited "advanced" setting *and* in the Element Mapping table.
- Expanded the advanced-settings note to cover the keys the guided flow preserves but does not edit (`elementOrder`, `mergeGroups`, `modelFormat`, `autoCompactWindow`, `sevenDayThreshold`, `advisorOverride`, `externalUsage*`, etc).
- Updated the **Full** preset to enable the newly documented elements.

## Verification

Diffed every `show*` key between `src/config.ts` and `commands/configure.md` — zero keys in schema missing from the doc after this change.

## Suggestion (not in this PR)

To prevent recurrence, consider a CI check that fails when a `show*` key exists in `config.ts` but not in `configure.md`.