### PR TITLE
feat: add opt-in SSH targets element (display.showSsh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Add `display.showSsh` (opt-in) — a session-scoped `ssh` element that shows the SSH destinations the session connected to, parsed from `ssh …` Bash commands in the transcript. Includes the main agent plus up to 3 subagents (read from `<session>/subagents/*.jsonl`), one `host:port` per source, most recent first, e.g. `⚡ SSH main 44.245.72.210:22 · sub#a4ad71 10.0.0.5:2222`.
+
 ## [0.3.0] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `pathLevels` | 1-3 | 1 | Directory levels to show in project path |
 | `maxWidth` | number \| `null` | `null` | Optional fallback width used only when terminal width detection fails completely |
 | `forceMaxWidth` | boolean | false | Always use `maxWidth` when it is set, even if terminal width detection returns a smaller value |
-| `elementOrder` | string[] | `["project","addedDirs","context","usage","promptCache","memory","environment","tools","skills","mcp","agents","todos","sessionTime"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. Existing configs keep their explicit order until updated. |
+| `elementOrder` | string[] | `["project","addedDirs","context","usage","promptCache","memory","environment","tools","skills","mcp","ssh","agents","todos","sessionTime"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. Existing configs keep their explicit order until updated. |
 | `display.mergeGroups` | string[][] | `[["context","usage"]]` | Expanded-mode groups that should share a line when adjacent. Set `[]` to disable merged lines. |
 | `gitStatus.enabled` | boolean | true | Show git branch in HUD |
 | `gitStatus.showDirty` | boolean | true | Show `*` for uncommitted changes |
@@ -197,6 +197,7 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showTools` | boolean | false | Show tools activity line |
 | `display.showSkills` | boolean | false | Show active Skills detected from `Skill` tool invocations |
 | `display.showMcp` | boolean | false | Show active MCP servers detected from `mcp__server__tool` invocations |
+| `display.showSsh` | boolean | false | Show SSH destinations this session connected to, parsed from `ssh …` Bash commands in the transcript. Session-scoped: the main agent plus up to 3 subagents (their own transcripts), one `host:port` per source, most recent first, e.g. `⚡ SSH main 44.245.72.210:22 · sub#a4ad71 10.0.0.5:2222` |
 | `display.toolNameMaxLength` | number | `0` | Maximum displayed tool-name length. `0` keeps full names; MCP names may shorten to their final segment when truncating |
 | `display.toolsMaxVisible` | number | `4` | Maximum completed tools shown on the tools line. `0` means unlimited |
 | `display.showAgents` | boolean | false | Show agents activity line |

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,7 @@ export type HudElement =
   | 'tools'
   | 'skills'
   | 'mcp'
+  | 'ssh'
   | 'agents'
   | 'todos'
   | 'sessionTime';
@@ -80,6 +81,7 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'tools',
   'skills',
   'mcp',
+  'ssh',
   'agents',
   'todos',
   'sessionTime',
@@ -128,6 +130,10 @@ export interface HudConfig {
     showTools: boolean;
     showSkills: boolean;
     showMcp: boolean;
+    // Show SSH destinations connected to this session (main agent + subagents),
+    // parsed from `ssh ...` Bash commands in the transcript. Opt-in. See
+    // src/ssh-targets.ts and src/render/ssh-line.ts.
+    showSsh: boolean;
     toolNameMaxLength: number;
     toolsMaxVisible: number;
     showAgents: boolean;
@@ -216,6 +222,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showTools: false,
     showSkills: false,
     showMcp: false,
+    showSsh: false,
     toolNameMaxLength: 0,
     toolsMaxVisible: 4,
     showAgents: false,
@@ -611,6 +618,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showMcp: typeof migrated.display?.showMcp === 'boolean'
       ? migrated.display.showMcp
       : DEFAULT_CONFIG.display.showMcp,
+    showSsh: typeof migrated.display?.showSsh === 'boolean'
+      ? migrated.display.showSsh
+      : DEFAULT_CONFIG.display.showSsh,
     toolNameMaxLength: validateNonNegativeInteger(
       migrated.display?.toolNameMaxLength,
       DEFAULT_CONFIG.display.toolNameMaxLength,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { readStdin, getUsageFromStdin } from "./stdin.js";
 import { parseTranscript } from "./transcript.js";
+import { collectSshTargets } from "./ssh-targets.js";
 import { render } from "./render/index.js";
 import { countConfigs } from "./config-reader.js";
 import { getGitStatus } from "./git.js";
@@ -23,6 +24,7 @@ export type MainDeps = {
   getUsageFromExternalSnapshot: typeof getUsageFromExternalSnapshot;
   writeExternalUsageSnapshot: typeof writeExternalUsageSnapshot;
   parseTranscript: typeof parseTranscript;
+  collectSshTargets: typeof collectSshTargets;
   countConfigs: typeof countConfigs;
   getGitStatus: typeof getGitStatus;
   loadConfig: typeof loadConfig;
@@ -64,6 +66,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     getUsageFromExternalSnapshot,
     writeExternalUsageSnapshot,
     parseTranscript,
+    collectSshTargets,
     countConfigs,
     getGitStatus,
     loadConfig,
@@ -106,6 +109,13 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
 
     const config = await deps.loadConfig();
     setLanguage(config.language);
+
+    // SSH targets are opt-in and read extra files (the session's subagent
+    // transcripts), so only gather them when the element is enabled.
+    if (config.display.showSsh) {
+      transcript.sshTargets = deps.collectSshTargets(transcriptPath);
+    }
+
     const gitStatus = config.gitStatus.enabled
       ? await deps.getGitStatus(stdin.cwd)
       : null;

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -4,6 +4,7 @@ import type { RenderContext } from '../types.js';
 import { renderSessionLine } from './session-line.js';
 import { renderToolsLine } from './tools-line.js';
 import { renderSkillsLine, renderMcpLine } from './skills-mcp-line.js';
+import { renderSshLine } from './ssh-line.js';
 import { renderAgentsLine } from './agents-line.js';
 import { renderTodosLine } from './todos-line.js';
 import {
@@ -308,7 +309,7 @@ function makeSeparator(length: number): string {
   return dim('─'.repeat(repeats));
 }
 
-const ACTIVITY_ELEMENTS = new Set<HudElement>(['tools', 'skills', 'mcp', 'agents', 'todos']);
+const ACTIVITY_ELEMENTS = new Set<HudElement>(['tools', 'skills', 'mcp', 'ssh', 'agents', 'todos']);
 
 function buildMergeGroupLookup(mergeGroups: HudElement[][]): Map<HudElement, Set<HudElement>> {
   const lookup = new Map<HudElement, Set<HudElement>>();
@@ -369,6 +370,13 @@ function collectActivityLines(ctx: RenderContext): string[] {
     }
   }
 
+  if (display?.showSsh === true) {
+    const sshLine = renderSshLine(ctx);
+    if (sshLine) {
+      activityLines.push(sshLine);
+    }
+  }
+
   if (display?.showAgents !== false) {
     const agentsLine = renderAgentsLine(ctx);
     if (agentsLine) {
@@ -415,6 +423,8 @@ function renderElementLine(
       return display?.showSkills === true ? renderSkillsLine(ctx) : null;
     case 'mcp':
       return display?.showMcp === true ? renderMcpLine(ctx) : null;
+    case 'ssh':
+      return display?.showSsh === true ? renderSshLine(ctx) : null;
     case 'agents':
       return display?.showAgents === false ? null : renderAgentsLine(ctx);
     case 'todos':

--- a/src/render/ssh-line.ts
+++ b/src/render/ssh-line.ts
@@ -1,0 +1,35 @@
+import type { RenderContext } from '../types.js';
+import { cyan, green, label } from './colors.js';
+import { sanitizeDisplayText } from '../utils/sanitize.js';
+
+const SHORT_ID_LEN = 6;
+
+/**
+ * Render the SSH element: the session's SSH destinations, one per source —
+ * the main agent first, then subagents (each tagged `sub#<short-id>`) — joined
+ * with a middle dot. Returns null when disabled or when no targets were found.
+ *
+ *   ⚡ SSH main 44.245.72.210:22 · sub#a4ad71 10.0.0.5:2222
+ */
+export function renderSshLine(ctx: RenderContext): string | null {
+  if (ctx.config?.display?.showSsh !== true) {
+    return null;
+  }
+
+  const targets = ctx.transcript.sshTargets ?? [];
+  if (targets.length === 0) {
+    return null;
+  }
+
+  const colors = ctx.config?.colors;
+  const parts = targets.map(target => {
+    const hostPort = cyan(`${sanitizeDisplayText(target.host)}:${target.port}`);
+    if (target.source === 'subagent') {
+      const shortId = sanitizeDisplayText(target.agentId ?? '').slice(0, SHORT_ID_LEN);
+      return `${label(`sub#${shortId}`, colors)} ${hostPort}`;
+    }
+    return `${label('main', colors)} ${hostPort}`;
+  });
+
+  return `${green('⚡')} SSH ${parts.join(' · ')}`;
+}

--- a/src/ssh-targets.ts
+++ b/src/ssh-targets.ts
@@ -1,0 +1,257 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createDebug } from './debug.js';
+import type { SshTarget } from './types.js';
+
+const debug = createDebug('ssh-targets');
+
+/** Read at most this many bytes from the end of each transcript. */
+const TAIL_BYTES = 1024 * 1024;
+/** Show at most this many subagent sources. */
+const MAX_SUBAGENTS = 3;
+/** Never stat/read more than this many subagent files, newest first. */
+const MAX_SUBAGENT_FILES = 20;
+const DEFAULT_PORT = 22;
+
+/**
+ * ssh options that consume the following token as their value, so the value is
+ * not mistaken for the destination host. `-p` is handled separately (port).
+ */
+const VALUE_OPTS = new Set([
+  '-i', '-o', '-F', '-l', '-b', '-c', '-D', '-e', '-I', '-J',
+  '-L', '-m', '-O', '-Q', '-R', '-S', '-W', '-w', '-B',
+]);
+
+interface HostPort {
+  host: string;
+  port: number;
+}
+
+function normalizePort(value: string): number {
+  const n = Number.parseInt(value, 10);
+  return Number.isInteger(n) && n > 0 && n < 65536 ? n : DEFAULT_PORT;
+}
+
+function isValidHost(host: string): boolean {
+  if (/^(?:\d{1,3}\.){3}\d{1,3}$/.test(host)) {
+    return host.split('.').every(octet => Number(octet) <= 255);
+  }
+  // Require at least one dot so bare command words / aliases are not treated as hosts.
+  return /^[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+$/.test(host);
+}
+
+function parseInvocation(args: string): HostPort | null {
+  const tokens = args.split(/\s+/).filter(Boolean);
+  let port = DEFAULT_PORT;
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const tok = tokens[i];
+
+    if (tok === '-p' && tokens[i + 1] !== undefined) {
+      port = normalizePort(tokens[i + 1]);
+      i += 1;
+      continue;
+    }
+    const attached = /^-p(\d{1,5})$/.exec(tok);
+    if (attached) {
+      port = normalizePort(attached[1]);
+      continue;
+    }
+    if (VALUE_OPTS.has(tok)) {
+      i += 1; // skip this option's value
+      continue;
+    }
+    if (tok.startsWith('-')) {
+      continue; // valueless flag (e.g. -t, -v) or attached option (e.g. -oFoo=bar)
+    }
+
+    // First non-option token is the [user@]host destination.
+    const at = tok.lastIndexOf('@');
+    const host = at >= 0 ? tok.slice(at + 1) : tok;
+    return isValidHost(host) ? { host, port } : null;
+  }
+
+  return null;
+}
+
+/**
+ * Parse the SSH destination from a single shell command string.
+ *
+ * Splits on shell separators and inspects each segment so `echo ssh x` and
+ * remote-command arguments are not misread as an ssh invocation. Requires
+ * whitespace after `ssh`, so `ssh-keygen`/`ssh-add` are excluded. Returns the
+ * LAST ssh target on the line (most recent), or null when there is none.
+ */
+export function extractSshTarget(command: string): HostPort | null {
+  if (typeof command !== 'string' || !command.includes('ssh')) {
+    return null;
+  }
+
+  const segments = command.split(/&&|\|\||[;|&()`\n]|\$\(/);
+  let result: HostPort | null = null;
+
+  for (const segment of segments) {
+    let seg = segment.trim();
+    if (!seg) continue;
+    // Strip leading env assignments / sudo / env so `sudo ssh host` still matches.
+    seg = seg.replace(/^(?:sudo\s+|env\s+|[A-Za-z_][A-Za-z0-9_]*=\S+\s+)+/, '');
+    const m = /^ssh\s+(.+)$/i.exec(seg);
+    if (!m) continue;
+    const target = parseInvocation(m[1]);
+    if (target) result = target;
+  }
+
+  return result;
+}
+
+function readTail(file: string): string {
+  let fd: number | null = null;
+  try {
+    const st = fs.statSync(file);
+    if (!st.isFile()) return '';
+    const size = st.size;
+    const start = size > TAIL_BYTES ? size - TAIL_BYTES : 0;
+    const len = size - start;
+    if (len <= 0) return '';
+    fd = fs.openSync(file, 'r');
+    const buf = Buffer.allocUnsafe(len);
+    fs.readSync(fd, buf, 0, len, start);
+    return buf.toString('utf8');
+  } catch (err) {
+    debug('tail read failed for %s: %s', file, err instanceof Error ? err.message : err);
+    return '';
+  } finally {
+    if (fd !== null) {
+      try { fs.closeSync(fd); } catch { /* ignore */ }
+    }
+  }
+}
+
+function bashCommandsFromEntry(entry: unknown): string[] {
+  const commands: string[] = [];
+  const content = (entry as { message?: { content?: unknown } })?.message?.content;
+  if (!Array.isArray(content)) return commands;
+  for (const block of content) {
+    if (
+      block
+      && typeof block === 'object'
+      && (block as { type?: unknown }).type === 'tool_use'
+      && (block as { name?: unknown }).name === 'Bash'
+      && typeof (block as { input?: { command?: unknown } }).input?.command === 'string'
+    ) {
+      commands.push((block as { input: { command: string } }).input.command);
+    }
+  }
+  return commands;
+}
+
+/** Most-recent ssh target seen in a single transcript file (tail only). */
+function lastSshInFile(file: string): HostPort | null {
+  const text = readTail(file);
+  if (!text || !text.includes('ssh')) return null;
+
+  let result: HostPort | null = null;
+  // A tail read can cut the first line mid-JSON; JSON.parse simply fails on it.
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let entry: unknown;
+    try {
+      entry = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    for (const command of bashCommandsFromEntry(entry)) {
+      const target = extractSshTarget(command);
+      if (target) result = target;
+    }
+  }
+  return result;
+}
+
+/** `<dir>/<sid>.jsonl` → `<dir>/<sid>/subagents` */
+function subagentsDir(transcriptPath: string): string {
+  const parsed = path.parse(transcriptPath);
+  return path.join(parsed.dir, parsed.name, 'subagents');
+}
+
+/** `agent-<id>.jsonl` → `<id>` */
+function agentIdFromFile(name: string): string {
+  const m = /^agent-(.+)\.jsonl$/i.exec(name);
+  return m ? m[1] : name.replace(/\.jsonl$/i, '');
+}
+
+interface AgentFile {
+  name: string;
+  path: string;
+  mtimeMs: number;
+}
+
+function listAgentFiles(dir: string): AgentFile[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const files: AgentFile[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.jsonl')) continue;
+    const full = path.join(dir, entry.name);
+    try {
+      files.push({ name: entry.name, path: full, mtimeMs: fs.statSync(full).mtimeMs });
+    } catch { /* skip unreadable */ }
+  }
+  files.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return files.slice(0, MAX_SUBAGENT_FILES);
+}
+
+function safeMtime(file: string): number {
+  try {
+    return fs.statSync(file).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Collect session-scoped SSH targets for the HUD: the main agent's most recent
+ * target (from `transcriptPath`) followed by up to three subagents' most recent
+ * targets (from `<sid>/subagents/*.jsonl`), most recently active first. Returns
+ * one entry per source; empty when nothing is found. All fs access is guarded so
+ * a missing transcript or subagents dir degrades gracefully.
+ */
+export function collectSshTargets(transcriptPath: string): SshTarget[] {
+  const out: SshTarget[] = [];
+  if (!transcriptPath) return out;
+
+  try {
+    const mainTarget = lastSshInFile(transcriptPath);
+    if (mainTarget) {
+      out.push({ ...mainTarget, source: 'main', lastSeen: safeMtime(transcriptPath) });
+    }
+  } catch (err) {
+    debug('main scan failed: %s', err instanceof Error ? err.message : err);
+  }
+
+  try {
+    let count = 0;
+    for (const file of listAgentFiles(subagentsDir(transcriptPath))) {
+      if (count >= MAX_SUBAGENTS) break;
+      const target = lastSshInFile(file.path);
+      if (target) {
+        out.push({
+          ...target,
+          source: 'subagent',
+          agentId: agentIdFromFile(file.name),
+          lastSeen: file.mtimeMs,
+        });
+        count += 1;
+      }
+    }
+  } catch (err) {
+    debug('subagent scan failed: %s', err instanceof Error ? err.message : err);
+  }
+
+  return out;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,20 @@ export interface SessionTokenUsage {
   cacheReadTokens: number;
 }
 
+/**
+ * An SSH destination the session connected to, parsed from `ssh ...` Bash
+ * commands in the transcript. `source` distinguishes the main agent from a
+ * subagent (each subagent transcript is a separate source, identified by
+ * `agentId`). `lastSeen` (ms epoch) orders sources by recency.
+ */
+export interface SshTarget {
+  host: string;
+  port: number;
+  source: 'main' | 'subagent';
+  agentId?: string;
+  lastSeen: number;
+}
+
 export interface TranscriptData {
   tools: ToolEntry[];
   skills: string[];
@@ -132,6 +146,9 @@ export interface TranscriptData {
   // Number of compact_boundary entries (manual /compact or auto compaction)
   // with a valid timestamp seen in the transcript.
   compactionCount?: number;
+  // SSH destinations connected to during this session (main agent + subagents).
+  // Populated only when display.showSsh is enabled. See ssh-targets.ts.
+  sshTargets?: SshTarget[];
   // Advisor model ID for the current session, captured from the top-level
   // `advisorModel` field that Claude Code stamps onto every assistant record
   // after `/advisor` is set (e.g. "claude-opus-4-7"). undefined when /advisor

--- a/tests/ssh-render.test.js
+++ b/tests/ssh-render.test.js
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderSshLine } from '../dist/render/ssh-line.js';
+import { mergeConfig } from '../dist/config.js';
+
+function stripAnsi(str) {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+function ctxWith(showSsh, sshTargets) {
+  return {
+    config: mergeConfig({ display: { showSsh } }),
+    transcript: { sshTargets },
+  };
+}
+
+test('renderSshLine returns null when showSsh is disabled', () => {
+  const ctx = ctxWith(false, [{ host: '10.0.0.1', port: 22, source: 'main', lastSeen: 1 }]);
+  assert.equal(renderSshLine(ctx), null);
+});
+
+test('renderSshLine returns null when there are no targets', () => {
+  assert.equal(renderSshLine(ctxWith(true, [])), null);
+  assert.equal(renderSshLine(ctxWith(true, undefined)), null);
+});
+
+test('renderSshLine renders the main target with a ⚡ marker', () => {
+  const ctx = ctxWith(true, [{ host: '44.245.72.210', port: 22, source: 'main', lastSeen: 1 }]);
+  const line = stripAnsi(renderSshLine(ctx));
+  assert.ok(line.includes('⚡'), 'has lightning marker');
+  assert.ok(line.includes('SSH'), 'has SSH label');
+  assert.ok(line.includes('main 44.245.72.210:22'), `main target formatted: ${line}`);
+});
+
+test('renderSshLine labels subagents with a short id and joins with ·', () => {
+  const ctx = ctxWith(true, [
+    { host: '44.245.72.210', port: 22, source: 'main', lastSeen: 3 },
+    { host: '10.0.0.5', port: 2222, source: 'subagent', agentId: 'a4ad710ecd0c0c2ad', lastSeen: 2 },
+  ]);
+  const line = stripAnsi(renderSshLine(ctx));
+  assert.ok(line.includes('main 44.245.72.210:22'), `main: ${line}`);
+  assert.ok(line.includes('sub#a4ad71 10.0.0.5:2222'), `subagent short id + host:port: ${line}`);
+  assert.ok(line.includes(' · '), `middle-dot separator: ${line}`);
+});

--- a/tests/ssh-targets.test.js
+++ b/tests/ssh-targets.test.js
@@ -170,3 +170,27 @@ test('collectSshTargets returns just the main target when no subagents dir exist
 test('collectSshTargets returns [] for a missing transcript', () => {
   assert.deepEqual(collectSshTargets('/no/such/transcript.jsonl'), []);
 });
+
+test('collectSshTargets is session-scoped: it ignores sibling sessions in the same project dir', async (t) => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'sshhud-'));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  // Session A (the one we query) + its subagent.
+  const aPath = path.join(dir, 'sess-A.jsonl');
+  await writeFile(aPath, bashLine('ssh a-user@10.0.0.1'));
+  const aSub = path.join(dir, 'sess-A', 'subagents');
+  await mkdir(aSub, { recursive: true });
+  await writeFile(path.join(aSub, 'agent-a1.jsonl'), bashLine('ssh a-sub@10.0.0.2'));
+
+  // Sibling session B with different hosts — must never leak into A's result.
+  const bPath = path.join(dir, 'sess-B.jsonl');
+  await writeFile(bPath, bashLine('ssh b-user@192.168.9.9'));
+  const bSub = path.join(dir, 'sess-B', 'subagents');
+  await mkdir(bSub, { recursive: true });
+  await writeFile(path.join(bSub, 'agent-b1.jsonl'), bashLine('ssh b-sub@192.168.9.10'));
+
+  const hosts = collectSshTargets(aPath).map(target => target.host);
+  assert.deepEqual([...hosts].sort(), ['10.0.0.1', '10.0.0.2']);
+  assert.ok(!hosts.includes('192.168.9.9'), 'must not include sibling session host');
+  assert.ok(!hosts.includes('192.168.9.10'), 'must not include sibling subagent host');
+});

--- a/tests/ssh-targets.test.js
+++ b/tests/ssh-targets.test.js
@@ -1,0 +1,172 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, utimes, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { extractSshTarget, collectSshTargets } from '../dist/ssh-targets.js';
+
+// ---------------------------------------------------------------------------
+// extractSshTarget — pure tokenizer over a single shell command string
+// ---------------------------------------------------------------------------
+
+test('extractSshTarget parses user@ipv4 with default port 22', () => {
+  assert.deepEqual(
+    extractSshTarget('ssh cloud-user@44.245.72.210 nvidia-smi'),
+    { host: '44.245.72.210', port: 22 },
+  );
+});
+
+test('extractSshTarget reads -p PORT', () => {
+  assert.deepEqual(
+    extractSshTarget('ssh -p 2222 user@host.example.com'),
+    { host: 'host.example.com', port: 2222 },
+  );
+});
+
+test('extractSshTarget reads attached -pPORT', () => {
+  assert.deepEqual(
+    extractSshTarget('ssh -p2222 user@1.2.3.4'),
+    { host: '1.2.3.4', port: 2222 },
+  );
+});
+
+test('extractSshTarget skips value-taking options (-i, -o) before the host', () => {
+  assert.deepEqual(
+    extractSshTarget('ssh -i ~/.ssh/key -o ConnectTimeout=20 -o StrictHostKeyChecking=accept-new cloud-user@10.0.0.5 uptime'),
+    { host: '10.0.0.5', port: 22 },
+  );
+});
+
+test('extractSshTarget ignores ssh-keygen and ssh-add', () => {
+  assert.equal(extractSshTarget('ssh-keygen -l -f key.pub'), null);
+  assert.equal(extractSshTarget('ssh-add -l'), null);
+});
+
+test('extractSshTarget does not treat "echo ssh x" as an ssh invocation', () => {
+  assert.equal(extractSshTarget('echo ssh not-a-host'), null);
+});
+
+test('extractSshTarget finds ssh after a command separator', () => {
+  assert.deepEqual(
+    extractSshTarget("cd /tmp && ssh user@node1.internal.example.com 'ls -la'"),
+    { host: 'node1.internal.example.com', port: 22 },
+  );
+});
+
+test('extractSshTarget honors a leading sudo', () => {
+  assert.deepEqual(
+    extractSshTarget('sudo ssh root@10.1.2.3'),
+    { host: '10.1.2.3', port: 22 },
+  );
+});
+
+test('extractSshTarget rejects a single-label host (no dot, not ipv4)', () => {
+  assert.equal(extractSshTarget('ssh myalias'), null);
+});
+
+test('extractSshTarget falls back to port 22 on an out-of-range port', () => {
+  assert.deepEqual(
+    extractSshTarget('ssh -p 99999 user@1.2.3.4'),
+    { host: '1.2.3.4', port: 22 },
+  );
+});
+
+test('extractSshTarget takes the last ssh invocation on a chained line', () => {
+  assert.deepEqual(
+    extractSshTarget('ssh a.example.com; ssh b.example.com'),
+    { host: 'b.example.com', port: 22 },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// collectSshTargets — session-scoped: main transcript + <sid>/subagents/*.jsonl
+// ---------------------------------------------------------------------------
+
+function bashLine(command) {
+  return JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', name: 'Bash', input: { command } }] },
+  });
+}
+
+async function makeSession(t) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'sshhud-'));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const sid = 'session-abc';
+  const transcriptPath = path.join(dir, `${sid}.jsonl`);
+  const subagentsDir = path.join(dir, sid, 'subagents');
+  await mkdir(subagentsDir, { recursive: true });
+  return { dir, sid, transcriptPath, subagentsDir };
+}
+
+test('collectSshTargets returns the main target first, then subagents', async (t) => {
+  const s = await makeSession(t);
+  await writeFile(s.transcriptPath, [bashLine('ssh main-user@10.0.0.1')].join('\n'));
+  await writeFile(path.join(s.subagentsDir, 'agent-aaaaaa111.jsonl'), bashLine('ssh sub@10.0.0.2'));
+
+  const targets = collectSshTargets(s.transcriptPath);
+  assert.equal(targets.length, 2);
+  assert.deepEqual(
+    { host: targets[0].host, port: targets[0].port, source: targets[0].source },
+    { host: '10.0.0.1', port: 22, source: 'main' },
+  );
+  assert.equal(targets[1].source, 'subagent');
+  assert.equal(targets[1].host, '10.0.0.2');
+  assert.equal(targets[1].agentId, 'aaaaaa111');
+});
+
+test('collectSshTargets takes the most recent ssh target per source', async (t) => {
+  const s = await makeSession(t);
+  await writeFile(
+    s.transcriptPath,
+    [bashLine('ssh user@10.0.0.1'), bashLine('ssh user@10.0.0.9')].join('\n'),
+  );
+  const targets = collectSshTargets(s.transcriptPath);
+  assert.equal(targets.length, 1);
+  assert.equal(targets[0].host, '10.0.0.9');
+});
+
+test('collectSshTargets caps subagents at 3 (most recently active)', async (t) => {
+  const s = await makeSession(t);
+  await writeFile(s.transcriptPath, bashLine('echo no-ssh-here'));
+  const mk = async (name, host, mtimeSec) => {
+    const p = path.join(s.subagentsDir, name);
+    await writeFile(p, bashLine(`ssh sub@${host}`));
+    await utimes(p, mtimeSec, mtimeSec);
+  };
+  await mk('agent-a.jsonl', '10.0.0.1', 1000);
+  await mk('agent-b.jsonl', '10.0.0.2', 2000);
+  await mk('agent-c.jsonl', '10.0.0.3', 3000);
+  await mk('agent-d.jsonl', '10.0.0.4', 4000);
+
+  const targets = collectSshTargets(s.transcriptPath);
+  assert.equal(targets.length, 3, 'main has no ssh, so only 3 subagents');
+  assert.deepEqual(
+    targets.map(t => t.host),
+    ['10.0.0.4', '10.0.0.3', '10.0.0.2'],
+    'newest three subagents, most recent first',
+  );
+});
+
+test('collectSshTargets returns only subagents when main has no ssh', async (t) => {
+  const s = await makeSession(t);
+  await writeFile(s.transcriptPath, bashLine('ls -la'));
+  await writeFile(path.join(s.subagentsDir, 'agent-x1.jsonl'), bashLine('ssh sub@1.2.3.4'));
+  const targets = collectSshTargets(s.transcriptPath);
+  assert.equal(targets.length, 1);
+  assert.equal(targets[0].source, 'subagent');
+});
+
+test('collectSshTargets returns just the main target when no subagents dir exists', async (t) => {
+  const s = await makeSession(t);
+  await rm(path.join(s.dir, s.sid), { recursive: true, force: true });
+  await writeFile(s.transcriptPath, bashLine('ssh user@5.6.7.8'));
+  const targets = collectSshTargets(s.transcriptPath);
+  assert.equal(targets.length, 1);
+  assert.equal(targets[0].source, 'main');
+  assert.equal(targets[0].host, '5.6.7.8');
+});
+
+test('collectSshTargets returns [] for a missing transcript', () => {
+  assert.deepEqual(collectSshTargets('/no/such/transcript.jsonl'), []);
+});


### PR DESCRIPTION
## Summary

Adds an opt-in, session-scoped **`ssh`** display element that shows the SSH
destinations the current session connected to, parsed from `ssh …` Bash
commands in the transcript.

```
⚡ SSH main 44.245.72.210:22 · sub#a4ad71 10.0.0.5:2222
```

Enabled via `display.showSsh` (default **off**), matching the `showTools` /
`showMcp` convention. Hidden entirely when disabled or when no `ssh` commands
are found.

## Why

When driving remote GPU/CI boxes over SSH — often several at once, including
from subagents — it's easy to lose track of which host each agent is on. This
surfaces it at a glance in the HUD, using data claude-hud already has access to
(the local transcript), with no network access.

## Behavior

- **Session-scoped.** Reads the main transcript plus the session's subagent
  transcripts at `<transcript_dir>/<session_id>/subagents/*.jsonl` (derived from
  the stdin `transcript_path`). Nothing outside the current session is read.
- **One `host:port` per source**, most-recent first: the main agent, then up to
  3 most-recently-active subagents (`sub#<short-id>`).
- **Robust parsing** (`src/ssh-targets.ts`): handles `-p`/`-pPORT`, skips
  value-taking options (`-i`, `-o`, …) so their values aren't mistaken for the
  host, ignores `ssh-keygen`/`ssh-add`, and requires an IPv4 or dotted hostname.
  Bounded tail-reads + guarded fs access, so a missing `subagents/` dir (older
  Claude Code) degrades gracefully to main-only.
- Gathered only when the element is enabled (no cost for users who leave it off).

## Files

- `src/ssh-targets.ts` — tokenizer + session collector (new)
- `src/render/ssh-line.ts` — renderer (new)
- `src/config.ts`, `src/types.ts`, `src/render/index.ts`, `src/index.ts` — wiring
  (element type, default, validation, `elementOrder`, dispatch, opt-in gather)
- `README.md`, `CHANGELOG.md` — docs
- `dist/` intentionally not committed (built by CI, per CONTRIBUTING)

## Tests

`tests/ssh-targets.test.js` (tokenizer edge cases + collector: main/subagents,
recency cap, per-source dedup, missing files) and `tests/ssh-render.test.js`
(disabled/empty → null, main + subagent formatting). All new tests pass.

> Note: a handful of pre-existing tests fail on my Windows dev box (child-process
> path resolution, cache mtime, etc.); the set is identical with and without this
> change, so no regressions were introduced. They should pass on CI/Linux.

## Notes for the maintainer

Happy to adjust the render format, the source cap (1 main + 3 subagents), or
split subagent support into a follow-up if you'd prefer a main-transcript-only
first cut.
