### PR TITLE
fix: remove numeric count prefixes from environment line

### DIFF
--- a/src/render/lines/environment.ts
+++ b/src/render/lines/environment.ts
@@ -13,19 +13,19 @@ export function renderEnvironmentLine(ctx: RenderContext): string | null {
 
   if (showCounts && totalCounts >= threshold && totalCounts > 0) {
     if (ctx.claudeMdCount > 0) {
-      parts.push(`${ctx.claudeMdCount} CLAUDE.md`);
+      parts.push(`CLAUDE.md`);
     }
 
     if (ctx.rulesCount > 0) {
-      parts.push(`${ctx.rulesCount} ${t("label.rules")}`);
+      parts.push(`${t("label.rules")}`);
     }
 
     if (ctx.mcpCount > 0) {
-      parts.push(`${ctx.mcpCount} MCPs`);
+      parts.push(`MCPs`);
     }
 
     if (ctx.hooksCount > 0) {
-      parts.push(`${ctx.hooksCount} ${t("label.hooks")}`);
+      parts.push(`${t("label.hooks")}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Remove numeric count prefixes from the environment line in the HUD, showing only labels without numbers.

### Before
```
1 CLAUDE.md | 3 rules | 4 MCPs | 4 hooks
```

### After
```
CLAUDE.md | rules | MCPs | hooks
```

### Rationale
The presence indicator is sufficient information — knowing that rules, MCPs, and hooks exist is what matters. The exact count adds visual noise with low information value.

### Changes
- `src/render/lines/environment.ts`: Removed `${ctx.*Count}` prefixes (4 lines changed)

### Verification
- Build: `npm run build` passes
- Tests: `npm test` — 25/28 pass (3 existing failures unrelated to this change)