### PR TITLE
refactor(i18n): let locales own layout via a tiny interpolate() helper

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -25,14 +25,14 @@ export const en: Messages = {
   // Format
   "format.resets": "resets",
   "format.resetsIn": "resets in",
-  "format.at": "at",
+  "format.absoluteTime": "at {time}",
   "format.in": "in",
   "format.cache": "cache",
   "format.out": "out",
   "format.tok": "tok",
   "format.tokPerSec": "tok/s",
   "format.justNow": "just now",
-  "format.ago": "ago",
+  "format.relativeTime": "{value} ago",
 
   // Init
   "init.initializing": "[claude-hud] Initializing...",

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -45,3 +45,10 @@ export function t(key: MessageKey): string {
   const canon = getCanonicalLanguage();
   return locales[canon]?.[key] ?? locales.en[key] ?? key;
 }
+
+// Minimal named-placeholder interpolation. Layout that varies by language
+// (spacing, affix position) lives in each locale's pattern string rather than in
+// render code. Unknown placeholders render as empty string (kept lenient).
+export function interpolate(pattern: string, params: Record<string, string | number>): string {
+  return pattern.replace(/\{(\w+)\}/g, (_, k) => String(params[k] ?? ""));
+}

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -21,14 +21,14 @@ export type MessageKey =
   // Format
   | "format.resets"
   | "format.resetsIn"
-  | "format.at"
+  | "format.absoluteTime"
   | "format.in"
   | "format.cache"
   | "format.out"
   | "format.tok"
   | "format.tokPerSec"
   | "format.justNow"
-  | "format.ago"
+  | "format.relativeTime"
   // Init
   | "init.initializing"
   | "init.macosNote";

--- a/src/i18n/zh-Hans.ts
+++ b/src/i18n/zh-Hans.ts
@@ -25,14 +25,14 @@ export const zhHans: Messages = {
   // Format
   "format.resets": "重置于",
   "format.resetsIn": "重置剩余",
-  "format.at": "",
+  "format.absoluteTime": "{time}",
   "format.in": "输入",
   "format.cache": "缓存",
   "format.out": "输出",
   "format.tok": "词元",
   "format.tokPerSec": "tok/s",
   "format.justNow": "刚刚",
-  "format.ago": "前",
+  "format.relativeTime": "{value} 前",
 
   // Init
   "init.initializing": "[claude-hud] 正在初始化...",

--- a/src/render/format-reset-time.ts
+++ b/src/render/format-reset-time.ts
@@ -1,5 +1,5 @@
 import type { TimeFormatMode } from '../config.js';
-import { t } from '../i18n/index.js';
+import { interpolate, t } from '../i18n/index.js';
 
 /**
  * Formats a usage-window reset timestamp for display in the HUD.
@@ -54,18 +54,15 @@ function formatRelative(diffMs: number): string {
 }
 
 function formatAbsolute(resetAt: Date, now: Date): string {
-  // The "at" prefix is i18n-aware. Locales that bake the preposition into
-  // "format.resets" (e.g. zh: "重置于") set "format.at" to "" so the time
-  // is returned bare ("14:30") and the preposition is supplied by the caller.
-  const at = t('format.at');
-  const prefix = at ? `${at} ` : '';
+  // The preposition + spacing live in each locale's "format.absoluteTime"
+  // pattern (en: "at {time}", zh: "{time}" — bare, preposition baked elsewhere).
   const timeStr = resetAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
   // Show the date only when the reset falls on a different calendar day
   if (resetAt.toDateString() === now.toDateString()) {
-    return `${prefix}${timeStr}`;
+    return interpolate(t('format.absoluteTime'), { time: timeStr });
   }
 
   const dateStr = resetAt.toLocaleDateString([], { month: 'short', day: 'numeric' });
-  return `${prefix}${dateStr} ${timeStr}`;
+  return interpolate(t('format.absoluteTime'), { time: `${dateStr} ${timeStr}` });
 }

--- a/src/render/lines/session-time.ts
+++ b/src/render/lines/session-time.ts
@@ -1,6 +1,6 @@
 import type { RenderContext } from '../../types.js';
 import { label } from '../colors.js';
-import { getLanguage, t } from '../../i18n/index.js';
+import { interpolate, t } from '../../i18n/index.js';
 
 function pad(n: number): string {
   return n < 10 ? `0${n}` : `${n}`;
@@ -20,10 +20,7 @@ function formatRelativeTime(ms: number): string {
     return t('format.justNow');
   }
 
-  const withAgo = (value: string): string => {
-    const ago = t('format.ago');
-    return getLanguage() === 'zh' ? `${value}${ago}` : `${value} ${ago}`;
-  };
+  const withAgo = (value: string): string => interpolate(t('format.relativeTime'), { value });
 
   const seconds = Math.floor(ms / 1000);
   if (seconds < 60) {

--- a/tests/session-time.test.js
+++ b/tests/session-time.test.js
@@ -167,7 +167,7 @@ test('renders localized labels and relative suffix', () => {
     assert.ok(result);
     assert.ok(result.includes('开始:'));
     assert.ok(result.includes('上次回复:'));
-    assert.ok(result.includes('5m前'));
+    assert.ok(result.includes('5m 前'));
   } finally {
     setLanguage('en');
   }


### PR DESCRIPTION
## Summary

Layout that varies by language (spacing, affix position) is currently hardcoded in render code rather than owned by the locale. Two existing examples:

- `session-time.ts` hardcodes the relative-time suffix spacing behind a `getLanguage() === 'zh'` branch.
- `format-reset-time.ts` uses an empty-string key (`format.at: ""`) as a workaround so locales that bake the preposition elsewhere get a bare time.

This adds a minimal named-placeholder `interpolate()` helper so each locale's pattern string owns its own layout, and migrates those two spots as the first applications:

- **`interpolate()`** (`src/i18n/index.ts`): named `{x}` substitution only (no plural/select for now); unknown placeholders render as empty string.
- **Relative time**: `format.ago` → `format.relativeTime` (`"{value} ago"` / `"{value} 前"`), dropping the `getLanguage() === 'zh'` branch. This also fixes an inconsistency: the same language rendered `5m前` or `5m 前` depending on whether the stored tag was `zh` or `zh-Hans` (the latter is what the configure command saves); it is now consistently `5m 前`. `en` unchanged.
- **Absolute reset time**: `format.at` → `format.absoluteTime` (`"at {time}"` / `"{time}"`), removing the empty-string-key workaround; the preposition and spacing now live in the locale pattern.

Because these are key renames in the shared `MessageKey` type, every locale file updates to the new keys (`en` and `zh-Hans`) — this is structural, not a wording change. `en` renders identically (`5m ago`, `at 14:30`); `zh-Hans` changes only the relative-time spacing noted above (`5m前` → `5m 前`). No other locale strings change.

## Why a helper, not `isCjkLanguage()`?

The minimal fix looks like swapping `getLanguage() === 'zh'` for `isCjkLanguage()`. But a boolean CJK branch can only toggle one binary decision (space or no space) — it cannot handle word **order**. A named placeholder lets the locale decide where the value goes, with no code branch. For example, a phrase like `resets in {time}` could become `{time} 後重置` in another language (the value moves to the front) — purely in the pattern. The same mechanism makes future locales pure data, with no render-code changes.

## Testing

- [x] `npm test`
- [x] `npm run test:coverage`

Updated `tests/session-time.test.js` (zh suffix is now `5m 前`).

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed
