### PR TITLE
fix: Fix duplicate counting issue in assistant message usage statistics

### DIFF
--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -22,6 +22,7 @@ interface TranscriptLine {
   // set. Holds the canonical advisor model ID (e.g. "claude-opus-4-7").
   advisorModel?: string;
   message?: {
+    id?: string;
     content?: ContentBlock[];
     usage?: {
       input_tokens?: number;
@@ -340,7 +341,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
     cacheCreationTokens: 0,
     cacheReadTokens: 0,
   };
-  let lastUsageKey: string | undefined;
+  const seenMessageIds = new Set<string>();
 
   let parsedCleanly = false;
 
@@ -353,7 +354,6 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
 
     for await (const line of rl) {
       if (!line.trim()) {
-        lastUsageKey = undefined;
         continue;
       }
 
@@ -379,19 +379,18 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
         }
         // Accumulate token usage from assistant messages.
         // Claude Code can write the same API response to the transcript 2-3 times
-        // consecutively (dual-logging). Skip consecutive duplicates to avoid inflating counts.
+        // (dual-logging). Deduplicate by message.id — the API-response-level unique
+        // identifier that is stable across repeated transcript writes.
         if (entry.type === 'assistant' && entry.message?.usage) {
-          const usage = entry.message.usage;
-          const key = `${usage.input_tokens}|${usage.output_tokens}|${usage.cache_creation_input_tokens}|${usage.cache_read_input_tokens}`;
-          if (key !== lastUsageKey) {
+          const msgId = entry.message.id;
+          if (!msgId || !seenMessageIds.has(msgId)) {
+            if (msgId) seenMessageIds.add(msgId);
+            const usage = entry.message.usage;
             sessionTokens.inputTokens += normalizeTokenCount(usage.input_tokens);
             sessionTokens.outputTokens += normalizeTokenCount(usage.output_tokens);
             sessionTokens.cacheCreationTokens += normalizeTokenCount(usage.cache_creation_input_tokens);
             sessionTokens.cacheReadTokens += normalizeTokenCount(usage.cache_read_input_tokens);
           }
-          lastUsageKey = key;
-        } else {
-          lastUsageKey = undefined;
         }
         // Track Claude Code's compact_boundary marker. Both manual (/compact)
         // and auto compaction emit this system entry with compactMetadata; we
@@ -425,7 +424,6 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
         }
         processEntry(entry, toolMap, skillSet, mcpServerSet, agentMap, taskIdToIndex, latestTodos, result);
       } catch (err) {
-        lastUsageKey = undefined;
         debug('Skipping malformed transcript line:', err instanceof Error ? err.message : err);
       }
     }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -22,7 +22,7 @@ interface TranscriptLine {
   // set. Holds the canonical advisor model ID (e.g. "claude-opus-4-7").
   advisorModel?: string;
   message?: {
-    id?: string;
+    id?: unknown;
     content?: ContentBlock[];
     usage?: {
       input_tokens?: number;
@@ -86,9 +86,11 @@ interface TranscriptCacheFile {
   data: SerializedTranscriptData;
 }
 
-const TRANSCRIPT_CACHE_VERSION = 9;
+const TRANSCRIPT_CACHE_VERSION = 10;
 const MCP_TOOL_NAME_PATTERN = /^mcp__(.+?)__(.+)$/;
 const ACTIVITY_NAME_MAX_LEN = 64;
+const MESSAGE_ID_MAX_LEN = 128;
+const SEEN_MESSAGE_IDS_MAX = 4096;
 
 // Hard cap on the advisor model ID captured from the transcript. Real Claude
 // model IDs (e.g. "claude-haiku-4-5-20251001") fit comfortably under this; the
@@ -104,6 +106,22 @@ function normalizeTokenCount(value: unknown): number {
   }
 
   return Math.max(0, Math.trunc(value));
+}
+
+function normalizeMessageId(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 && value.length <= MESSAGE_ID_MAX_LEN
+    ? value
+    : null;
+}
+
+function rememberMessageId(seenMessageIds: Set<string>, messageId: string): void {
+  if (seenMessageIds.size >= SEEN_MESSAGE_IDS_MAX) {
+    const oldest = seenMessageIds.values().next().value;
+    if (oldest !== undefined) {
+      seenMessageIds.delete(oldest);
+    }
+  }
+  seenMessageIds.add(messageId);
 }
 
 function normalizeSessionTokens(tokens: unknown): SessionTokenUsage | undefined {
@@ -342,6 +360,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
     cacheReadTokens: 0,
   };
   const seenMessageIds = new Set<string>();
+  let lastUsageKey: string | undefined;
 
   let parsedCleanly = false;
 
@@ -354,6 +373,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
 
     for await (const line of rl) {
       if (!line.trim()) {
+        lastUsageKey = undefined;
         continue;
       }
 
@@ -379,18 +399,37 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
         }
         // Accumulate token usage from assistant messages.
         // Claude Code can write the same API response to the transcript 2-3 times
-        // (dual-logging). Deduplicate by message.id — the API-response-level unique
-        // identifier that is stable across repeated transcript writes.
+        // (dual-logging). Prefer the API-response-level message.id so duplicates
+        // can be removed even when another record appears between them. Only
+        // bounded string IDs are retained, and the set is capped to keep a
+        // malformed transcript from growing memory without limit. Records with
+        // missing or invalid IDs keep the previous consecutive usage-fingerprint
+        // fallback.
         if (entry.type === 'assistant' && entry.message?.usage) {
-          const msgId = entry.message.id;
-          if (!msgId || !seenMessageIds.has(msgId)) {
-            if (msgId) seenMessageIds.add(msgId);
-            const usage = entry.message.usage;
+          const usage = entry.message.usage;
+          const msgId = normalizeMessageId(entry.message.id);
+          let shouldCount = false;
+
+          if (msgId !== null) {
+            lastUsageKey = undefined;
+            if (!seenMessageIds.has(msgId)) {
+              rememberMessageId(seenMessageIds, msgId);
+              shouldCount = true;
+            }
+          } else {
+            const usageKey = `${usage.input_tokens}|${usage.output_tokens}|${usage.cache_creation_input_tokens}|${usage.cache_read_input_tokens}`;
+            shouldCount = usageKey !== lastUsageKey;
+            lastUsageKey = usageKey;
+          }
+
+          if (shouldCount) {
             sessionTokens.inputTokens += normalizeTokenCount(usage.input_tokens);
             sessionTokens.outputTokens += normalizeTokenCount(usage.output_tokens);
             sessionTokens.cacheCreationTokens += normalizeTokenCount(usage.cache_creation_input_tokens);
             sessionTokens.cacheReadTokens += normalizeTokenCount(usage.cache_read_input_tokens);
           }
+        } else {
+          lastUsageKey = undefined;
         }
         // Track Claude Code's compact_boundary marker. Both manual (/compact)
         // and auto compaction emit this system entry with compactMetadata; we
@@ -424,6 +463,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
         }
         processEntry(entry, toolMap, skillSet, mcpServerSet, agentMap, taskIdToIndex, latestTodos, result);
       } catch (err) {
+        lastUsageKey = undefined;
         debug('Skipping malformed transcript line:', err instanceof Error ? err.message : err);
       }
     }

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -608,10 +608,11 @@ test('parseTranscript accumulates session token usage from assistant messages', 
   }
 });
 
-test('parseTranscript counts adjacent duplicate assistant usage once', async () => {
+test('parseTranscript deduplicates adjacent duplicate assistant usage by message.id', async () => {
   const usageEntry = {
     type: 'assistant',
     message: {
+      id: 'msg-001',
       usage: {
         input_tokens: 100,
         output_tokens: 25,
@@ -634,10 +635,11 @@ test('parseTranscript counts adjacent duplicate assistant usage once', async () 
   });
 });
 
-test('parseTranscript counts identical assistant usage separated by another line twice', async () => {
+test('parseTranscript deduplicates non-consecutive duplicate assistant usage by message.id', async () => {
   const usageEntry = {
     type: 'assistant',
     message: {
+      id: 'msg-002',
       usage: {
         input_tokens: 100,
         output_tokens: 25,
@@ -654,10 +656,10 @@ test('parseTranscript counts identical assistant usage separated by another line
   ]);
 
   assert.deepEqual(result.sessionTokens, {
-    inputTokens: 200,
-    outputTokens: 50,
-    cacheCreationTokens: 20,
-    cacheReadTokens: 10,
+    inputTokens: 100,
+    outputTokens: 25,
+    cacheCreationTokens: 10,
+    cacheReadTokens: 5,
   });
 });
 

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -663,6 +663,110 @@ test('parseTranscript deduplicates non-consecutive duplicate assistant usage by 
   });
 });
 
+test('parseTranscript counts different message IDs with identical usage', async () => {
+  const usage = {
+    input_tokens: 100,
+    output_tokens: 25,
+    cache_creation_input_tokens: 10,
+    cache_read_input_tokens: 5,
+  };
+
+  const result = await parseTempTranscript('session-tokens-distinct-ids.jsonl', [
+    { type: 'assistant', message: { id: 'msg-a', usage } },
+    { type: 'assistant', message: { id: 'msg-b', usage } },
+  ]);
+
+  assert.deepEqual(result.sessionTokens, {
+    inputTokens: 200,
+    outputTokens: 50,
+    cacheCreationTokens: 20,
+    cacheReadTokens: 10,
+  });
+});
+
+test('parseTranscript deduplicates adjacent idless usage with the legacy fingerprint fallback', async () => {
+  const entry = {
+    type: 'assistant',
+    message: {
+      usage: {
+        input_tokens: 100,
+        output_tokens: 25,
+        cache_creation_input_tokens: 10,
+        cache_read_input_tokens: 5,
+      },
+    },
+  };
+
+  const result = await parseTempTranscript('session-tokens-idless-adjacent.jsonl', [entry, entry]);
+
+  assert.deepEqual(result.sessionTokens, {
+    inputTokens: 100,
+    outputTokens: 25,
+    cacheCreationTokens: 10,
+    cacheReadTokens: 5,
+  });
+});
+
+test('parseTranscript treats malformed and oversized message IDs as idless', async () => {
+  const usage = {
+    input_tokens: 100,
+    output_tokens: 25,
+    cache_creation_input_tokens: 10,
+    cache_read_input_tokens: 5,
+  };
+  const objectIdEntry = {
+    type: 'assistant',
+    message: { id: { nested: 'payload' }, usage },
+  };
+  const oversizedIdEntry = {
+    type: 'assistant',
+    message: { id: 'x'.repeat(129), usage },
+  };
+  const nonStringIdEntry = {
+    type: 'assistant',
+    message: { id: 42, usage },
+  };
+
+  const result = await parseTempTranscript('session-tokens-invalid-ids.jsonl', [
+    objectIdEntry,
+    objectIdEntry,
+    { type: 'user', timestamp: '2024-01-01T00:00:01.000Z' },
+    oversizedIdEntry,
+    oversizedIdEntry,
+    { type: 'user', timestamp: '2024-01-01T00:00:02.000Z' },
+    nonStringIdEntry,
+    nonStringIdEntry,
+  ]);
+
+  assert.deepEqual(result.sessionTokens, {
+    inputTokens: 300,
+    outputTokens: 75,
+    cacheCreationTokens: 30,
+    cacheReadTokens: 15,
+  });
+});
+
+test('parseTranscript bounds retained message IDs', async () => {
+  const entries = Array.from({ length: 4097 }, (_, index) => ({
+    type: 'assistant',
+    message: {
+      id: `msg-${index}`,
+      usage: { input_tokens: 1 },
+    },
+  }));
+  entries.push({
+    type: 'assistant',
+    message: {
+      id: 'msg-0',
+      usage: { input_tokens: 1 },
+    },
+  });
+
+  const result = await parseTempTranscript('session-tokens-bounded-message-ids.jsonl', entries);
+
+  assert.equal(result.sessionTokens?.inputTokens, 4098);
+});
+
 test('parseTranscript records the most recent compact_boundary and postTokens', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-'));
   const filePath = path.join(dir, 'compact-boundary.jsonl');


### PR DESCRIPTION
## Summary

## Testing

- [ ] `npm test`
- [ ] `npm run test:coverage`

## Checklist

- [✅ ] Tests updated or not needed
- [ ] Docs updated if behavior changed


type=assistant  msgId=ef28bb51  TaskCreate 的响应 (in=10241 out=238 cr=23296)
type=assistant  msgId=ef28bb51  ← 同一份，dual-log
type=user       role=user  content=[{type:"tool_result", tool_use_id:"call_00_uIDTmm...", content:"Task #1 created"}]
type=assistant  msgId=ef28bb51  ← 同一份，但被行28隔开，旧方法漏判