### PR TITLE
feat: opt-in model-scoped weekly usage windows (e.g. Fable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 | `display.showDuration` | boolean | false | Show session duration `⏱️ 5m` |
 | `display.showSpeed` | boolean | false | Show output token speed `out: 42.1 tok/s` |
 | `display.showUsage` | boolean | true | Show Claude subscriber usage limits when available |
+| `display.showScopedUsage` | boolean | false | Opt-in: also show model-scoped weekly quota windows (e.g. Fable) fetched from the OAuth usage API via a background-refreshed cache. Requires access to the Claude Code credential store (macOS keychain / `~/.claude/.credentials.json`) |
 | `display.usageValue` | `percent` \| `remaining` | `percent` | Usage display format (`25%` used, or `75%` remaining) |
 | `display.usageBarEnabled` | boolean | true | Display usage as visual bar instead of text |
 | `display.usageCompact` | boolean | false | Display usage in a shorter text form such as `5h: 25% (1h 30m)`; takes precedence over `display.usageBarEnabled` |

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,6 +124,13 @@ export interface HudConfig {
     showSpeed: boolean;
     showTokenBreakdown: boolean;
     showUsage: boolean;
+    /**
+     * Opt-in: show model-scoped weekly quota windows (e.g. the Fable window)
+     * fetched from the OAuth usage API via a background-refreshed file cache.
+     * Off by default because it reads the Claude Code OAuth token
+     * (macOS keychain / ~/.claude/.credentials.json) outside the render path.
+     */
+    showScopedUsage: boolean;
     usageValue: UsageValueMode;
     usageBarEnabled: boolean;
     showResetLabel: boolean;
@@ -229,6 +236,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showSpeed: false,
     showTokenBreakdown: true,
     showUsage: true,
+    showScopedUsage: false,
     usageValue: 'percent',
     usageBarEnabled: true,
     showResetLabel: true,
@@ -617,6 +625,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showUsage: typeof migrated.display?.showUsage === 'boolean'
       ? migrated.display.showUsage
       : DEFAULT_CONFIG.display.showUsage,
+    showScopedUsage: typeof migrated.display?.showScopedUsage === 'boolean'
+      ? migrated.display.showScopedUsage
+      : DEFAULT_CONFIG.display.showScopedUsage,
     usageValue: validateUsageValue(migrated.display?.usageValue)
       ? migrated.display.usageValue
       : DEFAULT_CONFIG.display.usageValue,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { readStdin, getUsageFromStdin } from "./stdin.js";
+import { getScopedUsage } from './scoped-usage.js';
 import { parseTranscript } from "./transcript.js";
 import { render } from "./render/index.js";
 import { countConfigs } from "./config-reader.js";
@@ -143,6 +144,14 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
             }),
           };
         }
+      }
+    }
+
+    // Model-scoped weekly windows (e.g. Fable) — opt-in, OAuth usage API via SWR file cache.
+    if (usageData && config.display.showScopedUsage === true && config.display.showUsage !== false) {
+      const scopedWindows = getScopedUsage(deps.now());
+      if (scopedWindows.length > 0) {
+        usageData = { ...usageData, scopedWindows };
       }
     }
 

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -44,6 +44,35 @@ export function renderUsageLine(
   const resetsKey = limitResetTimeFormat(timeFormat) === 'absolute' ? "format.resets" : "format.resetsIn";
   const usageCompact = display?.usageCompact ?? false;
   const usageValueMode = display?.usageValue ?? 'percent';
+  const barWidthForScoped = getAdaptiveBarWidth();
+  // Model-scoped weekly windows (e.g. Fable) — same window style, but a distinct
+  // normal-range color (Claude orange 208) so the scoped quota is instantly
+  // distinguishable from the generic 5h/7d windows. Warning/critical thresholds
+  // keep the shared palette. Override via colors.usage as usual.
+  const scopedColors = { ...(colors ?? {}), usage: 208 as const };
+  const scopedWindows = ctx.usageData.scopedWindows ?? [];
+  const scopedSuffix = scopedWindows.length
+    ? ' | ' + scopedWindows
+        .map((w) =>
+          usageCompact
+            ? formatCompactWindowPart(w.label, w.percent, w.resetAt, SEVEN_DAY_WINDOW_MS, timeFormat, scopedColors, usageValueMode)
+            : formatUsageWindowPart({
+                label: w.label,
+                percent: w.percent,
+                resetAt: w.resetAt,
+                windowMs: SEVEN_DAY_WINDOW_MS,
+                colors: scopedColors,
+                usageBarEnabled: display?.usageBarEnabled ?? true,
+                barWidth: barWidthForScoped,
+                timeFormat,
+                showResetLabel,
+                forceLabel: true,
+                alignLabels,
+                usageValueMode,
+              }),
+        )
+        .join(' | ')
+    : '';
 
   if (isLimitReached(ctx.usageData)) {
     const limitTimeFormat = limitResetTimeFormat(timeFormat);
@@ -82,10 +111,13 @@ export function renderUsageLine(
       : null;
 
     if (fiveHourPart && sevenDayPart) {
-      return appendBalance(`${fiveHourPart} | ${sevenDayPart}`, balanceLabel);
+      return appendBalance(`${fiveHourPart} | ${sevenDayPart}${scopedSuffix}`, balanceLabel);
     }
     const compactLine = fiveHourPart ?? sevenDayPart;
-    return compactLine ? appendBalance(compactLine, balanceLabel) : null;
+    if (compactLine) {
+      return appendBalance(`${compactLine}${scopedSuffix}`, balanceLabel);
+    }
+    return scopedSuffix ? appendBalance(scopedSuffix.slice(3), balanceLabel) : null;
   }
 
   const usageBarEnabled = display?.usageBarEnabled ?? true;
@@ -107,7 +139,7 @@ export function renderUsageLine(
       alignLabels,
       usageValueMode,
     });
-    return appendBalance(`${usageLabel} ${weeklyOnlyPart}`, balanceLabel);
+    return appendBalance(`${usageLabel} ${weeklyOnlyPart}${scopedSuffix}`, balanceLabel);
   }
 
   const fiveHourPart = formatUsageWindowPart({
@@ -139,10 +171,10 @@ export function renderUsageLine(
       alignLabels,
       usageValueMode,
     });
-    return appendBalance(`${usageLabel} ${fiveHourPart} | ${sevenDayPart}`, balanceLabel);
+    return appendBalance(`${usageLabel} ${fiveHourPart} | ${sevenDayPart}${scopedSuffix}`, balanceLabel);
   }
 
-  return appendBalance(`${usageLabel} ${fiveHourPart}`, balanceLabel);
+  return appendBalance(`${usageLabel} ${fiveHourPart}${scopedSuffix}`, balanceLabel);
 }
 
 function appendBalance(line: string, balanceLabel: string | null): string {

--- a/src/scoped-usage.ts
+++ b/src/scoped-usage.ts
@@ -24,6 +24,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { spawnSync, spawn } from 'node:child_process';
 import type { ScopedUsageWindow } from './types.js';
 
@@ -92,14 +93,18 @@ export function getScopedUsage(now: number = Date.now(), options: ScopedUsageOpt
 function triggerBackgroundRefresh(dir: string, now: number): void {
   try {
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const marker = refreshMarkerPath(dir);
     try {
-      const markerAge = now - fs.statSync(refreshMarkerPath(dir)).mtimeMs;
+      const markerAge = now - fs.statSync(marker).mtimeMs;
       if (markerAge < REFRESH_MARKER_TTL_MS) return; // refresh already in flight
+      fs.unlinkSync(marker); // stale marker (crashed refresh) — clear before retry
     } catch {
       // no marker — proceed
     }
-    fs.writeFileSync(refreshMarkerPath(dir), String(now), { mode: 0o600 });
-    const child = spawn(process.execPath, [fileURLToPathSafe(import.meta.url), '--refresh'], {
+    // 'wx' creates atomically: if two statusline instances race here, exactly
+    // one wins and spawns the refresh; the loser throws EEXIST into the catch.
+    fs.writeFileSync(marker, String(now), { mode: 0o600, flag: 'wx' });
+    const child = spawn(process.execPath, [fileURLToPath(import.meta.url), '--refresh'], {
       detached: true,
       stdio: 'ignore',
     });
@@ -107,10 +112,6 @@ function triggerBackgroundRefresh(dir: string, now: number): void {
   } catch {
     // best-effort — the HUD must never break on refresh scheduling
   }
-}
-
-function fileURLToPathSafe(url: string): string {
-  return url.startsWith('file://') ? new URL(url).pathname : url;
 }
 
 // ── Refresh path (runs in a detached child, never in the render path) ──
@@ -203,6 +204,16 @@ export async function refreshScopedUsage(options: RefreshOptions = {}): Promise<
   }
 }
 
-if (process.argv.includes('--refresh')) {
+// Refresh entrypoint — only when this file itself is executed with --refresh
+// (argv check alone would run on mere import from another --refresh process).
+const isDirectRun = (() => {
+  try {
+    return Boolean(process.argv[1]) && pathToFileURL(process.argv[1]).href === import.meta.url;
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectRun && process.argv.includes('--refresh')) {
   void refreshScopedUsage();
 }

--- a/src/scoped-usage.ts
+++ b/src/scoped-usage.ts
@@ -1,0 +1,208 @@
+/**
+ * Model-scoped weekly usage windows (e.g. the Fable weekly quota).
+ *
+ * Claude Code's statusline stdin only carries the generic five_hour/seven_day
+ * rate limits. Premium models (Fable/Mythos class) have an additional
+ * `weekly_scoped` window that is only visible via the OAuth usage API
+ * (the same source the /usage screen uses):
+ *
+ *   GET https://api.anthropic.com/api/oauth/usage
+ *   → limits[] entries with kind="weekly_scoped" and scope.model.display_name
+ *
+ * Strategy: stale-while-revalidate file cache so the statusline render path
+ * never blocks on the network or keychain.
+ *  - Fresh cache (< TTL): read the cache file only.
+ *  - Stale/missing: serve stale data for this tick and spawn a detached
+ *    background refresh (`node scoped-usage.js --refresh`) that reads the
+ *    OAuth token from the macOS keychain (or ~/.claude/.credentials.json)
+ *    and rewrites the cache. The token never leaves the refresh process
+ *    and is never logged or rendered.
+ *
+ * Opt-in via `display.showScopedUsage` (default false) because the refresh
+ * process reads the Claude Code OAuth credential store.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawnSync, spawn } from 'node:child_process';
+import type { ScopedUsageWindow } from './types.js';
+
+export type { ScopedUsageWindow };
+
+interface ScopedUsageCacheFile {
+  updated_at: number;
+  windows: Array<{ label: string; percent: number; resets_at: string | null }>;
+}
+
+export interface ScopedUsageOptions {
+  /** Cache directory override (tests). Defaults to ~/.claude/plugins/claude-hud/scoped-usage-cache. */
+  cacheDir?: string;
+  /** Set false to suppress the background refresh spawn (tests). */
+  triggerRefresh?: boolean;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+/** After this long without a successful refresh, hide the data instead of showing stale values. */
+const CACHE_MAX_AGE_MS = 60 * 60 * 1000;
+const REFRESH_MARKER_TTL_MS = 60 * 1000;
+
+function defaultCacheDir(): string {
+  return path.join(os.homedir(), '.claude', 'plugins', 'claude-hud', 'scoped-usage-cache');
+}
+
+function cachePath(dir: string): string {
+  return path.join(dir, 'cache.json');
+}
+
+function refreshMarkerPath(dir: string): string {
+  return path.join(dir, 'refreshing');
+}
+
+/**
+ * Read model-scoped weekly windows for the HUD. Never blocks on the network:
+ * serves cached data and triggers a detached background refresh when stale.
+ */
+export function getScopedUsage(now: number = Date.now(), options: ScopedUsageOptions = {}): ScopedUsageWindow[] {
+  const dir = options.cacheDir ?? defaultCacheDir();
+  let cache: ScopedUsageCacheFile | null = null;
+  try {
+    cache = JSON.parse(fs.readFileSync(cachePath(dir), 'utf8')) as ScopedUsageCacheFile;
+  } catch {
+    cache = null;
+  }
+
+  const age = cache && typeof cache.updated_at === 'number' ? now - cache.updated_at : Infinity;
+  if (age >= CACHE_TTL_MS && options.triggerRefresh !== false) {
+    triggerBackgroundRefresh(dir, now);
+  }
+  if (!cache || !Array.isArray(cache.windows) || age >= CACHE_MAX_AGE_MS) {
+    return [];
+  }
+
+  return cache.windows
+    .filter((w) => typeof w?.percent === 'number' && typeof w?.label === 'string' && w.label.length > 0)
+    .map((w) => ({
+      label: w.label,
+      percent: Math.max(0, Math.min(100, w.percent)),
+      resetAt: w.resets_at ? new Date(w.resets_at) : null,
+    }));
+}
+
+/** Spawn a detached refresh process at most once per marker TTL. Best-effort — never throws. */
+function triggerBackgroundRefresh(dir: string, now: number): void {
+  try {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      const markerAge = now - fs.statSync(refreshMarkerPath(dir)).mtimeMs;
+      if (markerAge < REFRESH_MARKER_TTL_MS) return; // refresh already in flight
+    } catch {
+      // no marker — proceed
+    }
+    fs.writeFileSync(refreshMarkerPath(dir), String(now), { mode: 0o600 });
+    const child = spawn(process.execPath, [fileURLToPathSafe(import.meta.url), '--refresh'], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+  } catch {
+    // best-effort — the HUD must never break on refresh scheduling
+  }
+}
+
+function fileURLToPathSafe(url: string): string {
+  return url.startsWith('file://') ? new URL(url).pathname : url;
+}
+
+// ── Refresh path (runs in a detached child, never in the render path) ──
+
+function readOAuthToken(): string | null {
+  // Primary: the macOS keychain entry Claude Code maintains.
+  try {
+    const out = spawnSync('security', ['find-generic-password', '-s', 'Claude Code-credentials', '-w'], {
+      encoding: 'utf8',
+      timeout: 5000,
+    });
+    if (out.status === 0 && out.stdout.trim()) {
+      const creds = JSON.parse(out.stdout.trim()) as { claudeAiOauth?: { accessToken?: string } };
+      const token = creds.claudeAiOauth?.accessToken;
+      if (token) return token;
+    }
+  } catch {
+    // fall through
+  }
+  // Fallback: credentials file (Linux / setups without keychain).
+  try {
+    const raw = fs.readFileSync(path.join(os.homedir(), '.claude', '.credentials.json'), 'utf8');
+    const creds = JSON.parse(raw) as { claudeAiOauth?: { accessToken?: string } };
+    return creds.claudeAiOauth?.accessToken ?? null;
+  } catch {
+    return null;
+  }
+}
+
+interface OAuthUsageLimit {
+  kind?: string;
+  percent?: number;
+  resets_at?: string | null;
+  scope?: { model?: { display_name?: string | null } | null } | null;
+}
+
+/** Extract model-scoped weekly windows from an OAuth usage API response body. */
+export function parseScopedLimits(body: unknown): ScopedUsageCacheFile['windows'] {
+  const limits = (body as { limits?: OAuthUsageLimit[] } | null)?.limits;
+  if (!Array.isArray(limits)) return [];
+  return limits
+    .filter(
+      (l) =>
+        l?.kind === 'weekly_scoped'
+        && typeof l.percent === 'number'
+        && typeof l.scope?.model?.display_name === 'string'
+        && l.scope.model.display_name.length > 0,
+    )
+    .map((l) => ({
+      label: String(l.scope!.model!.display_name),
+      percent: l.percent as number,
+      resets_at: l.resets_at ?? null,
+    }));
+}
+
+export interface RefreshOptions {
+  cacheDir?: string;
+  /** Token override (tests). Defaults to the Claude Code credential store. */
+  token?: string | null;
+  /** Fetch override (tests). */
+  fetchImpl?: typeof fetch;
+}
+
+export async function refreshScopedUsage(options: RefreshOptions = {}): Promise<void> {
+  const dir = options.cacheDir ?? defaultCacheDir();
+  const token = options.token !== undefined ? options.token : readOAuthToken();
+  const doFetch = options.fetchImpl ?? fetch;
+  if (!token) return;
+  try {
+    const res = await doFetch('https://api.anthropic.com/api/oauth/usage', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'anthropic-beta': 'oauth-2025-04-20',
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return;
+    const windows = parseScopedLimits(await res.json());
+    const cache: ScopedUsageCacheFile = { updated_at: Date.now(), windows };
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(cachePath(dir), JSON.stringify(cache), { mode: 0o600 });
+  } catch {
+    // best-effort — keep the previous cache on failure
+  } finally {
+    try {
+      fs.unlinkSync(refreshMarkerPath(dir));
+    } catch {
+      // ignore
+    }
+  }
+}
+
+if (process.argv.includes('--refresh')) {
+  void refreshScopedUsage();
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,15 @@ export interface UsageData {
   fiveHourResetAt: Date | null;
   sevenDayResetAt: Date | null;
   balanceLabel?: string | null;  // optional raw balance text (e.g. "¥6.35")
+  /** Model-scoped weekly windows (e.g. Fable) from the OAuth usage API — see scoped-usage.ts. */
+  scopedWindows?: ScopedUsageWindow[];
+}
+
+/** One model-scoped weekly quota window (e.g. label "Fable", used percent). */
+export interface ScopedUsageWindow {
+  label: string;
+  percent: number;
+  resetAt: Date | null;
 }
 
 export interface ExternalUsageSnapshot {

--- a/tests/scoped-usage.test.js
+++ b/tests/scoped-usage.test.js
@@ -1,0 +1,221 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { getScopedUsage, parseScopedLimits, refreshScopedUsage } from '../dist/scoped-usage.js';
+
+async function withTempDir() {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-scoped-usage-'));
+  return { dir, cleanup: () => rm(dir, { recursive: true, force: true }) };
+}
+
+function cacheJson(updatedAt, windows) {
+  return JSON.stringify({ updated_at: updatedAt, windows });
+}
+
+const FABLE_WINDOW = { label: 'Fable', percent: 38, resets_at: '2026-07-21T06:00:00.000Z' };
+
+// ── getScopedUsage — cache reading ──
+
+test('getScopedUsage returns windows from a fresh cache', async () => {
+  const { dir, cleanup } = await withTempDir();
+  try {
+    const now = Date.now();
+    await writeFile(path.join(dir, 'cache.json'), cacheJson(now, [FABLE_WINDOW]));
+
+    const windows = getScopedUsage(now, { cacheDir: dir, triggerRefresh: false });
+
+    assert.equal(windows.length, 1);
+    assert.equal(windows[0].label, 'Fable');
+    assert.equal(windows[0].percent, 38);
+    assert.equal(windows[0].resetAt.toISOString(), '2026-07-21T06:00:00.000Z');
+  } finally {
+    await cleanup();
+  }
+});
+
+test('getScopedUsage returns empty when there is no cache', async () => {
+  const { dir, cleanup } = await withTempDir();
+  try {
+    assert.deepEqual(getScopedUsage(Date.now(), { cacheDir: dir, triggerRefresh: false }), []);
+  } finally {
+    await cleanup();
+  }
+});
+
+test('getScopedUsage serves stale data within the max age (stale-while-revalidate)', async () => {
+  const { dir, cleanup } = await withTempDir();
+  try {
+    const now = Date.now();
+    // 10 minutes old: past the 5m TTL but well within the 1h max age.
+    await writeFile(path.join(dir, 'cache.json'), cacheJson(now - 10 * 60 * 1000, [FABLE_WINDOW]));
+
+    const windows = getScopedUsage(now, { cacheDir: dir, triggerRefresh: false });
+
+    assert.equal(windows.length, 1);
+  } finally {
+    await cleanup();
+  }
+});
+
+test('getScopedUsage hides data older than the max age', async () => {
+  const { dir, cleanup } = await withTempDir();
+  try {
+    const now = Date.now();
+    await writeFile(path.join(dir, 'cache.json'), cacheJson(now - 2 * 60 * 60 * 1000, [FABLE_WINDOW]));
+
+    assert.deepEqual(getScopedUsage(now, { cacheDir: dir, triggerRefresh: false }), []);
+  } finally {
+    await cleanup();
+  }
+});
+
+test('getScopedUsage tolerates malformed cache content', async () => {
+  const { dir, cleanup } = await withTempDir();
+  try {
+    await writeFile(path.join(dir, 'cache.json'), 'not json');
+    assert.deepEqual(getScopedUsage(Date.now(), { cacheDir: dir, triggerRefresh: false }), []);
+
+    await writeFile(path.join(dir, 'cache.json'), cacheJson(Date.now(), [{ label: '', percent: 'x' }]));
+    assert.deepEqual(getScopedUsage(Date.now(), { cacheDir: dir, triggerRefresh: false }), []);
+  } finally {
+    await cleanup();
+  }
+});
+
+test('getScopedUsage clamps percent into 0-100', async () => {
+  const { dir, cleanup } = await withTempDir();
+  try {
+    const now = Date.now();
+    await writeFile(
+      path.join(dir, 'cache.json'),
+      cacheJson(now, [
+        { label: 'Fable', percent: 140, resets_at: null },
+        { label: 'Other', percent: -5, resets_at: null },
+      ]),
+    );
+
+    const windows = getScopedUsage(now, { cacheDir: dir, triggerRefresh: false });
+
+    assert.equal(windows[0].percent, 100);
+    assert.equal(windows[1].percent, 0);
+    assert.equal(windows[0].resetAt, null);
+  } finally {
+    await cleanup();
+  }
+});
+
+// ── parseScopedLimits — OAuth usage API response extraction ──
+
+test('parseScopedLimits extracts weekly_scoped model windows only', () => {
+  const body = {
+    limits: [
+      { kind: 'session', percent: 33, resets_at: '2026-07-15T11:30:00Z', scope: null },
+      { kind: 'weekly_all', percent: 21, resets_at: '2026-07-21T06:00:00Z', scope: null },
+      {
+        kind: 'weekly_scoped',
+        percent: 38,
+        resets_at: '2026-07-21T06:00:00Z',
+        scope: { model: { id: null, display_name: 'Fable' }, surface: null },
+      },
+    ],
+  };
+
+  const windows = parseScopedLimits(body);
+
+  assert.deepEqual(windows, [
+    { label: 'Fable', percent: 38, resets_at: '2026-07-21T06:00:00Z' },
+  ]);
+});
+
+test('parseScopedLimits skips scoped entries without a model display name or percent', () => {
+  const body = {
+    limits: [
+      { kind: 'weekly_scoped', percent: 12, scope: { model: { display_name: null } } },
+      { kind: 'weekly_scoped', percent: null, scope: { model: { display_name: 'Fable' } } },
+      { kind: 'weekly_scoped', percent: 12, scope: { surface: 'cowork' } },
+    ],
+  };
+
+  assert.deepEqual(parseScopedLimits(body), []);
+});
+
+test('parseScopedLimits tolerates missing or malformed bodies', () => {
+  assert.deepEqual(parseScopedLimits(null), []);
+  assert.deepEqual(parseScopedLimits({}), []);
+  assert.deepEqual(parseScopedLimits({ limits: 'nope' }), []);
+});
+
+// ── refreshScopedUsage — cache writing (fetch/token injected) ──
+
+test('refreshScopedUsage writes parsed windows to the cache file', async () => {
+  const { dir, cleanup } = await withTempDir();
+  try {
+    const fetchImpl = async () => ({
+      ok: true,
+      json: async () => ({
+        limits: [
+          {
+            kind: 'weekly_scoped',
+            percent: 38,
+            resets_at: '2026-07-21T06:00:00Z',
+            scope: { model: { display_name: 'Fable' } },
+          },
+        ],
+      }),
+    });
+
+    await refreshScopedUsage({ cacheDir: dir, token: 'test-token', fetchImpl });
+
+    const cache = JSON.parse(await readFile(path.join(dir, 'cache.json'), 'utf8'));
+    assert.equal(typeof cache.updated_at, 'number');
+    assert.deepEqual(cache.windows, [
+      { label: 'Fable', percent: 38, resets_at: '2026-07-21T06:00:00Z' },
+    ]);
+  } finally {
+    await cleanup();
+  }
+});
+
+test('refreshScopedUsage does nothing without a token', async () => {
+  const { dir, cleanup } = await withTempDir();
+  try {
+    let called = false;
+    await refreshScopedUsage({
+      cacheDir: dir,
+      token: null,
+      fetchImpl: async () => {
+        called = true;
+        return { ok: true, json: async () => ({}) };
+      },
+    });
+
+    assert.equal(called, false);
+    await assert.rejects(readFile(path.join(dir, 'cache.json'), 'utf8'));
+  } finally {
+    await cleanup();
+  }
+});
+
+test('refreshScopedUsage keeps the previous cache when the API fails', async () => {
+  const { dir, cleanup } = await withTempDir();
+  try {
+    const before = cacheJson(123, [FABLE_WINDOW]);
+    await writeFile(path.join(dir, 'cache.json'), before);
+
+    await refreshScopedUsage({ cacheDir: dir, token: 't', fetchImpl: async () => ({ ok: false }) });
+    assert.equal(await readFile(path.join(dir, 'cache.json'), 'utf8'), before);
+
+    await refreshScopedUsage({
+      cacheDir: dir,
+      token: 't',
+      fetchImpl: async () => {
+        throw new Error('network down');
+      },
+    });
+    assert.equal(await readFile(path.join(dir, 'cache.json'), 'utf8'), before);
+  } finally {
+    await cleanup();
+  }
+});

--- a/tests/usage-coverage.test.js
+++ b/tests/usage-coverage.test.js
@@ -289,3 +289,51 @@ test('renderUsageLine elapsedAndAbsolute format for limit uses absolute', () => 
   assert.ok(line.includes('Limit reached'));
   assert.ok(line.includes('resets at'));
 });
+
+// ── Model-scoped weekly windows (e.g. Fable) ──
+
+test('renderUsageLine appends scoped model windows after the shared windows', () => {
+  const ctx = baseContext();
+  ctx.usageData.fiveHour = 40;
+  ctx.usageData.scopedWindows = [
+    { label: 'Fable', percent: 38, resetAt: new Date(Date.now() + 60 * 60 * 1000) },
+  ];
+
+  const line = stripAnsi(renderUsageLine(ctx));
+
+  assert.match(line, /Fable/);
+  assert.match(line, /38%/);
+  // Shared 5h window still renders first.
+  assert.match(line, /40%.*Fable/s);
+});
+
+test('renderUsageLine renders scoped windows in compact mode', () => {
+  const ctx = baseContext();
+  ctx.config.display.usageCompact = true;
+  ctx.usageData.fiveHour = 40;
+  ctx.usageData.scopedWindows = [{ label: 'Fable', percent: 38, resetAt: null }];
+
+  const line = stripAnsi(renderUsageLine(ctx));
+
+  assert.match(line, /Fable: 38%/);
+});
+
+test('renderUsageLine respects usageValue remaining for scoped windows', () => {
+  const ctx = baseContext();
+  ctx.config.display.usageValue = 'remaining';
+  ctx.usageData.fiveHour = 40;
+  ctx.usageData.scopedWindows = [{ label: 'Fable', percent: 38, resetAt: null }];
+
+  const line = stripAnsi(renderUsageLine(ctx));
+
+  assert.match(line, /Fable.*62%/s);
+});
+
+test('renderUsageLine is unchanged when scopedWindows is absent', () => {
+  const withScoped = baseContext();
+  withScoped.usageData.fiveHour = 40;
+
+  const line = stripAnsi(renderUsageLine(withScoped));
+
+  assert.doesNotMatch(line, /Fable/);
+});


### PR DESCRIPTION
## Problem

Claude Code's statusline stdin only carries the generic `five_hour` / `seven_day` rate limits. Weekly quotas scoped to a specific model — e.g. the **Fable** window that the `/usage` screen shows as a separate limit — never appear in the HUD, so users on Claude 5 plans can't see how much of their premium-model quota is left.

The data exists on the OAuth usage API (the same source `/usage` uses): `limits[]` entries with `kind: "weekly_scoped"` and `scope.model.display_name`.

## Fix

Add an **opt-in** `display.showScopedUsage` (default **false**) that appends model-scoped weekly windows to the usage line in the existing window style:

```
Usage ███░░░░░░░ 33% (resets in 1h 24m) | Fable ████░░░░░░ 38% (resets in 5d 19h)
```

- Scoped windows use a distinct normal-range color (Claude orange, 208) so they're visually separate from the shared 5h/7d windows; warning/critical thresholds keep the shared palette, and `colors.usage`-style overrides still apply.
- Works with `usageCompact`, `usageValue: "remaining"`, bar/text styles, and reset-time formats — it reuses the existing `formatUsageWindowPart`/`formatCompactWindowPart` paths.
- Generic by design: any `weekly_scoped` model window the API returns is rendered, not just Fable.

## Render path never blocks

`src/scoped-usage.ts` implements a stale-while-revalidate file cache (5m TTL, 1h max age, `0700`/`0600` modes):

- Fresh cache → file read only.
- Stale/missing → serve stale data for this tick and spawn a **detached child** (`--refresh`) that reads the OAuth token from the macOS keychain (`Claude Code-credentials`) or `~/.claude/.credentials.json`, calls the usage API, and rewrites the cache. A marker file dedupes concurrent refreshes.
- The token stays inside the refresh process — never logged, rendered, or written.

Because the refresh touches the credential store, the feature is **off by default** and the README documents that requirement.

## Tests

- `tests/scoped-usage.test.js` (new): cache freshness/TTL/max-age, malformed-cache tolerance, percent clamping, `parseScopedLimits` extraction from the API shape, and `refreshScopedUsage` write/no-token/API-failure paths (fetch + token injected).
- `tests/usage-coverage.test.js`: scoped windows append after shared windows, compact mode, `usageValue: "remaining"`, and no-op when absent.
- `npm test`: 894 pass / 0 fail. Only `src/`, `tests/`, `README.md` touched — no `dist/` changes per CONTRIBUTING.
