### PR TITLE
test: lock down usage and speed cache hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showResetLabel` | boolean | true | Show the `resets in` prefix before usage countdowns |
 | `display.timeFormat` | `relative` \| `absolute` \| `both` \| `elapsed` \| `elapsedAndAbsolute` | `relative` | How usage-window time is shown: countdown only (`resets in 2h 30m`), wall-clock reset (`resets at 14:30`), both, elapsed window percentage (`53% elapsed`), or elapsed plus wall-clock reset |
 | `display.sevenDayThreshold` | 0-100 | 80 | Show 7-day usage when >= threshold (0 = always) |
-| `display.externalUsagePath` | string | `""` | Optional path to a local usage snapshot file. When stdin `rate_limits` are present, only `balance_label` is appended; when they are missing, valid usage windows can be used as a fallback |
+| `display.externalUsagePath` | string | `""` | Optional absolute path to a local usage snapshot file. Relative paths are ignored. When stdin `rate_limits` are present, only `balance_label` is appended; when they are missing, valid usage windows can be used as a fallback |
 | `display.externalUsageWritePath` | string | `""` | Optional absolute `.json` path in an existing directory. When stdin `rate_limits` exists, ClaudeHUD writes a private snapshot for other local tools. Relative paths, non-json files, and missing parent directories are ignored |
 | `display.externalUsageFreshnessMs` | number | `300000` | Maximum allowed age for the external usage snapshot before it is ignored |
 | `display.showTokenBreakdown` | boolean | true | Show token details at high context (85%+) |
@@ -243,7 +243,7 @@ Set `display.usageValue` to `remaining` to show quota left instead of quota used
 
 ClaudeHUD prefers the official statusline stdin payload for rate-limit windows. If `display.externalUsagePath` points to a fresh local sidecar snapshot, ClaudeHUD can append its `balance_label` alongside stdin windows. If stdin `rate_limits` are missing, the same snapshot can provide fallback usage windows.
 
-The fallback snapshot must be fresh enough (`display.externalUsageFreshnessMs`) and include valid `updated_at`, plus a `five_hour` window, `seven_day` window, or `balance_label`. `balance_label` is optional text for prepaid provider balances; it is trimmed, length-limited, and sanitized before display. Invalid JSON, stale files, or invalid timestamps are ignored quietly.
+The fallback snapshot path must be absolute. The snapshot must be fresh enough (`display.externalUsageFreshnessMs`) and include valid `updated_at`, plus a `five_hour` window, `seven_day` window, or `balance_label`. `balance_label` is optional text for prepaid provider balances; it is trimmed, length-limited, and sanitized before display. Relative paths, invalid JSON, stale files, or invalid timestamps are ignored quietly.
 
 Set `display.externalUsageWritePath` if you want ClaudeHUD to write the official stdin `rate_limits` into a local snapshot for other tools. The path must be absolute, end in `.json`, and live in an existing directory. ClaudeHUD writes the file with private permissions and ignores invalid paths quietly.
 

--- a/tests/external-usage.test.js
+++ b/tests/external-usage.test.js
@@ -85,6 +85,11 @@ test('getUsageFromExternalSnapshot parses a fresh snapshot', async () => {
   }
 });
 
+test('getUsageFromExternalSnapshot ignores relative read paths', () => {
+  const usage = getUsageFromExternalSnapshot(makeConfig('usage.json'), Date.now());
+  assert.equal(usage, null);
+});
+
 test('writeExternalUsageSnapshot writes stdin rate limits to the configured path', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-external-usage-write-'));
   const filePath = path.join(dir, 'usage.json');

--- a/tests/speed-tracker.test.js
+++ b/tests/speed-tracker.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { getOutputSpeed } from '../dist/speed-tracker.js';
@@ -152,6 +152,12 @@ test('getOutputSpeed creates fallback cache under CLAUDE_CONFIG_DIR by default',
     const defaultCacheDir = path.join(tempHome, '.claude', 'plugins', 'claude-hud', 'speed-cache');
     assert.equal(existsSync(customCacheDir), true);
     assert.equal(existsSync(defaultCacheDir), false);
+    assert.equal((await stat(customCacheDir)).mode & 0o777, 0o700);
+
+    const cacheFiles = await readdir(customCacheDir);
+    const fileSizeCache = cacheFiles.find((name) => name.endsWith('.json.fs'));
+    assert.ok(fileSizeCache, `expected file-size cache in ${cacheFiles.join(', ')}`);
+    assert.equal((await stat(path.join(customCacheDir, fileSizeCache))).mode & 0o777, 0o600);
   } finally {
     restoreEnvVar('HOME', originalHome);
     restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
@@ -311,6 +317,12 @@ test('getOutputSpeed writes cache under CLAUDE_CONFIG_DIR by default', async () 
     const defaultCacheDir = path.join(tempHome, '.claude', 'plugins', 'claude-hud', 'speed-cache');
     assert.equal(existsSync(customCacheDir), true);
     assert.equal(existsSync(defaultCacheDir), false);
+    assert.equal((await stat(customCacheDir)).mode & 0o777, 0o700);
+
+    const cacheFiles = await readdir(customCacheDir);
+    const speedCache = cacheFiles.find((name) => name.endsWith('.json'));
+    assert.ok(speedCache, `expected speed cache in ${cacheFiles.join(', ')}`);
+    assert.equal((await stat(path.join(customCacheDir, speedCache))).mode & 0o777, 0o600);
   } finally {
     restoreEnvVar('HOME', originalHome);
     restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);


### PR DESCRIPTION
## Summary
- document that `display.externalUsagePath` must be absolute
- add a read-side test rejecting relative external usage paths
- assert `speed-cache` directories are `0700` and both token/file-size cache files are `0600`

## Validation
- `npm ci`
- `npm run build`
- `node --test tests/external-usage.test.js tests/speed-tracker.test.js`
- `npm test`
- `npm run test:coverage`
