### PR TITLE
feat: optionally show provider label before the model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `gitStatus.showFileStats` | boolean | false | Show file change counts `!M +A ✘D ?U` |
 | `gitStatus.branchOverflow` | `truncate` \| `wrap` | `truncate` | Keep current truncation behavior or let the git block wrap onto its own line boundary when possible |
 | `display.showModel` | boolean | true | Show model name `[Opus]` |
+| `display.showProvider` | boolean | false | Show the provider label *before* the model name, e.g. `[Bedrock \| Opus 4.6]`. Useful when a custom proxy serves identically-named models from different providers. When off, an auto-detected provider still trails the model as before |
+| `display.providerName` | string | `""` | Explicit provider label used with `display.showProvider`, e.g. for a custom proxy that can't be auto-detected. Falls back to the auto-detected provider (Bedrock/Vertex/Enterprise) when empty; capped at 40 chars |
 | `display.showAddedDirs` | boolean | true | Show extra workspace directories from `/add-dir` (e.g. `+sparkle +lib-foo`); empty array renders nothing. In both layouts at most 5 dirs render (overflow shown as `+N more`) and basenames are truncated to 24 chars with `…` |
 | `display.addedDirsLayout` | `inline` \| `line` | `inline` | `inline` puts dirs next to the project name with a `+name` prefix per dir; `line` renders them on a separate `Added dirs: name1, name2` line (no `+` prefix, comma-separated) |
 | `display.showContextBar` | boolean | true | Show visual context bar `████░░░░░░` |

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -19,7 +19,8 @@ enabled — toggle them by editing `config.json` directly if needed:
 
 Advanced settings such as `colors.*`, `pathLevels`, `maxWidth`, `forceMaxWidth`,
 `elementOrder`, `display.mergeGroups`, `display.timeFormat`, `display.contextValue`,
-`display.modelFormat`, `display.modelOverride`, `display.autocompactBuffer`,
+`display.modelFormat`, `display.modelOverride`, `display.showProvider`,
+`display.providerName`, `display.autocompactBuffer`,
 `display.autoCompactWindow`, `display.promptCacheTtlSeconds`,
 `display.usageThreshold`, `display.sevenDayThreshold`,
 `display.environmentThreshold`, `display.contextWarningThreshold`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -154,6 +154,12 @@ export interface HudConfig {
     externalUsageFreshnessMs: number;
     modelFormat: ModelFormatMode;
     modelOverride: string;
+    // Show the provider label (custom name or auto-detected Bedrock/Vertex/
+    // Enterprise) BEFORE the model name on the project line. Default off.
+    showProvider: boolean;
+    // Explicit provider label, e.g. for custom proxies where the provider can't
+    // be auto-detected. Falls back to auto-detection when empty.
+    providerName: string;
     customLine: string;
     customLinePosition: CustomLinePosition;
     timeFormat: TimeFormatMode;
@@ -234,6 +240,8 @@ export const DEFAULT_CONFIG: HudConfig = {
     externalUsageFreshnessMs: 300000,
     modelFormat: 'full',
     modelOverride: '',
+    showProvider: false,
+    providerName: '',
     customLine: '',
     customLinePosition: 'last',
     timeFormat: 'relative',
@@ -672,6 +680,12 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     modelOverride: typeof migrated.display?.modelOverride === 'string'
       ? migrated.display.modelOverride.slice(0, 80)
       : DEFAULT_CONFIG.display.modelOverride,
+    showProvider: typeof migrated.display?.showProvider === 'boolean'
+      ? migrated.display.showProvider
+      : DEFAULT_CONFIG.display.showProvider,
+    providerName: typeof migrated.display?.providerName === 'string'
+      ? migrated.display.providerName.slice(0, 40)
+      : DEFAULT_CONFIG.display.providerName,
     customLine: typeof migrated.display?.customLine === 'string'
       ? migrated.display.customLine.slice(0, 80)
       : DEFAULT_CONFIG.display.customLine,

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -64,13 +64,26 @@ export function renderProjectLine(ctx: RenderContext): string | null {
 
   if (display?.showModel !== false) {
     const model = formatModelName(getModelName(ctx.stdin), ctx.config?.display?.modelFormat, ctx.config?.display?.modelOverride);
-    const providerLabel = getProviderLabel(ctx.stdin);
-    const modelQualifier = providerLabel ?? undefined;
-    let modelDisplay = modelQualifier ? `${model} | ${modelQualifier}` : model;
+
+    let effortSuffix = '';
     if (ctx.effortLevel && ctx.effortSymbol) {
-      modelDisplay += ` ${ctx.effortSymbol} ${ctx.effortLevel}`;
+      effortSuffix = ` ${ctx.effortSymbol} ${ctx.effortLevel}`;
     } else if (ctx.effortLevel) {
-      modelDisplay += ` ${ctx.effortLevel}`;
+      effortSuffix = ` ${ctx.effortLevel}`;
+    }
+
+    const autoProvider = getProviderLabel(ctx.stdin);
+    let modelDisplay: string;
+    if (display?.showProvider) {
+      // Provider (custom name, else auto-detected) leads the model name.
+      const providerLabel = display?.providerName?.trim() || autoProvider;
+      const core = `${model}${effortSuffix}`;
+      modelDisplay = providerLabel ? `${providerLabel} | ${core}` : core;
+    } else {
+      // Default: auto-detected provider trails the model name (legacy layout).
+      modelDisplay = autoProvider
+        ? `${model} | ${autoProvider}${effortSuffix}`
+        : `${model}${effortSuffix}`;
     }
     parts.push(modelColor(`[${modelDisplay}]`, colors));
   }

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -120,6 +120,19 @@ test('mergeConfig preserves explicit showSessionName=true', () => {
   assert.equal(config.display.showSessionName, true);
 });
 
+test('mergeConfig defaults provider options to off/empty', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.showProvider, false);
+  assert.equal(config.display.providerName, '');
+  assert.equal(DEFAULT_CONFIG.display.showProvider, false);
+});
+
+test('mergeConfig preserves provider options and caps providerName length', () => {
+  const config = mergeConfig({ display: { showProvider: true, providerName: 'x'.repeat(60) } });
+  assert.equal(config.display.showProvider, true);
+  assert.equal(config.display.providerName.length, 40);
+});
+
 test('mergeConfig defaults showClaudeCodeVersion to false', () => {
   const config = mergeConfig({});
   assert.equal(config.display.showClaudeCodeVersion, false);

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -676,6 +676,40 @@ test('renderProjectLine modelOverride takes precedence over modelFormat', () => 
   assert.ok(line.includes('My Custom Model'));
 });
 
+test('renderProjectLine shows custom provider before the model when showProvider is on', () => {
+  const ctx = baseContext();
+  ctx.stdin.model = { display_name: 'Claude Opus 4.6' };
+  ctx.config.display.showProvider = true;
+  ctx.config.display.providerName = 'MyProxy';
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(line.includes('[MyProxy | Claude Opus 4.6]'), `got: ${line}`);
+});
+
+test('renderProjectLine falls back to auto-detected provider before the model', () => {
+  process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+  try {
+    const ctx = baseContext();
+    ctx.stdin.model = { display_name: 'Claude Opus 4.6' };
+    ctx.config.display.showProvider = true;
+    const line = stripAnsi(renderProjectLine(ctx) ?? '');
+    assert.ok(line.includes('[Bedrock | Claude Opus 4.6]'), `got: ${line}`);
+  } finally {
+    delete process.env.CLAUDE_CODE_USE_BEDROCK;
+  }
+});
+
+test('renderProjectLine keeps the legacy trailing provider label when showProvider is off', () => {
+  process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+  try {
+    const ctx = baseContext();
+    ctx.stdin.model = { display_name: 'Claude Opus 4.6' };
+    const line = stripAnsi(renderProjectLine(ctx) ?? '');
+    assert.ok(line.includes('[Claude Opus 4.6 | Bedrock]'), `got: ${line}`);
+  } finally {
+    delete process.env.CLAUDE_CODE_USE_BEDROCK;
+  }
+});
+
 test('renderProjectLine uses configurable element colors', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = '/tmp/my-project';


### PR DESCRIPTION
## Problem

When a custom proxy serves identically-named models from different providers, it's easy to forget which provider is active. There was no way to surface the provider ahead of the model name, and custom providers aren't auto-detected.

## Changes

- **`display.showProvider`** (default `false`) — when on, the provider label leads the model badge, e.g. `[Bedrock | Opus 4.6]`.
- **`display.providerName`** — explicit label for custom proxies that can't be auto-detected; falls back to the auto-detected provider (Bedrock/Vertex/Enterprise) when empty.
- Default-off preserves the existing trailing auto-detected label, so nothing changes for current users.

## Test plan

- `npm test` — added render tests for custom provider before model, auto-detected fallback before model, and the legacy trailing label when off; plus config default/validation tests.

Closes #621