### PR TITLE
release: 0.4.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-    "version": "0.4.1"
+    "version": "0.4.2"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hud",
   "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-07-15
+
 ### Fixed
-- Show a useful git ref for detached HEAD sessions by preferring exact tags and falling back to a short detached commit label.
-- Preserve slash-separated branch names in GitHub branch links so clicking the HUD branch opens the expected remote branch.
-- Allow opt-in `--extra-cmd` hooks to use the last non-empty line of sanitized plain-text output in addition to JSON labels.
+- Show a useful git ref for detached HEAD sessions by preferring exact tags and falling back to a linked short commit label (#664).
+- Preserve slash-separated branch names in GitHub branch links so clicking the HUD branch opens the expected remote branch (#664).
+- Allow opt-in `--extra-cmd` hooks to use the last non-empty line of sanitized plain-text output in addition to JSON labels (#664).
+- Strip control and bidirectional characters from Git refs in compact rendering (#664).
 
 ## [0.4.1] - 2026-07-14
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hud",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hud",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hud",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Real-time statusline HUD for Claude Code",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- release the hardened Git ref and opt-in plain-output fixes from #664 as v0.4.2
- align plugin, marketplace, package, lockfile, and changelog versions
- publish from the trusted dist build already on main

## User impact

Detached sessions show useful linked refs, slash-separated branch links resolve correctly, explicitly enabled extra commands can return sanitized plain text, and compact Git refs strip control and bidirectional characters.

## Security and scope

The release diff changes only five version and changelog files. It adds no dependencies, scripts, generated artifacts, runtime behavior, network access, or filesystem behavior.

## Verification

- npm ci
- npm run build
- npm test: 877 passed, 1 skipped
- npm run test:coverage: 95.15% statements
- npm pack --dry-run: 286 files, 238.5 kB
- all five version values verified as 0.4.2