### PR TITLE
release: 0.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hud",
   "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-14
+
+### Fixed
+- Restore the default 80% weekly-usage threshold when the setting is omitted or invalid, preventing the weekly segment from appearing at 0% while preserving the existing usage and environment defaults (#662).
+
 ## [0.4.0] - 2026-07-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hud",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hud",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hud",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Real-time statusline HUD for Claude Code",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release 0.4.1

Patch release for the weekly usage threshold regression fixed in #662.

## Version updates

- `.claude-plugin/plugin.json` → `0.4.1`
- `.claude-plugin/marketplace.json` → `0.4.1`
- `package.json` → `0.4.1`
- `package-lock.json` → `0.4.1`
- `CHANGELOG.md` → `0.4.1` release notes

## Validation

- `npm ci`
- `npm run build`
- `npm test` — 872 passed, 1 skipped
- `npm run test:coverage` — 95.16% statements
- `npm pack --dry-run` — 286 files, 237.3 kB package
- version consistency check — all five version fields match `0.4.1`

After merge, tag `v0.4.1` will publish the GitHub release from the changelog entry.
