### PR TITLE
fix(cost): correct Opus 4.5 pricing

### DIFF
--- a/src/cost.ts
+++ b/src/cost.ts
@@ -27,6 +27,7 @@ const CACHE_READ_MULTIPLIER = 0.1;
 // model lines (Haiku 4.x differs from Haiku 3.5) must come before any broader
 // fallback patterns to avoid silent under-pricing.
 const ANTHROPIC_MODEL_PRICING: Array<{ pattern: RegExp; pricing: ModelPricing }> = [
+  { pattern: /\bopus 4 (?:[5-9]|\d{2,})\b/i, pricing: { inputUsdPerMillion: 5, outputUsdPerMillion: 25 } },
   { pattern: /\bopus 4(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 15, outputUsdPerMillion: 75 } },
   { pattern: /\bsonnet 4(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
   { pattern: /\bsonnet 3 7\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -421,7 +421,7 @@ test('resolveSessionCost falls back to transcript estimation when native cost is
 
   assert.ok(cost, 'expected fallback estimate');
   assert.equal(cost?.source, 'estimate');
-  assert.equal(formatUsd(cost?.totalUsd ?? 0), '$5.47');
+  assert.equal(formatUsd(cost?.totalUsd ?? 0), '$1.82');
 });
 
 test('resolveSessionCost ignores native cost for provider-routed sessions', () => {
@@ -503,6 +503,31 @@ test('estimateSessionCost prices Claude Haiku 4.5 (and future 4.x minors)', () =
   assert.ok(haiku35, 'expected non-null estimate for Claude Haiku 3.5');
   // 1M input @ $0.8 + 100k output @ $4 = $0.8 + $0.4 = $1.20
   assert.equal(formatUsd(haiku35.totalUsd), '$1.20');
+});
+
+test('estimateSessionCost prices newer Opus 4 models below the Opus 4.0 and 4.1 fallback', () => {
+  const tokens = {
+    inputTokens: 1_000_000,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    outputTokens: 100_000,
+  };
+
+  const opus45 = estimateSessionCost({ model: { display_name: 'Claude Opus 4.5' } }, tokens);
+  assert.ok(opus45, 'expected non-null estimate for Claude Opus 4.5');
+  assert.equal(formatUsd(opus45.totalUsd), '$7.50');
+
+  const opus46 = estimateSessionCost({ model: { display_name: 'Claude Opus 4.6' } }, tokens);
+  assert.ok(opus46, 'expected non-null estimate for Claude Opus 4.6');
+  assert.equal(formatUsd(opus46.totalUsd), '$7.50');
+
+  const bedrockOpus46 = estimateSessionCost({ model: { display_name: 'eu.anthropic.claude-opus-4-6-v1:0' } }, tokens);
+  assert.ok(bedrockOpus46, 'expected model ID normalization to match Claude Opus 4.6');
+  assert.equal(formatUsd(bedrockOpus46.totalUsd), '$7.50');
+
+  const opus41 = estimateSessionCost({ model: { display_name: 'Claude Opus 4.1' } }, tokens);
+  assert.ok(opus41, 'expected non-null estimate for Claude Opus 4.1');
+  assert.equal(formatUsd(opus41.totalUsd), '$22.50');
 });
 
 

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -794,7 +794,7 @@ test('renderProjectLine falls back to an estimate when native cost is absent', (
   };
 
   const line = stripAnsi(renderProjectLine(ctx));
-  assert.ok(line.includes('Est. $5.47'), `expected fallback estimate, got: ${line}`);
+  assert.ok(line.includes('Est. $1.82'), `expected fallback estimate, got: ${line}`);
 });
 
 test('renderProjectLine hides cost for provider-routed sessions', () => {


### PR DESCRIPTION
## Summary
- update Opus 4.5+ local cost estimates to the official standard Anthropic rate of $5/M input and $25/M output
- keep older Opus 4.0/4.1 estimates on $15/M input and $75/M output
- add focused coverage for Opus 4.5/4.6, Bedrock-style model IDs, and the older fallback

## Verification
- npm ci
- npm run build
- node --test tests/core.test.js tests/render.test.js

## Pricing source
- https://docs.anthropic.com/en/docs/about-claude/pricing

Fixes #622.
Supersedes #624.