### PR TITLE
feat(cost): show estimated session cost for Bedrock/Vertex users

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.contextValue` | `percent` \| `tokens` \| `remaining` \| `both` | `percent` | Context display format (`45%`, `45k/200k`, `55%` remaining, or `45% (45k/200k)`) |
 | `display.autoCompactWindow` | number \| `null` | `null` | When set to a positive number such as `200000`, compute the context percentage against this auto-compact window instead of the full model context window, matching the `/context` figure. Leave unset or `null` to preserve default full-window behavior. |
 | `display.showConfigCounts` | boolean | false | Show CLAUDE.md, rules, MCPs, hooks counts |
-| `display.showCost` | boolean | false | Show session cost using Claude Code's native `cost.total_cost_usd` when available, with a local estimate fallback for direct Anthropic sessions |
+| `display.showCost` | boolean | false | Show session cost using Claude Code's native `cost.total_cost_usd` when available, with a local token-based estimate fallback |
+| `display.showCostForCloudProviders` | boolean | true | Allow the token-based estimate for Bedrock/Vertex sessions (per-token pricing is identical to the direct API). Set `false` to hide cost entirely for cloud providers. The unreliable *native* total is always suppressed for cloud providers regardless |
 | `display.showOutputStyle` | boolean | false | Show the active Claude Code `outputStyle` from settings files as `style: <name>` |
 | `display.showDuration` | boolean | false | Show session duration `⏱️ 5m` |
 | `display.showSpeed` | boolean | false | Show output token speed `out: 42.1 tok/s` |
@@ -229,7 +230,9 @@ Supported color names: `dim`, `red`, `green`, `yellow`, `magenta`, `cyan`, `brig
 
 `display.showMemoryUsage` is fully opt-in and only renders in `expanded` layout. It reports approximate system RAM usage from the local machine, not precise memory pressure inside Claude Code or a specific process. The number may overstate actual pressure because reclaimable OS cache and buffers can still be counted as used memory.
 
-`display.showCost` is fully opt-in. ClaudeHUD prefers the native `cost.total_cost_usd` field that Claude Code provides on stdin when it is available. If that field is absent or invalid for a direct Anthropic session, ClaudeHUD falls back to the existing local transcript-based estimate so the cost line still works on older payloads. The native field is absent before the first API response in a session, so the cost display may stay hidden until then. ClaudeHUD also keeps the cost hidden for known routed providers such as Bedrock and Vertex AI, because cloud-provider billed sessions may report `$0.00` or omit the field even though the session was not literally free.
+`display.showCost` is fully opt-in. ClaudeHUD prefers the native `cost.total_cost_usd` field that Claude Code provides on stdin when it is available. If that field is absent or invalid, ClaudeHUD falls back to a local transcript-based estimate (labelled `Est.`) so the cost line still works on older payloads. The native field is absent before the first API response in a session, so the cost display may stay hidden until then.
+
+For routed providers such as Bedrock and Vertex AI, the *native* total is never trusted (cloud-billed sessions may report `$0.00` or omit the field). The token-based estimate, however, uses the same per-token pricing as the direct Anthropic API, so it is shown by default — set `display.showCostForCloudProviders` to `false` to suppress it. When a proxy reports `input_tokens: 0` in the transcript, the estimate falls back to the live context input-token count from stdin so it is not output-only.
 
 `display.showPromptCache` is fully opt-in. When enabled, ClaudeHUD looks at the timestamp of the last assistant response in the local transcript and shows a live countdown until the prompt cache expires. The default TTL is 5 minutes (`300` seconds). Set `display.promptCacheTtlSeconds` to `3600` if you want a 1-hour Max-style window. If the transcript does not have an assistant timestamp yet, the cache element stays hidden.
 

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -19,7 +19,8 @@ enabled — toggle them by editing `config.json` directly if needed:
 
 Advanced settings such as `colors.*`, `pathLevels`, `maxWidth`, `forceMaxWidth`,
 `elementOrder`, `display.mergeGroups`, `display.timeFormat`, `display.contextValue`,
-`display.modelFormat`, `display.modelOverride`, `display.autocompactBuffer`,
+`display.modelFormat`, `display.modelOverride`, `display.showCostForCloudProviders`,
+`display.autocompactBuffer`,
 `display.autoCompactWindow`, `display.promptCacheTtlSeconds`,
 `display.usageThreshold`, `display.sevenDayThreshold`,
 `display.environmentThreshold`, `display.contextWarningThreshold`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,6 +114,9 @@ export interface HudConfig {
     contextValue: ContextValueMode;
     showConfigCounts: boolean;
     showCost: boolean;
+    // Allow the token-based cost estimate for Bedrock/Vertex (default true).
+    // Native cost stays suppressed for cloud providers regardless.
+    showCostForCloudProviders: boolean;
     showDuration: boolean;
     showSpeed: boolean;
     showTokenBreakdown: boolean;
@@ -196,6 +199,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     contextValue: 'percent',
     showConfigCounts: false,
     showCost: false,
+    showCostForCloudProviders: true,
     showDuration: false,
     showSpeed: false,
     showTokenBreakdown: true,
@@ -567,6 +571,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showCost: typeof migrated.display?.showCost === 'boolean'
       ? migrated.display.showCost
       : DEFAULT_CONFIG.display.showCost,
+    showCostForCloudProviders: typeof migrated.display?.showCostForCloudProviders === 'boolean'
+      ? migrated.display.showCostForCloudProviders
+      : DEFAULT_CONFIG.display.showCostForCloudProviders,
     showDuration: typeof migrated.display?.showDuration === 'boolean'
       ? migrated.display.showDuration
       : DEFAULT_CONFIG.display.showDuration,

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -19,6 +19,16 @@ export interface SessionCostDisplay {
   source: 'native' | 'estimate';
 }
 
+export interface CostOptions {
+  /**
+   * When false, suppress the token-based estimate for Bedrock/Vertex. Defaults
+   * to true: cloud providers use the same per-token pricing as the direct API,
+   * so the estimate is just as accurate (it is only the *native* total that is
+   * unreliable for cloud billing).
+   */
+  showCostForCloudProviders?: boolean;
+}
+
 const TOKENS_PER_MILLION = 1_000_000;
 const CACHE_WRITE_MULTIPLIER = 1.25;
 const CACHE_READ_MULTIPLIER = 0.1;
@@ -86,16 +96,16 @@ function getAnthropicPricing(stdin: StdinData): ModelPricing | null {
 export function estimateSessionCost(
   stdin: StdinData,
   sessionTokens: SessionTokenUsage | undefined,
+  options: CostOptions = {},
 ): SessionCostEstimate | null {
   if (!sessionTokens) {
     return null;
   }
 
-  if (isBedrockModelId(stdin.model?.id)) {
-    return null;
-  }
-
-  if (isVertexModelId(stdin.model?.id)) {
+  // Bedrock/Vertex use identical per-token pricing, so the estimate is valid.
+  // Only suppress it when the user has explicitly opted out.
+  const isCloudProvider = isBedrockModelId(stdin.model?.id) || isVertexModelId(stdin.model?.id);
+  if (isCloudProvider && options.showCostForCloudProviders === false) {
     return null;
   }
 
@@ -104,7 +114,14 @@ export function estimateSessionCost(
     return null;
   }
 
-  const totalTokens = sessionTokens.inputTokens
+  // Some proxies (notably Bedrock via a local proxy on Claude Code v2.1.179+)
+  // report input_tokens: 0 in the transcript. Fall back to the live context
+  // input-token count from stdin so the estimate is not output-only.
+  const inputTokens = sessionTokens.inputTokens > 0
+    ? sessionTokens.inputTokens
+    : (stdin.context_window?.current_usage?.input_tokens ?? 0);
+
+  const totalTokens = inputTokens
     + sessionTokens.cacheCreationTokens
     + sessionTokens.cacheReadTokens
     + sessionTokens.outputTokens;
@@ -112,7 +129,7 @@ export function estimateSessionCost(
     return null;
   }
 
-  const inputUsd = calculateUsd(sessionTokens.inputTokens, pricing.inputUsdPerMillion);
+  const inputUsd = calculateUsd(inputTokens, pricing.inputUsdPerMillion);
   const cacheCreationUsd = calculateUsd(sessionTokens.cacheCreationTokens, pricing.inputUsdPerMillion * CACHE_WRITE_MULTIPLIER);
   const cacheReadUsd = calculateUsd(sessionTokens.cacheReadTokens, pricing.inputUsdPerMillion * CACHE_READ_MULTIPLIER);
   const outputUsd = calculateUsd(sessionTokens.outputTokens, pricing.outputUsdPerMillion);
@@ -132,6 +149,8 @@ function getNativeCostUsd(stdin: StdinData): number | null {
     return null;
   }
 
+  // Native total is unreliable for cloud billing (AWS/GCP handle it, and the
+  // value may be 0 or absent), so never trust it for Bedrock/Vertex.
   if (isBedrockModelId(stdin.model?.id)) {
     return null;
   }
@@ -146,6 +165,7 @@ function getNativeCostUsd(stdin: StdinData): number | null {
 export function resolveSessionCost(
   stdin: StdinData,
   sessionTokens: SessionTokenUsage | undefined,
+  options: CostOptions = {},
 ): SessionCostDisplay | null {
   const nativeCostUsd = getNativeCostUsd(stdin);
   if (nativeCostUsd !== null) {
@@ -155,7 +175,7 @@ export function resolveSessionCost(
     };
   }
 
-  const estimate = estimateSessionCost(stdin, sessionTokens);
+  const estimate = estimateSessionCost(stdin, sessionTokens, options);
   if (!estimate) {
     return null;
   }

--- a/src/render/lines/cost.ts
+++ b/src/render/lines/cost.ts
@@ -8,7 +8,9 @@ export function renderCostEstimate(ctx: RenderContext): string | null {
     return null;
   }
 
-  const cost = resolveSessionCost(ctx.stdin, ctx.transcript.sessionTokens);
+  const cost = resolveSessionCost(ctx.stdin, ctx.transcript.sessionTokens, {
+    showCostForCloudProviders: ctx.config?.display?.showCostForCloudProviders,
+  });
   if (!cost) {
     return null;
   }

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -120,6 +120,17 @@ test('mergeConfig preserves explicit showSessionName=true', () => {
   assert.equal(config.display.showSessionName, true);
 });
 
+test('mergeConfig defaults showCostForCloudProviders to true', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.showCostForCloudProviders, true);
+  assert.equal(DEFAULT_CONFIG.display.showCostForCloudProviders, true);
+});
+
+test('mergeConfig preserves explicit showCostForCloudProviders=false', () => {
+  const config = mergeConfig({ display: { showCostForCloudProviders: false } });
+  assert.equal(config.display.showCostForCloudProviders, false);
+});
+
 test('mergeConfig defaults showClaudeCodeVersion to false', () => {
   const config = mergeConfig({});
   assert.equal(config.display.showClaudeCodeVersion, false);

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -424,26 +424,50 @@ test('resolveSessionCost falls back to transcript estimation when native cost is
   assert.equal(formatUsd(cost?.totalUsd ?? 0), '$5.47');
 });
 
-test('resolveSessionCost ignores native cost for provider-routed sessions', () => {
+test('resolveSessionCost ignores native cost but still estimates for provider-routed sessions', () => {
   process.env.CLAUDE_CODE_USE_BEDROCK = '1';
   try {
-    const cost = resolveSessionCost(
-      {
-        model: { id: 'anthropic.claude-sonnet-4-20250514-v1:0' },
-        cost: { total_cost_usd: 0 },
-      },
-      {
-        inputTokens: 100000,
-        cacheCreationTokens: 10000,
-        cacheReadTokens: 20000,
-        outputTokens: 50000,
-      },
-    );
+    const stdin = {
+      model: { id: 'anthropic.claude-sonnet-4-20250514-v1:0' },
+      cost: { total_cost_usd: 0 },
+    };
+    const tokens = {
+      inputTokens: 100000,
+      cacheCreationTokens: 10000,
+      cacheReadTokens: 20000,
+      outputTokens: 50000,
+    };
 
-    assert.equal(cost, null);
+    // Native total is unreliable for cloud billing, but the token-based
+    // estimate uses identical per-token pricing, so it is shown by default.
+    const cost = resolveSessionCost(stdin, tokens);
+    assert.ok(cost, 'expected a token estimate for cloud-provider session');
+    assert.equal(cost?.source, 'estimate');
+    assert.equal(formatUsd(cost?.totalUsd ?? 0), '$1.09');
+
+    // Opting out suppresses the cloud-provider estimate entirely.
+    const optedOut = resolveSessionCost(stdin, tokens, { showCostForCloudProviders: false });
+    assert.equal(optedOut, null);
   } finally {
     delete process.env.CLAUDE_CODE_USE_BEDROCK;
   }
+});
+
+test('estimateSessionCost falls back to stdin context input tokens when transcript reports 0', () => {
+  const stdin = {
+    model: { display_name: 'Claude Sonnet 4.5' },
+    context_window: { current_usage: { input_tokens: 200000 } },
+  };
+  const estimate = estimateSessionCost(stdin, {
+    inputTokens: 0,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    outputTokens: 50000,
+  });
+
+  // input 200k @ $3 + output 50k @ $15 = $0.60 + $0.75 = $1.35
+  assert.ok(estimate, 'expected estimate using stdin input-token fallback');
+  assert.equal(formatUsd(estimate.totalUsd), '$1.35');
 });
 
 test('resolveSessionCost falls back when native cost is invalid', () => {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -797,7 +797,7 @@ test('renderProjectLine falls back to an estimate when native cost is absent', (
   assert.ok(line.includes('Est. $5.47'), `expected fallback estimate, got: ${line}`);
 });
 
-test('renderProjectLine hides cost for provider-routed sessions', () => {
+test('renderProjectLine shows an estimate for provider-routed sessions by default', () => {
   process.env.CLAUDE_CODE_USE_BEDROCK = '1';
   try {
     const ctx = baseContext();
@@ -812,8 +812,16 @@ test('renderProjectLine hides cost for provider-routed sessions', () => {
       outputTokens: 50000,
     };
 
+    // Native cost (0) is ignored, but the token estimate is shown since
+    // Bedrock/Vertex use identical per-token pricing.
     const line = stripAnsi(renderProjectLine(ctx));
-    assert.ok(!line.includes('Cost '), 'cost should stay hidden when billing is routed through the provider');
+    assert.ok(line.includes('Est. $1.09'), `expected cloud estimate, got: ${line}`);
+
+    // showCostForCloudProviders: false suppresses it entirely.
+    ctx.config.display.showCostForCloudProviders = false;
+    const hidden = stripAnsi(renderProjectLine(ctx));
+    assert.ok(!hidden.includes('Est. $'), 'estimate should be hidden when opted out');
+    assert.ok(!hidden.includes('Cost '), 'native cost should stay hidden for cloud providers');
   } finally {
     delete process.env.CLAUDE_CODE_USE_BEDROCK;
   }


### PR DESCRIPTION
**What it solves:** With `display.showCost` enabled, Bedrock/Vertex users saw nothing — the token estimate was suppressed for cloud providers even though their per-token pricing is identical to the direct API.

- `estimateSessionCost()` now runs for Bedrock/Vertex; the unreliable *native* total stays suppressed.
- `display.showCostForCloudProviders` (default **true**) to opt out.
- Falls back to stdin context `input_tokens` when a proxy reports `input_tokens: 0`.
- Estimate is labelled `Est.` to mark it as approximate.
- Unit tests included.

Closes #622