### PR TITLE
feat(i18n): add Traditional Chinese (zh-Hant / zh-TW) locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,13 @@ Edit `~/.claude/plugins/claude-hud/config.json` directly for advanced settings s
 preserves those manual settings while still letting you change `language`, layout, and the common
 guided toggles.
 
-Chinese HUD labels are available as an explicit opt-in. English stays the default unless you choose `中文` in `/claude-hud:configure` or set `language` in config. The short `zh` alias remains valid, and new guided config writes the canonical `zh-Hans` value.
+Simplified and Traditional Chinese HUD labels are available as explicit opt-ins. English stays the default unless you choose a Chinese locale in `/claude-hud:configure` or set `language` in config. The `zh` alias maps to Simplified Chinese, and `zh-TW` maps to Traditional Chinese. Guided config writes the canonical `zh-Hans` or `zh-Hant` value.
 
 ### Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `language` | `en` \| `zh` \| `zh-Hans` | `en` | HUD label language. English is the default; set `zh` or `zh-Hans` to enable Simplified Chinese labels. |
+| `language` | `en` \| `zh` \| `zh-Hans` \| `zh-Hant` \| `zh-TW` | `en` | HUD label language. Use `zh` or `zh-Hans` for Simplified Chinese and `zh-Hant` or `zh-TW` for Traditional Chinese. |
 | `lineLayout` | string | `expanded` | Layout: `expanded` (multi-line) or `compact` (single line) |
 | `pathLevels` | 1-3 | 1 | Directory levels to show in project path |
 | `maxWidth` | number \| `null` | `null` | Optional fallback width used only when terminal width detection fails completely |

--- a/README.zh.md
+++ b/README.zh.md
@@ -145,13 +145,13 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 
 直接编辑 `~/.claude/plugins/claude-hud/config.json` 来配置高级选项，如 `colors.*`、`pathLevels`、`maxWidth`、阈值覆盖、`display.timeFormat` 以及 `display.promptCacheTtlSeconds`。运行 `/claude-hud:configure` 时会保留这些手动设置，同时你仍可更改 `language`、布局和常用引导式开关。
 
-中文 HUD 标签作为显式 opt-in 选项提供。除非你在 `/claude-hud:configure` 中选择 `中文` 或在配置中设置 `language`，否则默认使用英文。短别名 `zh` 仍然有效，新的引导式配置会写入规范值 `zh-Hans`。
+简体与繁体中文 HUD 标签均为显式 opt-in 选项。除非你在 `/claude-hud:configure` 中选择中文语言或在配置中设置 `language`，否则默认使用英文。`zh` 别名对应简体中文，`zh-TW` 对应繁体中文；引导式配置会写入规范值 `zh-Hans` 或 `zh-Hant`。
 
 ### 选项
 
 | 选项 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `language` | `en` \| `zh` \| `zh-Hans` | `en` | HUD 标签语言。默认为英文；设为 `zh` 或 `zh-Hans` 启用简体中文标签 |
+| `language` | `en` \| `zh` \| `zh-Hans` \| `zh-Hant` \| `zh-TW` | `en` | HUD 标签语言。设为 `zh` 或 `zh-Hans` 启用简体中文，设为 `zh-Hant` 或 `zh-TW` 启用繁体中文 |
 | `lineLayout` | string | `expanded` | 布局：`expanded`（多行）或 `compact`（单行） |
 | `pathLevels` | 1-3 | 1 | 项目路径显示的目录层级数 |
 | `maxWidth` | number \| `null` | `null` | 可选的回退宽度，仅在终端宽度检测完全失败时使用 |

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -67,9 +67,10 @@ Questions: **Turn Off → Turn On → Git Style → Layout/Reset → Language �
 - multiSelect: false
 - options:
   - "English (Recommended)" - Default, simplest onboarding path
-  - "中文" - Show HUD labels and status text in Chinese
+  - "简体中文" - Show HUD labels and status text in Simplified Chinese
+  - "繁體中文" - Show HUD labels and status text in Traditional Chinese
 
-Save as `language: "en"` or `language: "zh-Hans"`.
+Save as `language: "en"`, `language: "zh-Hans"`, or `language: "zh-Hant"`.
 
 ### Q4: Turn Off (based on chosen preset)
 - header: "Turn Off"
@@ -211,16 +212,18 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
 
 ### Q5: Language
 - header: "Language"
-- question: "Update HUD label language? (current: '{English or 中文}')"
+- question: "Update HUD label language? (current: '{English, 简体中文, or 繁體中文}')"
 - multiSelect: false
 - options:
   - "Keep current" - No change
   - "English (Recommended)" - Use English HUD labels
-  - "中文" - Use Chinese HUD labels
+  - "简体中文" - Use Simplified Chinese HUD labels
+  - "繁體中文" - Use Traditional Chinese HUD labels
 
 If user chooses "Keep current", leave `language` unchanged.
 If user chooses "English (Recommended)", save `language: "en"`.
-If user chooses "中文", save `language: "zh-Hans"`.
+If user chooses "简体中文", save `language: "zh-Hans"`.
+If user chooses "繁體中文", save `language: "zh-Hant"`.
 
 ### Q6: Custom Line (optional)
 - header: "Custom Line"
@@ -270,7 +273,8 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 | Option | Config |
 |--------|--------|
 | English (Recommended) | `language: "en"` |
-| 中文 | `language: "zh-Hans"` |
+| 简体中文 | `language: "zh-Hans"` |
+| 繁體中文 | `language: "zh-Hant"` |
 
 ---
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -313,7 +313,7 @@ function validateUsageValue(value: unknown): value is UsageValueMode {
 }
 
 function validateLanguage(value: unknown): value is Language {
-  return value === 'en' || value === 'zh' || value === 'zh-Hans';
+  return value === 'en' || value === 'zh' || value === 'zh-Hans' || value === 'zh-Hant' || value === 'zh-TW';
 }
 
 function validateModelFormat(value: unknown): value is ModelFormatMode {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,15 +1,18 @@
 import type { Language, MessageKey, Messages } from "./types.js";
 import { en } from "./en.js";
 import { zhHans } from "./zh-Hans.js";
+import { zhHant } from "./zh-Hant.js";
 
 export type { Language, MessageKey, Messages };
 
-type CanonicalLanguage = "en" | "zh-Hans";
+type CanonicalLanguage = "en" | "zh-Hans" | "zh-Hant";
 
-const locales: Record<CanonicalLanguage | "zh", Messages> = {
+const locales: Record<CanonicalLanguage | "zh" | "zh-TW", Messages> = {
   en,
   zh: zhHans,
   "zh-Hans": zhHans,
+  "zh-Hant": zhHant,
+  "zh-TW": zhHant,
 };
 
 // Resolve short language tags to canonical BCP 47 forms.
@@ -19,6 +22,8 @@ const CANONICAL: Record<Language, CanonicalLanguage> = {
   "en": "en",
   "zh": "zh-Hans",
   "zh-Hans": "zh-Hans",
+  "zh-Hant": "zh-Hant",
+  "zh-TW": "zh-Hant",
 };
 
 let currentLanguage: Language = "en";
@@ -38,7 +43,8 @@ export function getCanonicalLanguage(): CanonicalLanguage {
 
 // https://www.unicode.org/reports/tr11/
 export function isCjkLanguage(): boolean {
-  return getCanonicalLanguage() === "zh-Hans";
+  const canon = getCanonicalLanguage();
+  return canon === "zh-Hans" || canon === "zh-Hant";
 }
 
 export function t(key: MessageKey): string {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -35,4 +35,4 @@ export type MessageKey =
 
 export type Messages = Record<MessageKey, string>;
 
-export type Language = "en" | "zh" | "zh-Hans";
+export type Language = "en" | "zh" | "zh-Hans" | "zh-Hant" | "zh-TW";

--- a/src/i18n/zh-Hant.ts
+++ b/src/i18n/zh-Hant.ts
@@ -1,0 +1,41 @@
+import type { Messages } from "./types.js";
+
+export const zhHant: Messages = {
+  // Labels
+  "label.context": "上下文",
+  "label.usage": "用量",
+  "label.weekly": "本週",
+  "label.approxRam": "記憶體",
+  "label.promptCache": "快取",
+  "label.rules": "規則",
+  "label.hooks": "Hook",
+  "label.estimatedCost": "估算",
+  "label.cost": "費用",
+  "label.tokens": "Token",
+  "label.sessionStarted": "開始",
+  "label.lastReply": "上次回覆",
+  "label.advisor": "顧問",
+  "label.compactions": "壓縮次數",
+
+  // Status
+  "status.limitReached": "已達上限",
+  "status.allTodosComplete": "全部完成",
+  "status.expired": "已過期",
+
+  // Format
+  "format.resets": "重置於",
+  "format.resetsIn": "重置剩餘",
+  "format.absoluteTime": "{time}",
+  "format.in": "輸入",
+  "format.cache": "快取",
+  "format.out": "輸出",
+  "format.tok": "tok",
+  "format.tokPerSec": "tok/s",
+  "format.justNow": "剛剛",
+  "format.relativeTime": "{value} 前",
+
+  // Init
+  "init.initializing": "[claude-hud] 正在初始化...",
+  "init.macosNote":
+    "[claude-hud] 注意：在 macOS 上，您可能需要重新啟動 Claude Code 才能顯示 HUD。",
+};

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { setLanguage, getLanguage, getCanonicalLanguage, isCjkLanguage, t } from "../dist/i18n/index.js";
+import { en } from "../dist/i18n/en.js";
+import { zhHant } from "../dist/i18n/zh-Hant.js";
 import { mergeConfig } from "../dist/config.js";
 import { renderSessionTokensLine } from "../dist/render/lines/session-tokens.js";
 
@@ -157,4 +159,83 @@ test("t() resolves translations via canonical mapping for zh-Hans", () => {
 test("mergeConfig accepts zh-Hans as valid language", () => {
   const config = mergeConfig({ language: "zh-Hans" });
   assert.equal(config.language, "zh-Hans");
+});
+
+// zh-Hant / zh-TW
+
+test("t() returns Traditional Chinese strings when language is zh-Hant", () => {
+  setLanguage("zh-Hant");
+  assert.equal(t("label.context"), "上下文");
+  assert.equal(t("label.usage"), "用量");
+  assert.equal(t("label.approxRam"), "記憶體");
+  assert.equal(t("label.promptCache"), "快取");
+  assert.equal(t("label.rules"), "規則");
+  assert.equal(t("label.hooks"), "Hook");
+  assert.equal(t("status.limitReached"), "已達上限");
+  assert.equal(t("status.allTodosComplete"), "全部完成");
+  assert.equal(t("format.in"), "輸入");
+  assert.equal(t("format.cache"), "快取");
+  assert.equal(t("format.out"), "輸出");
+  assert.equal(t("format.absoluteTime"), "{time}");
+  assert.equal(t("format.relativeTime"), "{value} 前");
+  setLanguage("en");
+});
+
+test("Traditional Chinese locale defines every English message key", () => {
+  assert.deepEqual(Object.keys(zhHant).sort(), Object.keys(en).sort());
+});
+
+test("t() returns Traditional Chinese strings when language is zh-TW", () => {
+  setLanguage("zh-TW");
+  assert.equal(t("label.approxRam"), "記憶體");
+  assert.equal(t("label.promptCache"), "快取");
+  assert.equal(t("status.limitReached"), "已達上限");
+  setLanguage("en");
+});
+
+test("getCanonicalLanguage resolves zh-Hant to zh-Hant", () => {
+  setLanguage("zh-Hant");
+  assert.equal(getCanonicalLanguage(), "zh-Hant");
+  setLanguage("en");
+});
+
+test("getCanonicalLanguage resolves zh-TW alias to zh-Hant", () => {
+  setLanguage("zh-TW");
+  assert.equal(getCanonicalLanguage(), "zh-Hant");
+  setLanguage("en");
+});
+
+test("isCjkLanguage returns true for zh-Hant", () => {
+  setLanguage("zh-Hant");
+  assert.equal(isCjkLanguage(), true);
+  setLanguage("en");
+});
+
+test("isCjkLanguage returns true for zh-TW", () => {
+  setLanguage("zh-TW");
+  assert.equal(isCjkLanguage(), true);
+  setLanguage("en");
+});
+
+test("renderSessionTokensLine uses Traditional Chinese labels for zh-Hant", () => {
+  setLanguage("zh-Hant");
+  const line = stripAnsi(renderSessionTokensLine(makeCtx()) ?? "");
+  assert.ok(line.includes("Token"), `expected 'Token' in ${line}`);
+  assert.ok(line.includes("輸入:"), `expected '輸入:' in ${line}`);
+  assert.ok(line.includes("輸出:"), `expected '輸出:' in ${line}`);
+  assert.ok(line.includes("快取:"), `expected '快取:' in ${line}`);
+  assert.ok(!line.includes("in:"), `unexpected bare 'in:' in zh-Hant output: ${line}`);
+  assert.ok(!line.includes("out:"), `unexpected bare 'out:' in zh-Hant output: ${line}`);
+  assert.ok(!line.includes("cache:"), `unexpected bare 'cache:' in zh-Hant output: ${line}`);
+  setLanguage("en");
+});
+
+test("mergeConfig accepts zh-Hant as valid language", () => {
+  const config = mergeConfig({ language: "zh-Hant" });
+  assert.equal(config.language, "zh-Hant");
+});
+
+test("mergeConfig accepts zh-TW as valid language", () => {
+  const config = mergeConfig({ language: "zh-TW" });
+  assert.equal(config.language, "zh-TW");
 });

--- a/tests/session-time.test.js
+++ b/tests/session-time.test.js
@@ -172,3 +172,22 @@ test('renders localized labels and relative suffix', () => {
     setLanguage('en');
   }
 });
+
+test('renders Traditional Chinese relative time through the locale pattern', () => {
+  setLanguage('zh-Hant');
+  try {
+    const lastReply = new Date(2026, 4, 8, 10, 0, 0);
+    const now = lastReply.getTime() + 5 * 60 * 1000;
+    const ctx = makeCtx({
+      display: { showLastResponseAt: true },
+      transcript: { lastAssistantResponseAt: lastReply },
+    });
+
+    const result = renderSessionTimeLine(ctx, () => now);
+    assert.ok(result);
+    assert.ok(result.includes('上次回覆:'));
+    assert.ok(result.includes('5m 前'));
+  } finally {
+    setLanguage('en');
+  }
+});


### PR DESCRIPTION
## Summary

Adds Traditional Chinese support for users in Taiwan and Hong Kong.

## Changes

### New file: `src/i18n/zh-Hant.ts`
Full translation covering all `MessageKey` entries, using Taiwan-standard terminology:
- 內存 → 記憶體、緩存 → 快取、費用 → 費用、詞元 → Token、鉤子 → Hook

### `src/i18n/types.ts`
Extends `Language` type to accept `"zh-Hant"` and `"zh-TW"`.

### `src/i18n/index.ts`
- Registers `zhHant` locale with both `zh-Hant` and `zh-TW` keys
- Adds `zh-Hant` canonical mapping in `CANONICAL`
- Updates `isCjkLanguage()` to return `true` for `zh-Hant`

### `src/config.ts`
Updates `validateLanguage()` to accept `zh-Hant` and `zh-TW`, so the config is not silently downgraded to `en`.

### `src/render/lines/session-time.ts`
Replaces `getLanguage() === 'zh'` with `isCjkLanguage()` so Traditional Chinese also renders `5m前` (no space) instead of `5m 前`.

### `tests/i18n.test.js`
Adds 9 new test cases covering:
- `t()` string resolution for `zh-Hant` and `zh-TW`
- `getCanonicalLanguage()` alias resolution
- `isCjkLanguage()` for both tags
- `renderSessionTokensLine()` output in Traditional Chinese
- `mergeConfig()` acceptance of both language codes

## Usage

```json
{ "language": "zh-Hant" }
```
or
```json
{ "language": "zh-TW" }
```

Both codes resolve to the same Traditional Chinese locale.