### PR TITLE
fix: correct effort suffix placement and guard check inconsistencies

### DIFF
--- a/src/config-reader.ts
+++ b/src/config-reader.ts
@@ -5,7 +5,7 @@ import { createHash } from 'node:crypto';
 import { createDebug } from './debug.js';
 import { getClaudeConfigDir, getClaudeConfigJsonPath, getHudPluginDir } from './claude-config-dir.js';
 
-const debug = createDebug('config');
+const debug = createDebug('config-reader');
 
 export interface ConfigCounts {
   claudeMdCount: number;

--- a/src/render/lines/environment.ts
+++ b/src/render/lines/environment.ts
@@ -7,7 +7,7 @@ export function renderEnvironmentLine(ctx: RenderContext): string | null {
   const totalCounts =
     ctx.claudeMdCount + ctx.rulesCount + ctx.mcpCount + ctx.hooksCount;
   const threshold = display?.environmentThreshold ?? 0;
-  const showCounts = display?.showConfigCounts !== false;
+  const showCounts = display?.showConfigCounts === true;
   const showOutputStyle = display?.showOutputStyle === true;
   const parts: string[] = [];
 

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -135,7 +135,7 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     parts.push(label(ctx.extraLabel, colors));
   }
 
-  if (display?.showDuration !== false && ctx.sessionDuration) {
+  if (display?.showDuration === true && ctx.sessionDuration) {
     parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
   }
 

--- a/src/render/model-display.ts
+++ b/src/render/model-display.ts
@@ -17,5 +17,5 @@ export function formatModelDisplay(model: string, ctx: RenderContext): string {
     return providerLabel ? `${providerLabel} | ${core}` : core;
   }
 
-  return autoProvider ? `${model} | ${autoProvider}${effortSuffix}` : `${model}${effortSuffix}`;
+  return autoProvider ? `${model}${effortSuffix} | ${autoProvider}` : `${model}${effortSuffix}`;
 }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -15,7 +15,7 @@ import { formatTokens, formatContextValue } from '../utils/format.js';
 import { createDebug } from '../debug.js';
 import { formatModelDisplay } from './model-display.js';
 
-const debug = createDebug('context');
+const debug = createDebug('session-line');
 
 /**
  * Renders the full session line (model + context bar + project + git + counts + usage + duration).
@@ -143,7 +143,7 @@ export function renderSessionLine(ctx: RenderContext): string {
   }
 
   // Config counts (respects environmentThreshold)
-  if (display?.showConfigCounts !== false) {
+  if (display?.showConfigCounts === true) {
     const totalCounts = ctx.claudeMdCount + ctx.rulesCount + ctx.mcpCount + ctx.hooksCount;
     const envThreshold = display?.environmentThreshold ?? 0;
 
@@ -297,7 +297,7 @@ export function renderSessionLine(ctx: RenderContext): string {
     }
   }
 
-  if (display?.showDuration !== false && ctx.sessionDuration) {
+  if (display?.showDuration === true && ctx.sessionDuration) {
     parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
   }
 

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -744,6 +744,40 @@ test('renderSessionLine keeps the legacy trailing provider label when showProvid
   }
 });
 
+test('renderProjectLine keeps effort attached to the model before a trailing provider', () => {
+  process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+  try {
+    const ctx = baseContext();
+    ctx.config.lineLayout = 'expanded';
+    ctx.stdin.model = { display_name: 'Claude Opus 4.6' };
+    ctx.effortLevel = 'xhigh';
+    ctx.effortSymbol = '◕';
+
+    const line = stripAnsi(renderProjectLine(ctx) ?? '');
+    assert.ok(line.includes('[Claude Opus 4.6 ◕ xhigh | Bedrock]'), `got: ${line}`);
+    assert.ok(!line.includes('Bedrock ◕ xhigh'), `effort must not attach to provider: ${line}`);
+  } finally {
+    delete process.env.CLAUDE_CODE_USE_BEDROCK;
+  }
+});
+
+test('renderSessionLine keeps effort attached to the model before a trailing provider', () => {
+  process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+  try {
+    const ctx = baseContext();
+    ctx.config.lineLayout = 'compact';
+    ctx.stdin.model = { display_name: 'Claude Opus 4.6' };
+    ctx.effortLevel = 'xhigh';
+    ctx.effortSymbol = '◕';
+
+    const line = stripAnsi(renderSessionLine(ctx));
+    assert.ok(line.includes('[Claude Opus 4.6 ◕ xhigh | Bedrock]'), `got: ${line}`);
+    assert.ok(!line.includes('Bedrock ◕ xhigh'), `effort must not attach to provider: ${line}`);
+  } finally {
+    delete process.env.CLAUDE_CODE_USE_BEDROCK;
+  }
+});
+
 test('renderProjectLine uses configurable element colors', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = '/tmp/my-project';
@@ -831,6 +865,32 @@ test('renderEnvironmentLine appends output style after config counts', () => {
   assert.ok(line?.includes('style: learning'));
 });
 
+test('renderEnvironmentLine treats missing showConfigCounts as disabled in expanded layout', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  delete ctx.config.display.showConfigCounts;
+  ctx.claudeMdCount = 2;
+  ctx.rulesCount = 1;
+  ctx.mcpCount = 3;
+  ctx.hooksCount = 4;
+
+  assert.equal(renderEnvironmentLine(ctx), null);
+});
+
+test('renderSessionLine treats missing showConfigCounts as disabled in compact layout', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'compact';
+  delete ctx.config.display.showConfigCounts;
+  ctx.claudeMdCount = 2;
+  ctx.rulesCount = 1;
+  ctx.mcpCount = 3;
+  ctx.hooksCount = 4;
+
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(!line.includes('CLAUDE.md'), `config counts must remain opt-in: ${line}`);
+  assert.ok(!line.includes('MCPs'), `config counts must remain opt-in: ${line}`);
+});
+
 test('renderProjectLine includes duration when showDuration is true', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = '/tmp/my-project';
@@ -909,6 +969,26 @@ test('renderProjectLine omits duration when showDuration is false', () => {
   ctx.sessionDuration = '12m 34s';
   const line = renderProjectLine(ctx);
   assert.ok(!line?.includes('12m 34s'), 'should not include session duration when disabled');
+});
+
+test('renderProjectLine treats missing showDuration as disabled in expanded layout', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  delete ctx.config.display.showDuration;
+  ctx.sessionDuration = '12m 34s';
+
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(!line.includes('12m 34s'), `duration must remain opt-in: ${line}`);
+});
+
+test('renderSessionLine treats missing showDuration as disabled in compact layout', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'compact';
+  delete ctx.config.display.showDuration;
+  ctx.sessionDuration = '12m 34s';
+
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(!line.includes('12m 34s'), `duration must remain opt-in: ${line}`);
 });
 
 test('renderProjectLine includes speed when showSpeed is true and speed is available', async () => {


### PR DESCRIPTION
Found a small display bug — when using a provider like Bedrock, the effort level shows up after the provider name (`Opus | Bedrock max`) instead of after the model (`Opus max | Bedrock`). Quick swap fixes it.

Also noticed that `showDuration` and `showConfigCounts` both default to `false` in the config, but the render checks were using `!== false` instead of `=== true`. That means they'd show up if the display config was ever partially constructed. Aligned the checks to match the opt-in defaults.

Lastly — two pairs of modules were using identical debug namespaces (`'context'` and `'config'`), so debug output was impossible to tell apart. Gave each its own name.