### PR TITLE
Fix symlinked rules and compact cache tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Show cache creation and cache read tokens in compact session-token summaries (#653).
+- Count symlinked rule files and directories with cycle-safe, bounded traversal and cache invalidation (#644).
+
 ## [0.3.0] - 2026-06-19
 
 ### Added

--- a/src/config-reader.ts
+++ b/src/config-reader.ts
@@ -18,6 +18,7 @@ export interface ConfigCounts {
 interface SentinelState {
   mtimeMs: number;
   size: number;
+  realPath?: string;
 }
 
 interface ConfigCacheKey {
@@ -106,17 +107,58 @@ function readStringSetting(filePath: string, key: string): string | undefined {
   return undefined;
 }
 
-function countRulesInDir(rulesDir: string): number {
-  if (!fs.existsSync(rulesDir)) return 0;
+const MAX_RULE_TREE_ENTRIES = 10_000;
+const MAX_RULE_TREE_DIRECTORIES = 1_000;
+
+interface RuleTraversalState {
+  visited: Set<string>;
+  entries: number;
+  directories: number;
+}
+
+function newRuleTraversalState(): RuleTraversalState {
+  return { visited: new Set(), entries: 0, directories: 0 };
+}
+
+function inspectRulePath(inputPath: string): { realPath: string; stat: fs.Stats } | null {
+  try {
+    const realPath = fs.realpathSync.native(inputPath);
+    return { realPath, stat: fs.statSync(realPath) };
+  } catch {
+    return null;
+  }
+}
+
+function countRulesInDir(rulesDir: string, state: RuleTraversalState = newRuleTraversalState()): number {
+  const root = inspectRulePath(rulesDir);
+  if (!root?.stat.isDirectory() || state.visited.has(root.realPath)) return 0;
+  if (state.directories >= MAX_RULE_TREE_DIRECTORIES) {
+    debug(`Rule directory traversal limit reached at ${rulesDir}`);
+    return 0;
+  }
+
+  state.visited.add(root.realPath);
+  state.directories += 1;
   let count = 0;
   try {
-    const entries = fs.readdirSync(rulesDir, { withFileTypes: true });
+    const entries = fs.readdirSync(root.realPath, { withFileTypes: true });
     for (const entry of entries) {
-      const fullPath = path.join(rulesDir, entry.name);
-      if (entry.isDirectory()) {
-        count += countRulesInDir(fullPath);
-      } else if (entry.isFile() && entry.name.endsWith('.md')) {
-        count++;
+      if (state.entries >= MAX_RULE_TREE_ENTRIES) {
+        debug(`Rule entry traversal limit reached at ${rulesDir}`);
+        break;
+      }
+      state.entries += 1;
+
+      const fullPath = path.join(root.realPath, entry.name);
+      const node = inspectRulePath(fullPath);
+      if (!node || state.visited.has(node.realPath)) {
+        continue;
+      }
+      if (node.stat.isDirectory()) {
+        count += countRulesInDir(fullPath, state);
+      } else if (node.stat.isFile() && entry.name.endsWith('.md')) {
+        state.visited.add(node.realPath);
+        count += 1;
       }
     }
   } catch (error) {
@@ -162,7 +204,11 @@ function getConfigCachePath(cwd: string | null, claudeConfigDir: string, homeDir
 function statSentinel(filePath: string): SentinelState | null {
   try {
     const stat = fs.statSync(filePath);
-    return { mtimeMs: stat.mtimeMs, size: stat.size };
+    return {
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+      realPath: normalizePathForComparison(fs.realpathSync.native(filePath)),
+    };
   } catch (err) {
     debug('Failed to stat sentinel %s:', filePath, err instanceof Error ? err.message : err);
     return null;
@@ -195,17 +241,35 @@ function buildSentinelPaths(claudeDir: string, claudeConfigJsonPath: string, cwd
   return paths;
 }
 
-function collectRuleDirectorySentinels(rulesDir: string): string[] {
-  if (!fs.existsSync(rulesDir)) return [];
+function collectRuleDirectorySentinels(
+  rulesDir: string,
+  state: RuleTraversalState = newRuleTraversalState(),
+): string[] {
+  const root = inspectRulePath(rulesDir);
+  if (!root?.stat.isDirectory() || state.visited.has(root.realPath)) return [];
+  if (state.directories >= MAX_RULE_TREE_DIRECTORIES) {
+    debug(`Rule sentinel traversal limit reached at ${rulesDir}`);
+    return [];
+  }
 
+  state.visited.add(root.realPath);
+  state.directories += 1;
   const sentinels = [rulesDir];
   try {
-    const entries = fs.readdirSync(rulesDir, { withFileTypes: true });
+    const entries = fs.readdirSync(root.realPath, { withFileTypes: true });
     for (const entry of entries) {
-      if (!entry.isDirectory()) {
+      if (state.entries >= MAX_RULE_TREE_ENTRIES) {
+        debug(`Rule sentinel entry limit reached at ${rulesDir}`);
+        break;
+      }
+      state.entries += 1;
+
+      const fullPath = path.join(root.realPath, entry.name);
+      const node = inspectRulePath(fullPath);
+      if (!node?.stat.isDirectory() || state.visited.has(node.realPath)) {
         continue;
       }
-      sentinels.push(...collectRuleDirectorySentinels(path.join(rulesDir, entry.name)));
+      sentinels.push(...collectRuleDirectorySentinels(fullPath, state));
     }
   } catch (error) {
     debug(`Failed to read rule sentinel paths from ${rulesDir}:`, error);
@@ -241,7 +305,7 @@ function sentinelsMatch(a: Record<string, SentinelState | null>, b: Record<strin
     const sb = b[key];
     if (sa === null && sb === null) continue;
     if (sa === null || sb === null) return false;
-    if (sa.mtimeMs !== sb.mtimeMs || sa.size !== sb.size) return false;
+    if (sa.mtimeMs !== sb.mtimeMs || sa.size !== sb.size || sa.realPath !== sb.realPath) return false;
   }
   return true;
 }

--- a/src/render/lines/session-tokens.ts
+++ b/src/render/lines/session-tokens.ts
@@ -3,6 +3,27 @@ import { label } from '../colors.js';
 import { t } from '../../i18n/index.js';
 import { formatTokens } from '../../utils/format.js';
 
+export function formatSessionTokenSummary(
+  tokens: NonNullable<RenderContext['transcript']['sessionTokens']>,
+  prefix: string,
+): string | null {
+  const total = tokens.inputTokens + tokens.outputTokens + tokens.cacheCreationTokens + tokens.cacheReadTokens;
+  if (total === 0) {
+    return null;
+  }
+
+  const parts: string[] = [
+    `${t('format.in')}: ${formatTokens(tokens.inputTokens)}`,
+    `${t('format.out')}: ${formatTokens(tokens.outputTokens)}`,
+  ];
+
+  if (tokens.cacheCreationTokens > 0 || tokens.cacheReadTokens > 0) {
+    parts.push(`${t('format.cache')}: ${formatTokens(tokens.cacheCreationTokens + tokens.cacheReadTokens)}`);
+  }
+
+  return `${prefix} ${formatTokens(total)} (${parts.join(', ')})`;
+}
+
 export function renderSessionTokensLine(ctx: RenderContext): string | null {
   const display = ctx.config?.display;
   if (display?.showSessionTokens === false) {
@@ -14,20 +35,7 @@ export function renderSessionTokensLine(ctx: RenderContext): string | null {
     return null;
   }
 
-  const total = tokens.inputTokens + tokens.outputTokens + tokens.cacheCreationTokens + tokens.cacheReadTokens;
-  if (total === 0) {
-    return null;
-  }
-
   const colors = ctx.config?.colors;
-  const parts: string[] = [
-    `${t('format.in')}: ${formatTokens(tokens.inputTokens)}`,
-    `${t('format.out')}: ${formatTokens(tokens.outputTokens)}`,
-  ];
-
-  if (tokens.cacheCreationTokens > 0 || tokens.cacheReadTokens > 0) {
-    parts.push(`${t('format.cache')}: ${formatTokens(tokens.cacheCreationTokens + tokens.cacheReadTokens)}`);
-  }
-
-  return label(`${t('label.tokens')} ${formatTokens(total)} (${parts.join(', ')})`, colors);
+  const summary = formatSessionTokenSummary(tokens, t('label.tokens'));
+  return summary ? label(summary, colors) : null;
 }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -15,6 +15,7 @@ import { formatTokens, formatContextValue } from '../utils/format.js';
 import { formatAuthSegment } from '../auth.js';
 import { createDebug } from '../debug.js';
 import { formatModelDisplay } from './model-display.js';
+import { formatSessionTokenSummary } from './lines/session-tokens.js';
 
 const debug = createDebug('session-line');
 
@@ -274,10 +275,9 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   // Session token usage (cumulative)
   if (display?.showSessionTokens && ctx.transcript.sessionTokens) {
-    const st = ctx.transcript.sessionTokens;
-    const total = st.inputTokens + st.outputTokens + st.cacheCreationTokens + st.cacheReadTokens;
-    if (total > 0) {
-      parts.push(label(`${t('format.tok')}: ${formatTokens(total)} (${t('format.in')}: ${formatTokens(st.inputTokens)}, ${t('format.out')}: ${formatTokens(st.outputTokens)})`, colors));
+    const summary = formatSessionTokenSummary(ctx.transcript.sessionTokens, `${t('format.tok')}:`);
+    if (summary) {
+      parts.push(label(summary, colors));
     }
   }
 

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1931,6 +1931,63 @@ test('countConfigs tolerates rule directory read errors', async () => {
   }
 });
 
+test('countConfigs follows symlinked rule files and directories safely', async () => {
+  const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
+  const projectDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-project-'));
+  const sharedDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-rules-'));
+  const originalHome = process.env.HOME;
+  process.env.HOME = homeDir;
+
+  try {
+    const rulesDir = path.join(projectDir, '.claude', 'rules');
+    await mkdir(rulesDir, { recursive: true });
+    await writeFile(path.join(sharedDir, 'shared.md'), '# shared', 'utf8');
+    await writeFile(path.join(sharedDir, 'direct.md'), '# direct', 'utf8');
+    fs.symlinkSync(sharedDir, path.join(rulesDir, 'pack'), 'dir');
+    fs.symlinkSync(path.join(sharedDir, 'direct.md'), path.join(rulesDir, 'linked.md'), 'file');
+
+    const counts = await countConfigs(projectDir);
+    assert.equal(counts.rulesCount, 2);
+
+    const statBefore = fs.statSync(sharedDir);
+    await writeFile(path.join(sharedDir, 'added.md'), '# added', 'utf8');
+    fs.utimesSync(sharedDir, statBefore.atimeMs / 1000 + 1, statBefore.mtimeMs / 1000 + 1);
+    const updated = await countConfigs(projectDir);
+    assert.equal(updated.rulesCount, 3, 'cache should invalidate when a symlink target changes');
+  } finally {
+    process.env.HOME = originalHome;
+    await rm(homeDir, { recursive: true, force: true });
+    await rm(projectDir, { recursive: true, force: true });
+    await rm(sharedDir, { recursive: true, force: true });
+  }
+});
+
+test('countConfigs skips dangling links, cycles, and duplicate symlink targets', async () => {
+  const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
+  const projectDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-project-'));
+  const sharedDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-rules-'));
+  const originalHome = process.env.HOME;
+  process.env.HOME = homeDir;
+
+  try {
+    const rulesDir = path.join(projectDir, '.claude', 'rules');
+    await mkdir(rulesDir, { recursive: true });
+    await writeFile(path.join(sharedDir, 'one.md'), '# one', 'utf8');
+    fs.symlinkSync(sharedDir, path.join(rulesDir, 'pack-a'), 'dir');
+    fs.symlinkSync(sharedDir, path.join(rulesDir, 'pack-b'), 'dir');
+    fs.symlinkSync(rulesDir, path.join(sharedDir, 'cycle'), 'dir');
+    fs.symlinkSync(path.join(sharedDir, 'missing.md'), path.join(rulesDir, 'dangling.md'), 'file');
+
+    const counts = await countConfigs(projectDir);
+    assert.equal(counts.rulesCount, 1);
+  } finally {
+    process.env.HOME = originalHome;
+    await rm(homeDir, { recursive: true, force: true });
+    await rm(projectDir, { recursive: true, force: true });
+    await rm(sharedDir, { recursive: true, force: true });
+  }
+});
+
 test('countConfigs ignores non-string values in disabledMcpServers', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
   const originalHome = process.env.HOME;

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -2947,6 +2947,23 @@ test('renderSessionLine includes compact session token summary when enabled', ()
   assert.ok(line.includes('tok: 2k (in: 2k, out: 250)'), 'should include compact token summary');
 });
 
+test('renderSessionLine includes compact cache token details when present', () => {
+  const ctx = baseContext();
+  ctx.config.display.showSessionTokens = true;
+  ctx.transcript.sessionTokens = {
+    inputTokens: 7000,
+    outputTokens: 28000,
+    cacheCreationTokens: 12000000,
+    cacheReadTokens: 800000,
+  };
+
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(
+    line.includes('tok: 12.8M (in: 7k, out: 28k, cache: 12.8M)'),
+    `unexpected compact token summary: ${line}`,
+  );
+});
+
 test('renderSessionLine translates compact session token summary when Chinese is enabled', () => {
   const ctx = baseContext();
   ctx.config.display.showSessionTokens = true;
@@ -2960,7 +2977,7 @@ test('renderSessionLine translates compact session token summary when Chinese is
   setLanguage('zh');
   try {
     const line = stripAnsi(renderSessionLine(ctx));
-    assert.ok(line.includes('词元: 2k (输入: 2k, 输出: 250)'), `unexpected zh compact token summary: ${line}`);
+    assert.ok(line.includes('词元: 2k (输入: 2k, 输出: 250, 缓存: 500)'), `unexpected zh compact token summary: ${line}`);
     assert.ok(!line.includes('tok:'), `unexpected bare English token label in zh output: ${line}`);
     assert.ok(!line.includes('in:'), `unexpected bare English input label in zh output: ${line}`);
     assert.ok(!line.includes('out:'), `unexpected bare English output label in zh output: ${line}`);


### PR DESCRIPTION
## Summary

- count symlinked rule files and directories with realpath cycle protection and bounded traversal
- include resolved path identity in config-cache sentinels so symlink target changes invalidate cached counts
- share session-token formatting across layouts and include cache tokens in compact mode

Closes #644
Closes #653

## Security

- traversal is capped at 1,000 directories and 10,000 entries
- dangling links and cycles are skipped
- duplicate symlink targets are counted once

## Validation

- npm ci
- npm run build
- focused symlink and compact-token tests: 4 passed
- npm test: 804 passed, 1 skipped