### PR TITLE
feat(display): show auth method and logged-in account on the first line

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showAgents` | boolean | false | Show agents activity line |
 | `display.showTodos` | boolean | false | Show todos progress line |
 | `display.showSessionName` | boolean | false | Show session slug or custom title from `/rename` |
+| `display.showAuth` | boolean | false | Show the auth method (subscription plan) of the current login as its own segment at the end of the first line, e.g. `Claude Max 20x`. Derived from the `oauthAccount` block in `{CLAUDE_CONFIG_DIR}.json`; shows `API Key` when there is no OAuth login but `ANTHROPIC_API_KEY` is set |
+| `display.showAuthUser` | boolean | false | Show the logged-in account (email local part, falling back to profile display name) next to the auth method |
+| `display.authUserLength` | number | `8` | Maximum characters of the account name to display before truncating with `…`. `0` shows the full name |
 | `display.showAdvisor` | boolean | false | Inline the model configured via Claude Code's `/advisor` on the project line, e.g. `Advisor: Opus 4.7`. Read from the `advisorModel` field that Claude Code stamps on each assistant transcript record; sanitised and capped at 64 chars before rendering |
 | `display.advisorOverride` | string | `""` | Optional manual override for the displayed advisor label. When non-empty, replaces transcript-driven detection. Also sanitised and capped at 64 chars |
 | `display.showSessionStartDate` | boolean | false | Show the transcript session start timestamp |

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -24,7 +24,8 @@ Advanced settings such as `colors.*`, `pathLevels`, `maxWidth`, `forceMaxWidth`,
 `display.autoCompactWindow`, `display.promptCacheTtlSeconds`,
 `display.usageThreshold`, `display.sevenDayThreshold`,
 `display.environmentThreshold`, `display.contextWarningThreshold`,
-`display.contextCriticalThreshold`, `display.advisorOverride`, and the
+`display.contextCriticalThreshold`, `display.advisorOverride`,
+`display.showAuth`, `display.showAuthUser`, `display.authUserLength`, and the
 `display.externalUsage*` keys are preserved when saving but are not edited by
 this guided flow.
 
@@ -305,6 +306,8 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 | Usage value | `display.usageValue` |
 | Usage reset label | `display.showResetLabel` |
 | Session name | `display.showSessionName` |
+| Auth method | `display.showAuth` (plan label, e.g. "Claude Max 20x", own segment at end of first line) |
+| Auth user | `display.showAuthUser` (login account, truncated to `display.authUserLength` chars, 0 = full) |
 | Session duration | `display.showDuration` |
 | Session tokens | `display.showSessionTokens` |
 | Session start date | `display.showSessionStartDate` |

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -16,6 +16,11 @@ export interface AuthInfo {
 }
 
 const EMPTY_AUTH_INFO: AuthInfo = { method: null, user: null };
+const API_KEY_AUTH_INFO: AuthInfo = { method: 'API Key', user: null };
+
+function hasApiKey(env: NodeJS.ProcessEnv): boolean {
+  return typeof env.ANTHROPIC_API_KEY === 'string' && env.ANTHROPIC_API_KEY.trim().length > 0;
+}
 
 // Strip ANSI sequences and control/bidi characters so values from
 // claude.json can never smuggle escape sequences into the terminal.
@@ -58,6 +63,12 @@ function extractTierSuffix(rateLimitTier: string): string | null {
  * Pure so it can be tested without touching the filesystem.
  */
 export function deriveAuthInfo(claudeJson: unknown, env: NodeJS.ProcessEnv = process.env): AuthInfo {
+  // ANTHROPIC_API_KEY takes precedence at runtime. oauthAccount can remain in
+  // claude.json after a user switches to API-key authentication.
+  if (hasApiKey(env)) {
+    return API_KEY_AUTH_INFO;
+  }
+
   const root = (claudeJson && typeof claudeJson === 'object')
     ? claudeJson as Record<string, unknown>
     : null;
@@ -66,10 +77,6 @@ export function deriveAuthInfo(claudeJson: unknown, env: NodeJS.ProcessEnv = pro
     : null;
 
   if (!account) {
-    // No OAuth login recorded — an exported key is the only signal left.
-    if (env.ANTHROPIC_API_KEY) {
-      return { method: 'API Key', user: null };
-    }
     return EMPTY_AUTH_INFO;
   }
 
@@ -92,6 +99,11 @@ export function deriveAuthInfo(claudeJson: unknown, env: NodeJS.ProcessEnv = pro
 
 /** Reads auth info for the current login. Never throws. */
 export function readAuthInfo(): AuthInfo {
+  // Avoid reading a stale OAuth profile when the active source is an API key.
+  if (hasApiKey(process.env)) {
+    return API_KEY_AUTH_INFO;
+  }
+
   try {
     const configJsonPath = getClaudeConfigJsonPath(os.homedir());
     const content = fs.readFileSync(configJsonPath, 'utf-8');

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,132 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { getClaudeConfigJsonPath } from './claude-config-dir.js';
+
+/**
+ * Authentication info for the current Claude Code login, derived from the
+ * `oauthAccount` block Claude Code persists in {CLAUDE_CONFIG_DIR}.json.
+ *
+ *   method: human-readable auth/plan label (e.g. "Claude Max 20x", "API Key")
+ *   user:   account identifier (email local part, falling back to displayName)
+ */
+export interface AuthInfo {
+  method: string | null;
+  user: string | null;
+}
+
+const EMPTY_AUTH_INFO: AuthInfo = { method: null, user: null };
+
+// Strip control/format characters so values from claude.json can never
+// smuggle escape sequences into the terminal.
+function sanitizeValue(value: string): string {
+  return value.replace(/[\p{Cc}\p{Cf}]/gu, '').trim();
+}
+
+function readString(obj: Record<string, unknown>, key: string): string | null {
+  const value = obj[key];
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const sanitized = sanitizeValue(value);
+  return sanitized.length > 0 ? sanitized : null;
+}
+
+/**
+ * Formats an organizationType value into a display label:
+ * "claude_max" → "Claude Max", "claude_pro" → "Claude Pro".
+ */
+function formatOrgType(orgType: string): string {
+  return orgType
+    .split('_')
+    .filter(Boolean)
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * Extracts a multiplier suffix from a rate-limit tier value:
+ * "default_claude_max_20x" → "20x". Returns null when no tier is encoded.
+ */
+function extractTierSuffix(rateLimitTier: string): string | null {
+  const match = /_(\d+x)$/i.exec(rateLimitTier);
+  return match ? match[1] : null;
+}
+
+/**
+ * Derives auth info from the parsed contents of {CLAUDE_CONFIG_DIR}.json.
+ * Pure so it can be tested without touching the filesystem.
+ */
+export function deriveAuthInfo(claudeJson: unknown, env: NodeJS.ProcessEnv = process.env): AuthInfo {
+  const root = (claudeJson && typeof claudeJson === 'object')
+    ? claudeJson as Record<string, unknown>
+    : null;
+  const account = (root?.oauthAccount && typeof root.oauthAccount === 'object')
+    ? root.oauthAccount as Record<string, unknown>
+    : null;
+
+  if (!account) {
+    // No OAuth login recorded — an exported key is the only signal left.
+    if (env.ANTHROPIC_API_KEY) {
+      return { method: 'API Key', user: null };
+    }
+    return EMPTY_AUTH_INFO;
+  }
+
+  let method: string | null = null;
+  const orgType = readString(account, 'organizationType');
+  if (orgType) {
+    method = formatOrgType(orgType);
+    const rateLimitTier = readString(account, 'organizationRateLimitTier');
+    const tier = rateLimitTier ? extractTierSuffix(rateLimitTier) : null;
+    if (tier && !method.toLowerCase().includes(tier.toLowerCase())) {
+      method += ` ${tier}`;
+    }
+  }
+
+  const email = readString(account, 'emailAddress');
+  const user = email ? email.split('@')[0] : readString(account, 'displayName');
+
+  return { method, user };
+}
+
+/** Reads auth info for the current login. Never throws. */
+export function readAuthInfo(): AuthInfo {
+  try {
+    const configJsonPath = getClaudeConfigJsonPath(os.homedir());
+    const content = fs.readFileSync(configJsonPath, 'utf-8');
+    return deriveAuthInfo(JSON.parse(content));
+  } catch {
+    return EMPTY_AUTH_INFO;
+  }
+}
+
+export function truncateUser(user: string, maxLength: number): string {
+  if (maxLength <= 0 || user.length <= maxLength) {
+    return user;
+  }
+  return `${user.slice(0, maxLength)}…`;
+}
+
+/**
+ * Builds the standalone auth segment for the end of the first HUD line,
+ * honoring the showAuth / showAuthUser / authUserLength display settings.
+ * Returns e.g. "Claude Max 20x · yukinosh…", or null when nothing to show.
+ */
+export function formatAuthSegment(
+  info: AuthInfo | null | undefined,
+  display: { showAuth?: boolean; showAuthUser?: boolean; authUserLength?: number } | undefined,
+): string | null {
+  if (!info) {
+    return null;
+  }
+
+  const parts: string[] = [];
+  if (display?.showAuth && info.method) {
+    parts.push(info.method);
+  }
+  if (display?.showAuthUser && info.user) {
+    parts.push(truncateUser(info.user, display?.authUserLength ?? 8));
+  }
+
+  return parts.length > 0 ? parts.join(' · ') : null;
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import { getClaudeConfigJsonPath } from './claude-config-dir.js';
+import { sanitizeDisplayText } from './utils/sanitize.js';
 
 /**
  * Authentication info for the current Claude Code login, derived from the
@@ -16,10 +17,10 @@ export interface AuthInfo {
 
 const EMPTY_AUTH_INFO: AuthInfo = { method: null, user: null };
 
-// Strip control/format characters so values from claude.json can never
-// smuggle escape sequences into the terminal.
+// Strip ANSI sequences and control/bidi characters so values from
+// claude.json can never smuggle escape sequences into the terminal.
 function sanitizeValue(value: string): string {
-  return value.replace(/[\p{Cc}\p{Cf}]/gu, '').trim();
+  return sanitizeDisplayText(value).trim();
 }
 
 function readString(obj: Record<string, unknown>, key: string): string | null {

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,6 +133,13 @@ export interface HudConfig {
     showAgents: boolean;
     showTodos: boolean;
     showSessionName: boolean;
+    // Show the auth method (subscription plan) for the current login,
+    // e.g. "Claude Max 20x", as its own segment at the end of the first line.
+    showAuth: boolean;
+    // Show the logged-in account (email local part) next to the auth method.
+    showAuthUser: boolean;
+    // Max characters of the account name to display (0 = full).
+    authUserLength: number;
     showClaudeCodeVersion: boolean;
     showEffortLevel: boolean;
     showMemoryUsage: boolean;
@@ -221,6 +228,9 @@ export const DEFAULT_CONFIG: HudConfig = {
     showAgents: false,
     showTodos: false,
     showSessionName: false,
+    showAuth: false,
+    showAuthUser: false,
+    authUserLength: 8,
     showClaudeCodeVersion: false,
     showEffortLevel: false,
     showMemoryUsage: false,
@@ -628,6 +638,16 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showSessionName: typeof migrated.display?.showSessionName === 'boolean'
       ? migrated.display.showSessionName
       : DEFAULT_CONFIG.display.showSessionName,
+    showAuth: typeof migrated.display?.showAuth === 'boolean'
+      ? migrated.display.showAuth
+      : DEFAULT_CONFIG.display.showAuth,
+    showAuthUser: typeof migrated.display?.showAuthUser === 'boolean'
+      ? migrated.display.showAuthUser
+      : DEFAULT_CONFIG.display.showAuthUser,
+    authUserLength: validateNonNegativeInteger(
+      migrated.display?.authUserLength,
+      DEFAULT_CONFIG.display.authUserLength,
+    ),
     showClaudeCodeVersion: typeof migrated.display?.showClaudeCodeVersion === 'boolean'
       ? migrated.display.showClaudeCodeVersion
       : DEFAULT_CONFIG.display.showClaudeCodeVersion,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { loadConfig } from "./config.js";
 import { parseExtraCmdArg, runExtraCmd } from "./extra-cmd.js";
 import { getClaudeCodeVersion } from "./version.js";
 import { getMemoryUsage } from "./memory.js";
+import { readAuthInfo } from "./auth.js";
 import { resolveEffortLevel } from "./effort.js";
 import { applyContextWindowFallback } from "./context-cache.js";
 import { getUsageFromExternalSnapshot, writeExternalUsageSnapshot } from "./external-usage.js";
@@ -30,6 +31,7 @@ export type MainDeps = {
   runExtraCmd: typeof runExtraCmd;
   getClaudeCodeVersion: typeof getClaudeCodeVersion;
   getMemoryUsage: typeof getMemoryUsage;
+  readAuthInfo: typeof readAuthInfo;
   applyContextWindowFallback: typeof applyContextWindowFallback;
   render: typeof render;
   now: () => number;
@@ -71,6 +73,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     runExtraCmd,
     getClaudeCodeVersion,
     getMemoryUsage,
+    readAuthInfo,
     applyContextWindowFallback,
     render,
     now: () => Date.now(),
@@ -160,6 +163,10 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       config.display.showMemoryUsage && config.lineLayout === "expanded"
         ? await deps.getMemoryUsage()
         : null;
+    const authInfo =
+      config.display.showAuth || config.display.showAuthUser
+        ? deps.readAuthInfo()
+        : null;
 
     const ctx: RenderContext = {
       stdin,
@@ -178,6 +185,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       claudeCodeVersion,
       effortLevel: effortInfo?.level,
       effortSymbol: effortInfo?.symbol,
+      authInfo,
     };
 
     deps.render(ctx);

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -10,6 +10,7 @@ import { renderAdvisorLine } from './advisor.js';
 import { normalizeAddedDirs, sanitize as sanitizeDisplayText, basenameOf, truncateBasename, MAX_RENDERED_ADDED_DIRS } from './added-dirs.js';
 import { hyperlink, getFileHref, safeHyperlink } from '../../utils/hyperlinks.js';
 import { formatModelDisplay } from '../model-display.js';
+import { formatAuthSegment } from '../../auth.js';
 
 function resolvePathWithinCwd(cwd: string, candidatePath: string): string | null {
   const resolvedCwd = path.resolve(cwd);
@@ -149,6 +150,11 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     if (speed !== null) {
       parts.push(label(`${t('format.out')}: ${speed.toFixed(1)} ${t('format.tokPerSec')}`, colors));
     }
+  }
+
+  const authSegment = formatAuthSegment(ctx.authInfo, display);
+  if (authSegment) {
+    parts.push(label(authSegment, colors));
   }
 
   if (customLine && customLinePosition === 'last') {

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -12,6 +12,7 @@ import { t } from '../i18n/index.js';
 import type { TimeFormatMode, UsageValueMode } from '../config.js';
 import { formatResetTime } from './format-reset-time.js';
 import { formatTokens, formatContextValue } from '../utils/format.js';
+import { formatAuthSegment } from '../auth.js';
 import { createDebug } from '../debug.js';
 import { formatModelDisplay } from './model-display.js';
 
@@ -325,6 +326,11 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   if (ctx.extraLabel) {
     parts.push(label(ctx.extraLabel, colors));
+  }
+
+  const authSegment = formatAuthSegment(ctx.authInfo, display);
+  if (authSegment) {
+    parts.push(label(authSegment, colors));
   }
 
   if (customLine && customLinePosition === 'last') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { HudConfig } from './config.js';
 import type { GitStatus } from './git.js';
+import type { AuthInfo } from './auth.js';
 
 export interface StdinData {
   transcript_path?: string;
@@ -156,4 +157,7 @@ export interface RenderContext {
   claudeCodeVersion?: string;
   effortLevel?: string;
   effortSymbol?: string;
+  // Auth method + account for the current login (see auth.ts). Only populated
+  // when display.showAuth or display.showAuthUser is enabled.
+  authInfo?: AuthInfo | null;
 }

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { deriveAuthInfo, truncateUser, formatAuthSegment } from '../dist/auth.js';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { deriveAuthInfo, readAuthInfo, truncateUser, formatAuthSegment } from '../dist/auth.js';
 
 const MAX_ACCOUNT = {
   oauthAccount: {
@@ -10,6 +13,14 @@ const MAX_ACCOUNT = {
     organizationRateLimitTier: 'default_claude_max_20x',
   },
 };
+
+function restoreEnvVar(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
 
 test('deriveAuthInfo formats claude_max with rate-limit tier', () => {
   const info = deriveAuthInfo(MAX_ACCOUNT, {});
@@ -46,6 +57,11 @@ test('deriveAuthInfo reports API Key when no oauth account but key exported', ()
   assert.equal(info.user, null);
 });
 
+test('deriveAuthInfo gives API Key precedence over a stale oauth account', () => {
+  const info = deriveAuthInfo(MAX_ACCOUNT, { ANTHROPIC_API_KEY: 'sk-test' });
+  assert.deepEqual(info, { method: 'API Key', user: null });
+});
+
 test('deriveAuthInfo returns nulls for missing/invalid input', () => {
   assert.deepEqual(deriveAuthInfo(null, {}), { method: null, user: null });
   assert.deepEqual(deriveAuthInfo('junk', {}), { method: null, user: null });
@@ -60,6 +76,46 @@ test('deriveAuthInfo strips ANSI sequences and control characters from values', 
     },
   }, {});
   assert.equal(info.user, 'evil');
+});
+
+test('readAuthInfo honors CLAUDE_CONFIG_DIR and handles unreadable profiles', async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-auth-test-'));
+  const configDir = path.join(tempDir, 'profile');
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  const originalApiKey = process.env.ANTHROPIC_API_KEY;
+
+  try {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+
+    assert.deepEqual(readAuthInfo(), { method: null, user: null });
+
+    await writeFile(`${configDir}.json`, JSON.stringify(MAX_ACCOUNT), 'utf8');
+    assert.deepEqual(readAuthInfo(), { method: 'Claude Max 20x', user: 'someone.long' });
+
+    await writeFile(`${configDir}.json`, '{invalid', 'utf8');
+    assert.deepEqual(readAuthInfo(), { method: null, user: null });
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    restoreEnvVar('ANTHROPIC_API_KEY', originalApiKey);
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('readAuthInfo reports an API key without requiring an oauth profile', async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-auth-key-test-'));
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  const originalApiKey = process.env.ANTHROPIC_API_KEY;
+
+  try {
+    process.env.CLAUDE_CONFIG_DIR = path.join(tempDir, 'missing');
+    process.env.ANTHROPIC_API_KEY = 'sk-test';
+    assert.deepEqual(readAuthInfo(), { method: 'API Key', user: null });
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    restoreEnvVar('ANTHROPIC_API_KEY', originalApiKey);
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test('truncateUser truncates with ellipsis and honors 0 = full', () => {

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,87 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveAuthInfo, truncateUser, formatAuthSegment } from '../dist/auth.js';
+
+const MAX_ACCOUNT = {
+  oauthAccount: {
+    emailAddress: 'someone.long@example.com',
+    displayName: 'Some One',
+    organizationType: 'claude_max',
+    organizationRateLimitTier: 'default_claude_max_20x',
+  },
+};
+
+test('deriveAuthInfo formats claude_max with rate-limit tier', () => {
+  const info = deriveAuthInfo(MAX_ACCOUNT, {});
+  assert.equal(info.method, 'Claude Max 20x');
+  assert.equal(info.user, 'someone.long');
+});
+
+test('deriveAuthInfo formats claude_pro without tier', () => {
+  const info = deriveAuthInfo({
+    oauthAccount: {
+      emailAddress: 'a@b.com',
+      organizationType: 'claude_pro',
+      organizationRateLimitTier: 'default_claude_pro',
+    },
+  }, {});
+  assert.equal(info.method, 'Claude Pro');
+  assert.equal(info.user, 'a');
+});
+
+test('deriveAuthInfo falls back to displayName without email', () => {
+  const info = deriveAuthInfo({
+    oauthAccount: {
+      displayName: 'Some One',
+      organizationType: 'claude_enterprise',
+    },
+  }, {});
+  assert.equal(info.method, 'Claude Enterprise');
+  assert.equal(info.user, 'Some One');
+});
+
+test('deriveAuthInfo reports API Key when no oauth account but key exported', () => {
+  const info = deriveAuthInfo({}, { ANTHROPIC_API_KEY: 'sk-test' });
+  assert.equal(info.method, 'API Key');
+  assert.equal(info.user, null);
+});
+
+test('deriveAuthInfo returns nulls for missing/invalid input', () => {
+  assert.deepEqual(deriveAuthInfo(null, {}), { method: null, user: null });
+  assert.deepEqual(deriveAuthInfo('junk', {}), { method: null, user: null });
+  assert.deepEqual(deriveAuthInfo({ oauthAccount: 42 }, {}), { method: null, user: null });
+});
+
+test('deriveAuthInfo strips control characters from values', () => {
+  const info = deriveAuthInfo({
+    oauthAccount: {
+      emailAddress: 'evil\x1b[31m@example.com',
+      organizationType: 'claude_max',
+    },
+  }, {});
+  assert.equal(info.user, 'evil[31m');
+});
+
+test('truncateUser truncates with ellipsis and honors 0 = full', () => {
+  assert.equal(truncateUser('yukinoshita.reimu', 8), 'yukinosh…');
+  assert.equal(truncateUser('short', 8), 'short');
+  assert.equal(truncateUser('yukinoshita.reimu', 0), 'yukinoshita.reimu');
+});
+
+test('formatAuthSegment joins method and truncated user', () => {
+  const info = deriveAuthInfo(MAX_ACCOUNT, {});
+  assert.equal(
+    formatAuthSegment(info, { showAuth: true, showAuthUser: true, authUserLength: 8 }),
+    'Claude Max 20x · someone.…',
+  );
+  assert.equal(
+    formatAuthSegment(info, { showAuth: true, showAuthUser: false }),
+    'Claude Max 20x',
+  );
+  assert.equal(
+    formatAuthSegment(info, { showAuth: false, showAuthUser: true, authUserLength: 0 }),
+    'someone.long',
+  );
+  assert.equal(formatAuthSegment(info, { showAuth: false, showAuthUser: false }), null);
+  assert.equal(formatAuthSegment(null, { showAuth: true, showAuthUser: true }), null);
+});

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -52,14 +52,14 @@ test('deriveAuthInfo returns nulls for missing/invalid input', () => {
   assert.deepEqual(deriveAuthInfo({ oauthAccount: 42 }, {}), { method: null, user: null });
 });
 
-test('deriveAuthInfo strips control characters from values', () => {
+test('deriveAuthInfo strips ANSI sequences and control characters from values', () => {
   const info = deriveAuthInfo({
     oauthAccount: {
       emailAddress: 'evil\x1b[31m@example.com',
       organizationType: 'claude_max',
     },
   }, {});
-  assert.equal(info.user, 'evil[31m');
+  assert.equal(info.user, 'evil');
 });
 
 test('truncateUser truncates with ellipsis and honors 0 = full', () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -600,3 +600,53 @@ test("main skips memoryUsage lookup for compact layout even when enabled", async
 
   assert.equal(lookupCalls, 0);
 });
+
+test("main reads auth info only when an auth segment is enabled", async () => {
+  let renderedContext;
+  let lookupCalls = 0;
+
+  await main({
+    readStdin: async () => makeStdin(),
+    parseTranscript: async () => makeTranscript(),
+    countConfigs: async () => makeCounts(),
+    loadConfig: async () => makeConfig({
+      display: { showAuth: true, showAuthUser: false },
+    }),
+    getGitStatus: async () => null,
+    readAuthInfo: () => {
+      lookupCalls += 1;
+      return { method: "API Key", user: null };
+    },
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.equal(lookupCalls, 1);
+  assert.deepEqual(renderedContext?.authInfo, { method: "API Key", user: null });
+});
+
+test("main skips auth file I/O when auth segments are disabled", async () => {
+  let renderedContext;
+  let lookupCalls = 0;
+
+  await main({
+    readStdin: async () => makeStdin(),
+    parseTranscript: async () => makeTranscript(),
+    countConfigs: async () => makeCounts(),
+    loadConfig: async () => makeConfig({
+      display: { showAuth: false, showAuthUser: false },
+    }),
+    getGitStatus: async () => null,
+    readAuthInfo: () => {
+      lookupCalls += 1;
+      return { method: "API Key", user: null };
+    },
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.equal(lookupCalls, 0);
+  assert.equal(renderedContext?.authInfo, null);
+});

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1016,6 +1016,27 @@ test('renderProjectLine can give git its own segment for wrapping', () => {
   assert.ok(line.includes('my-project │ git:(feature/add-auth)'), 'git should render as a separate segment');
 });
 
+test('renderSessionLine shows the enabled auth segment in compact layout', () => {
+  const ctx = baseContext();
+  ctx.authInfo = { method: 'Claude Max 20x', user: 'someone.long' };
+  ctx.config.display.showAuth = true;
+  ctx.config.display.showAuthUser = true;
+  ctx.config.display.authUserLength = 8;
+
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('Claude Max 20x · someone.…'));
+});
+
+test('renderProjectLine shows the enabled auth segment in expanded layout', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.authInfo = { method: 'API Key', user: null };
+  ctx.config.display.showAuth = true;
+
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(line.includes('API Key'));
+});
+
 test('renderToolsLine renders running and completed tools', () => {
   const ctx = baseContext();
   ctx.transcript.tools = [


### PR DESCRIPTION
## Summary

Adds an opt-in segment at the end of the first HUD line showing **how the current Claude Code session is authenticated** — the subscription plan (e.g. `Claude Max 20x`, `Claude Pro`, or `API Key`) and the logged-in account — so multi-account users can tell at a glance which login (and which rate-limit pool) they are currently burning.

```diff
- [Fable] │ my-project git:(main*)
+ [Fable] │ my-project git:(main*) │ Claude Max 20x · yukinosh…
```

Both parts are independently toggleable and **default off**:

| Key | Default | Effect |
|-----|---------|--------|
| `display.showAuth` | `false` | Plan label, e.g. `Claude Max 20x` (tier suffix parsed from the rate-limit tier), or `API Key` when there is no OAuth login but `ANTHROPIC_API_KEY` is set |
| `display.showAuthUser` | `false` | Login account: email local part, falling back to the profile display name |
| `display.authUserLength` | `8` | Truncate the account to N chars + `…` (privacy-friendly for screenshots/streams); `0` shows it in full |

### Changes

- `src/auth.ts` (new) — reads the `oauthAccount` block from `{CLAUDE_CONFIG_DIR}.json` (via the existing `getClaudeConfigJsonPath` helper, so `CLAUDE_CONFIG_DIR` is honored): `organizationType` → plan label (`claude_max` → `Claude Max`), `organizationRateLimitTier` → tier suffix (`default_claude_max_20x` → `20x`), `emailAddress`/`displayName` → account. Pure derivation is separated from I/O for testability, and `readAuthInfo()` never throws
- `src/render/lines/project.ts`, `src/render/session-line.ts` — render the segment (label color) right before the `customLine`-last slot, in both expanded and compact layouts
- `src/config.ts`, `src/types.ts`, `src/index.ts` — config keys + validation, `RenderContext.authInfo`, and a `readAuthInfo` entry in `MainDeps` following the existing injection pattern
- `tests/auth.test.js` (new) — 8 tests covering plan/tier formatting, email/displayName fallback, API-key detection, invalid input, control-character stripping, and truncation
- `README.md`, `commands/configure.md` — document the new keys; listed as preserved advanced settings so the guided `/claude-hud:configure` flow keeps them intact
- `dist/` is intentionally untouched; it is auto-compiled by the `build-dist` workflow

### Design notes

- **Privacy-first defaults**: everything is off unless explicitly enabled, and the account is truncated to 8 chars by default. The statusline is exactly the kind of thing that ends up in screenshots and screen shares, so full identifiers are opt-in twice (enable + `authUserLength: 0`).
- **No extra I/O unless enabled**: `readAuthInfo()` is only called when `showAuth || showAuthUser` (gated in `index.ts`), so users who don't turn this on pay nothing. When enabled it adds one `readFileSync` + `JSON.parse` of `~/.claude.json` per tick — the same file `config-reader.ts` already parses for user-scope MCP counts.
- **Terminal-safety**: all values read from `claude.json` are stripped of control/format characters (`\p{Cc}\p{Cf}`) before rendering, mirroring the sanitization used for other externally-sourced display text.
- Unknown `organizationType` values degrade gracefully (generic word-capitalization, e.g. `claude_team` → `Claude Team`), and a missing/corrupt `claude.json` renders nothing rather than erroring.

## Testing

- `npm test` — 799 pass / 0 fail, including the 8 new `tests/auth.test.js` cases
- End-to-end: piped statusline stdin JSON through `bun src/index.ts` with the options enabled on a real Max login and verified both layouts render `… │ Claude Max 20x · yukinosh…`; with the options absent from config, output is byte-identical to `main`
