### PR TITLE
fix weekly usage threshold default

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -480,9 +480,9 @@ function migrateConfig(userConfig: Partial<HudConfig> & LegacyConfig): Partial<H
   return migrated;
 }
 
-function validateThreshold(value: unknown, max = 100): number {
-  if (typeof value !== 'number') return 0;
-  return Math.max(0, Math.min(max, value));
+function validateThreshold(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.min(100, value));
 }
 
 function validateContextThreshold(value: unknown, fallback: number): number {
@@ -708,9 +708,18 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
       migrated.display?.contextCriticalThreshold,
       DEFAULT_CONFIG.display.contextCriticalThreshold,
     ),
-    usageThreshold: validateThreshold(migrated.display?.usageThreshold, 100),
-    sevenDayThreshold: validateThreshold(migrated.display?.sevenDayThreshold, 100),
-    environmentThreshold: validateThreshold(migrated.display?.environmentThreshold, 100),
+    usageThreshold: validateThreshold(
+      migrated.display?.usageThreshold,
+      DEFAULT_CONFIG.display.usageThreshold,
+    ),
+    sevenDayThreshold: validateThreshold(
+      migrated.display?.sevenDayThreshold,
+      DEFAULT_CONFIG.display.sevenDayThreshold,
+    ),
+    environmentThreshold: validateThreshold(
+      migrated.display?.environmentThreshold,
+      DEFAULT_CONFIG.display.environmentThreshold,
+    ),
     externalUsagePath: validateOptionalPath(migrated.display?.externalUsagePath),
     externalUsageWritePath: validateOptionalPath(migrated.display?.externalUsageWritePath),
     externalUsageFreshnessMs: validateFreshnessMs(migrated.display?.externalUsageFreshnessMs),

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -252,6 +252,35 @@ test('mergeConfig falls back to defaults for invalid context thresholds', () => 
   assert.equal(config.display.contextCriticalThreshold, 85);
 });
 
+test('mergeConfig defaults display thresholds from DEFAULT_CONFIG', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.usageThreshold, DEFAULT_CONFIG.display.usageThreshold);
+  assert.equal(config.display.sevenDayThreshold, DEFAULT_CONFIG.display.sevenDayThreshold);
+  assert.equal(config.display.environmentThreshold, DEFAULT_CONFIG.display.environmentThreshold);
+});
+
+test('mergeConfig preserves and clamps explicit display thresholds', () => {
+  const config = mergeConfig({
+    display: { usageThreshold: -10, sevenDayThreshold: 42, environmentThreshold: 150 },
+  });
+  assert.equal(config.display.usageThreshold, 0);
+  assert.equal(config.display.sevenDayThreshold, 42);
+  assert.equal(config.display.environmentThreshold, 100);
+});
+
+test('mergeConfig falls back to defaults for invalid display thresholds', () => {
+  const config = mergeConfig({
+    display: { usageThreshold: 'always', sevenDayThreshold: Number.NaN, environmentThreshold: null },
+  });
+  assert.equal(config.display.usageThreshold, DEFAULT_CONFIG.display.usageThreshold);
+  assert.equal(config.display.sevenDayThreshold, DEFAULT_CONFIG.display.sevenDayThreshold);
+  assert.equal(config.display.environmentThreshold, DEFAULT_CONFIG.display.environmentThreshold);
+  assert.equal(
+    mergeConfig({ display: { sevenDayThreshold: Number.POSITIVE_INFINITY } }).display.sevenDayThreshold,
+    DEFAULT_CONFIG.display.sevenDayThreshold,
+  );
+});
+
 test('mergeConfig preserves valid git branch overflow modes', () => {
   assert.equal(mergeConfig({ gitStatus: { branchOverflow: 'wrap' } }).gitStatus.branchOverflow, 'wrap');
   assert.equal(mergeConfig({ gitStatus: { branchOverflow: 'truncate' } }).gitStatus.branchOverflow, 'truncate');

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1905,6 +1905,25 @@ test('renderSessionLine displays usage percentages (7d hidden when low)', () => 
   assert.ok(line.includes('6%'), 'should include 5h percentage');
 });
 
+test('default merged config hides low weekly usage in compact and expanded layouts', () => {
+  const ctx = baseContext();
+  ctx.config = mergeConfig({});
+  ctx.usageData = {
+    planName: 'Pro',
+    fiveHour: 10,
+    sevenDay: 0,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+  };
+
+  const compactLine = stripAnsi(renderSessionLine(ctx));
+  const expandedLine = stripAnsi(renderUsageLine(ctx) ?? '');
+  assert.ok(compactLine.includes('Usage'), `compact usage should include the 5h window: ${compactLine}`);
+  assert.ok(!compactLine.includes('Weekly'), `compact usage should hide low weekly usage: ${compactLine}`);
+  assert.ok(expandedLine.includes('Usage'), `expanded usage should include the 5h window: ${expandedLine}`);
+  assert.ok(!expandedLine.includes('Weekly'), `expanded usage should hide low weekly usage: ${expandedLine}`);
+});
+
 test('renderSessionLine displays external balance labels', () => {
   const ctx = baseContext();
   ctx.usageData = {
@@ -2055,7 +2074,7 @@ test('renderSessionLine shows 7d reset countdown in text-only mode', () => {
 
 test('renderSessionLine respects sevenDayThreshold override', () => {
   const ctx = baseContext();
-  ctx.config.display.sevenDayThreshold = 0;
+  ctx.config = mergeConfig({ display: { sevenDayThreshold: 0 } });
   ctx.usageData = {
     planName: 'Pro',
     fiveHour: 10,


### PR DESCRIPTION
## What changed

- restore display-threshold fallbacks from `DEFAULT_CONFIG`
- keep explicit threshold values clamped to 0–100
- reject non-finite threshold inputs
- cover config defaults and both compact/expanded weekly rendering

## Root cause

`mergeConfig({})` passed an omitted `sevenDayThreshold` through a validator whose non-number fallback was hardcoded to `0`. That overwrote the documented/default value of `80`, so the Weekly segment rendered even at 0%.

The fix deliberately preserves the existing `usageThreshold: 0` and `environmentThreshold: 0` defaults. No generated `dist/`, dependency, or package-script changes are included.

## Impact

Users who omit `display.sevenDayThreshold` once again see weekly usage only at the default 80% threshold. An explicit value of `0` still opts into always-visible weekly usage.

## Validation

- `npm ci`
- `npm run build`
- focused config/render tests
- `npm test` — 872 passed, 1 skipped
- `npm run test:coverage` — 95.16% statements
- adversarial security review: passed
- readability/maintainability review: passed

Closes #661
