### PR TITLE
test: handle non-ASCII entrypoint paths

### DIFF
--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 import { DEFAULT_CONFIG } from "../dist/config.js";
 import { setLanguage } from "../dist/i18n/index.js";
 import { formatSessionDuration, main } from "../dist/index.js";
@@ -158,7 +159,7 @@ test("index entrypoint runs when executed directly", async () => {
     process.env.CLAUDE_CONFIG_DIR = dir;
     setLanguage("en");
     const moduleUrl = new URL("../dist/index.js", import.meta.url);
-    process.argv[1] = new URL(moduleUrl).pathname;
+    process.argv[1] = fileURLToPath(moduleUrl);
     Object.defineProperty(process.stdin, "isTTY", {
       value: true,
       configurable: true,


### PR DESCRIPTION
## Summary

- use Node's `fileURLToPath` when simulating the direct CLI entrypoint
- keep the test aligned with the production entrypoint comparison
- fix the test in checkout paths containing non-ASCII characters

## Root cause

The test assigned `new URL(moduleUrl).pathname` to `process.argv[1]`. URL pathnames retain percent-encoding for non-ASCII characters, while the production entrypoint uses `fileURLToPath(import.meta.url)` and receives a decoded native path. The mismatch prevented the direct-execution branch from running.

## Impact

This only changes test path construction. Production behavior is unchanged. `fileURLToPath` also handles Windows drive letters and UNC paths correctly.

## Verification

- before: `npm test` -> 790 passed, 1 failed, 1 skipped
- after: `npm test` -> 791 passed, 0 failed, 1 skipped
- targeted entrypoint test passed twice
- `npm run build` passed
- `npm run test:stdin` passed

The failure was reproduced from a checkout whose absolute path contains Chinese characters.
