### PR TITLE
fix: merge sevenDay from external snapshot when stdin omits it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,8 +127,18 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
         usageData = deps.getUsageFromExternalSnapshot(config, deps.now());
       } else if (config.display.externalUsagePath) {
         const ext = deps.getUsageFromExternalSnapshot(config, deps.now());
-        if (ext?.balanceLabel != null) {
-          usageData = { ...usageData, balanceLabel: ext.balanceLabel };
+        if (ext != null) {
+          usageData = {
+            ...usageData,
+            ...(ext.balanceLabel != null && { balanceLabel: ext.balanceLabel }),
+            // If stdin did not provide sevenDay (e.g. third-party clients like the
+            // Claudian Obsidian plugin that only surface five_hour), fall back to the
+            // external snapshot so the weekly limit still shows in the HUD.
+            ...(usageData.sevenDay == null && ext.sevenDay != null && {
+              sevenDay: ext.sevenDay,
+              sevenDayResetAt: ext.sevenDayResetAt ?? null,
+            }),
+          };
         }
       }
     }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -431,6 +431,47 @@ test("main appends external balance label to stdin usage when snapshot path is c
   });
 });
 
+test("main fills missing seven-day usage from external snapshot", async () => {
+  let renderedContext;
+  let externalCalls = 0;
+
+  await main({
+    readStdin: async () => makeStdin({
+      rate_limits: {
+        five_hour: { used_percentage: 21.9, resets_at: 1710000000 },
+      },
+    }),
+    parseTranscript: async () => makeTranscript(),
+    countConfigs: async () => makeCounts(),
+    loadConfig: async () => makeConfig({
+      display: { externalUsagePath: "/tmp/usage.json" },
+    }),
+    getGitStatus: async () => null,
+    getUsageFromExternalSnapshot: () => {
+      externalCalls += 1;
+      return {
+        fiveHour: 99,
+        sevenDay: 85,
+        fiveHourResetAt: null,
+        sevenDayResetAt: new Date("2026-04-27T12:00:00.000Z"),
+        balanceLabel: "$12.34 / $20.00",
+      };
+    },
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.equal(externalCalls, 1);
+  assert.deepEqual(renderedContext?.usageData, {
+    fiveHour: 22,
+    sevenDay: 85,
+    fiveHourResetAt: new Date(1710000000 * 1000),
+    sevenDayResetAt: new Date("2026-04-27T12:00:00.000Z"),
+    balanceLabel: "$12.34 / $20.00",
+  });
+});
+
 test("main skips all usage loading when usage display is disabled", async () => {
   let renderedContext;
   let externalCalls = 0;


### PR DESCRIPTION
## Problem

When a third-party Claude client (e.g. **Claudian**, the Obsidian plugin) only provides `rate_limits.five_hour` via stdin but **not** `rate_limits.seven_day`, the weekly limit disappears from the HUD — even if `externalUsagePath` points to a valid, fresh snapshot that contains `seven_day` data.

## Root Cause

`src/index.ts` — the `else if (externalUsagePath)` branch:

```ts
} else if (config.display.externalUsagePath) {
  const ext = deps.getUsageFromExternalSnapshot(config, deps.now());
  if (ext?.balanceLabel != null) {
    usageData = { ...usageData, balanceLabel: ext.balanceLabel }; // only balanceLabel merged
  }
  // ← sevenDay from snapshot silently dropped
}
```

The full fallback (`if (!usageData)`) only fires when **both** `fiveHour` and `sevenDay` are missing. When only `sevenDay` is absent, `stdinUsage` is non-null and the else-if branch runs — but it only merges `balanceLabel`, ignoring any `sevenDay` value the snapshot may carry.

## Fix

Also pull in `sevenDay` / `sevenDayResetAt` from the external snapshot when stdin did not supply a value:

```ts
} else if (config.display.externalUsagePath) {
  const ext = deps.getUsageFromExternalSnapshot(config, deps.now());
  if (ext != null) {
    usageData = {
      ...usageData,
      ...(ext.balanceLabel != null && { balanceLabel: ext.balanceLabel }),
      ...(usageData.sevenDay == null && ext.sevenDay != null && {
        sevenDay: ext.sevenDay,
        sevenDayResetAt: ext.sevenDayResetAt ?? null,
      }),
    };
  }
}
```

## Behaviour

- **No change** when stdin provides `sevenDay` — the `usageData.sevenDay == null` guard ensures stdin always wins.
- **No change** when `externalUsagePath` is not configured.
- **Fixed** when stdin only has `fiveHour`: the snapshot's `sevenDay` is now merged in, so the weekly limit displays correctly.

## Reproduction

1. Configure `externalUsagePath` pointing to a snapshot with `seven_day` data.
2. Use claude-hud in a session where `stdin.rate_limits` only contains `five_hour` (e.g. Claudian/Obsidian).
3. Weekly limit disappears from HUD despite fresh snapshot data. ← fixed by this PR