### PR TITLE
feat: render model-scoped weekly usage windows (e.g. Fable) from stdin

### DIFF
--- a/src/external-usage.ts
+++ b/src/external-usage.ts
@@ -220,7 +220,11 @@ export function writeExternalUsageSnapshot(
   deps: FileSystemDeps = fsDeps,
 ): boolean {
   const snapshotPath = resolveSnapshotWritePath(config.display.externalUsageWritePath);
-  if (!snapshotPath || !usage) {
+  if (
+    !snapshotPath
+    || !usage
+    || (usage.fiveHour === null && usage.sevenDay === null)
+  ) {
     return false;
   }
 

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -33,7 +33,10 @@ export function renderUsageLine(
 
   const usageLabel = progressLabel("label.usage", colors, alignLabels);
   const balanceLabel = ctx.usageData.balanceLabel ?? null;
-  const hasWindowData = ctx.usageData.fiveHour !== null || ctx.usageData.sevenDay !== null;
+  const scopedWindows = ctx.usageData.scopedWindows ?? [];
+  const hasWindowData = ctx.usageData.fiveHour !== null
+    || ctx.usageData.sevenDay !== null
+    || scopedWindows.length > 0;
 
   if (balanceLabel && !hasWindowData) {
     return `${usageLabel} ${balanceLabel}`;
@@ -45,23 +48,17 @@ export function renderUsageLine(
   const usageCompact = display?.usageCompact ?? false;
   const usageValueMode = display?.usageValue ?? 'percent';
   const barWidthForScoped = getAdaptiveBarWidth();
-  // Model-scoped weekly windows (e.g. Fable) — same window style, but a distinct
-  // normal-range color (Claude orange 208) so the scoped quota is instantly
-  // distinguishable from the generic 5h/7d windows. Warning/critical thresholds
-  // keep the shared palette. Override via colors.usage as usual.
-  const scopedColors = { ...(colors ?? {}), usage: 208 as const };
-  const scopedWindows = ctx.usageData.scopedWindows ?? [];
   const scopedSuffix = scopedWindows.length
     ? ' | ' + scopedWindows
         .map((w) =>
           usageCompact
-            ? formatCompactWindowPart(w.label, w.percent, w.resetAt, SEVEN_DAY_WINDOW_MS, timeFormat, scopedColors, usageValueMode)
+            ? formatCompactWindowPart(w.label, w.percent, w.resetAt, SEVEN_DAY_WINDOW_MS, timeFormat, colors, usageValueMode)
             : formatUsageWindowPart({
                 label: w.label,
                 percent: w.percent,
                 resetAt: w.resetAt,
                 windowMs: SEVEN_DAY_WINDOW_MS,
-                colors: scopedColors,
+                colors,
                 usageBarEnabled: display?.usageBarEnabled ?? true,
                 barWidth: barWidthForScoped,
                 timeFormat,
@@ -81,21 +78,25 @@ export function renderUsageLine(
         ? formatResetTime(ctx.usageData.fiveHourResetAt, limitTimeFormat)
         : formatResetTime(ctx.usageData.sevenDayResetAt, limitTimeFormat);
     if (usageCompact) {
-      return appendBalance(critical(`⚠ Limit${resetTime ? ` (${resetTime})` : ""}`, colors), balanceLabel);
+      return appendBalance(`${critical(`⚠ Limit${resetTime ? ` (${resetTime})` : ""}`, colors)}${scopedSuffix}`, balanceLabel);
     }
     const resetSuffix = resetTime
       ? showResetLabel
         ? ` (${t(resetsKey)} ${resetTime})`
         : ` (${resetTime})`
       : "";
-    return appendBalance(`${usageLabel} ${critical(`⚠ ${t("status.limitReached")}${resetSuffix}`, colors)}`, balanceLabel);
+    return appendBalance(`${usageLabel} ${critical(`⚠ ${t("status.limitReached")}${resetSuffix}`, colors)}${scopedSuffix}`, balanceLabel);
   }
 
   const threshold = display?.usageThreshold ?? 0;
   const fiveHour = ctx.usageData.fiveHour;
   const sevenDay = ctx.usageData.sevenDay;
 
-  const effectiveUsage = Math.max(fiveHour ?? 0, sevenDay ?? 0);
+  const effectiveUsage = Math.max(
+    fiveHour ?? 0,
+    sevenDay ?? 0,
+    ...scopedWindows.map((window) => window.percent ?? 0),
+  );
   if (effectiveUsage < threshold) {
     return balanceLabel ? `${usageLabel} ${balanceLabel}` : null;
   }
@@ -122,6 +123,14 @@ export function renderUsageLine(
 
   const usageBarEnabled = display?.usageBarEnabled ?? true;
   const barWidth = getAdaptiveBarWidth();
+
+  if (fiveHour === null && sevenDay === null) {
+    return scopedSuffix
+      ? appendBalance(`${usageLabel} ${scopedSuffix.slice(3)}`, balanceLabel)
+      : balanceLabel
+        ? `${usageLabel} ${balanceLabel}`
+        : null;
+  }
 
   if (fiveHour === null && sevenDay !== null) {
     const weeklyOnlyPart = formatUsageWindowPart({

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -44,6 +44,35 @@ export function renderUsageLine(
   const resetsKey = limitResetTimeFormat(timeFormat) === 'absolute' ? "format.resets" : "format.resetsIn";
   const usageCompact = display?.usageCompact ?? false;
   const usageValueMode = display?.usageValue ?? 'percent';
+  const barWidthForScoped = getAdaptiveBarWidth();
+  // Model-scoped weekly windows (e.g. Fable) — same window style, but a distinct
+  // normal-range color (Claude orange 208) so the scoped quota is instantly
+  // distinguishable from the generic 5h/7d windows. Warning/critical thresholds
+  // keep the shared palette. Override via colors.usage as usual.
+  const scopedColors = { ...(colors ?? {}), usage: 208 as const };
+  const scopedWindows = ctx.usageData.scopedWindows ?? [];
+  const scopedSuffix = scopedWindows.length
+    ? ' | ' + scopedWindows
+        .map((w) =>
+          usageCompact
+            ? formatCompactWindowPart(w.label, w.percent, w.resetAt, SEVEN_DAY_WINDOW_MS, timeFormat, scopedColors, usageValueMode)
+            : formatUsageWindowPart({
+                label: w.label,
+                percent: w.percent,
+                resetAt: w.resetAt,
+                windowMs: SEVEN_DAY_WINDOW_MS,
+                colors: scopedColors,
+                usageBarEnabled: display?.usageBarEnabled ?? true,
+                barWidth: barWidthForScoped,
+                timeFormat,
+                showResetLabel,
+                forceLabel: true,
+                alignLabels,
+                usageValueMode,
+              }),
+        )
+        .join(' | ')
+    : '';
 
   if (isLimitReached(ctx.usageData)) {
     const limitTimeFormat = limitResetTimeFormat(timeFormat);
@@ -82,10 +111,13 @@ export function renderUsageLine(
       : null;
 
     if (fiveHourPart && sevenDayPart) {
-      return appendBalance(`${fiveHourPart} | ${sevenDayPart}`, balanceLabel);
+      return appendBalance(`${fiveHourPart} | ${sevenDayPart}${scopedSuffix}`, balanceLabel);
     }
     const compactLine = fiveHourPart ?? sevenDayPart;
-    return compactLine ? appendBalance(compactLine, balanceLabel) : null;
+    if (compactLine) {
+      return appendBalance(`${compactLine}${scopedSuffix}`, balanceLabel);
+    }
+    return scopedSuffix ? appendBalance(scopedSuffix.slice(3), balanceLabel) : null;
   }
 
   const usageBarEnabled = display?.usageBarEnabled ?? true;
@@ -107,7 +139,7 @@ export function renderUsageLine(
       alignLabels,
       usageValueMode,
     });
-    return appendBalance(`${usageLabel} ${weeklyOnlyPart}`, balanceLabel);
+    return appendBalance(`${usageLabel} ${weeklyOnlyPart}${scopedSuffix}`, balanceLabel);
   }
 
   const fiveHourPart = formatUsageWindowPart({
@@ -139,10 +171,10 @@ export function renderUsageLine(
       alignLabels,
       usageValueMode,
     });
-    return appendBalance(`${usageLabel} ${fiveHourPart} | ${sevenDayPart}`, balanceLabel);
+    return appendBalance(`${usageLabel} ${fiveHourPart} | ${sevenDayPart}${scopedSuffix}`, balanceLabel);
   }
 
-  return appendBalance(`${usageLabel} ${fiveHourPart}`, balanceLabel);
+  return appendBalance(`${usageLabel} ${fiveHourPart}${scopedSuffix}`, balanceLabel);
 }
 
 function appendBalance(line: string, balanceLabel: string | null): string {

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -174,8 +174,34 @@ export function renderSessionLine(ctx: RenderContext): string {
     const usageCompact = display?.usageCompact ?? false;
     const showResetLabel = display?.showResetLabel ?? true;
     const usageValueMode = display?.usageValue ?? 'percent';
+    const scopedWindows = ctx.usageData.scopedWindows ?? [];
+    const hasGenericWindowData = ctx.usageData.fiveHour !== null || ctx.usageData.sevenDay !== null;
+    const hasWindowData = hasGenericWindowData || scopedWindows.length > 0;
+    const scopedParts = scopedWindows.map((window) =>
+      usageCompact
+        ? formatCompactWindowPart(
+            window.label,
+            window.percent,
+            window.resetAt,
+            timeFormat,
+            colors,
+            usageValueMode,
+          )
+        : formatUsageWindowPart({
+            label: window.label,
+            percent: window.percent,
+            resetAt: window.resetAt,
+            colors,
+            usageBarEnabled: display?.usageBarEnabled ?? true,
+            barWidth,
+            timeFormat,
+            showResetLabel,
+            forceLabel: true,
+            usageValueMode,
+            windowDurationLabel: '7d',
+          }),
+    );
 
-    const hasWindowData = ctx.usageData.fiveHour !== null || ctx.usageData.sevenDay !== null;
     if (isLimitReached(ctx.usageData)) {
       const resetTime = ctx.usageData.fiveHour === 100
         ? formatResetTime(ctx.usageData.fiveHourResetAt, timeFormat)
@@ -190,11 +216,16 @@ export function renderSessionLine(ctx: RenderContext): string {
           : '';
         parts.push(critical(`⚠ ${t('status.limitReached')}${resetSuffix}`, colors));
       }
+      parts.push(...scopedParts);
     } else {
       const usageThreshold = display?.usageThreshold ?? 0;
       const fiveHour = ctx.usageData.fiveHour;
       const sevenDay = ctx.usageData.sevenDay;
-      const effectiveUsage = Math.max(fiveHour ?? 0, sevenDay ?? 0);
+      const effectiveUsage = Math.max(
+        fiveHour ?? 0,
+        sevenDay ?? 0,
+        ...scopedWindows.map((window) => window.percent ?? 0),
+      );
 
       if ((hasWindowData || !ctx.usageData.balanceLabel) && effectiveUsage >= usageThreshold) {
         const usageBarEnabled = display?.usageBarEnabled ?? true;
@@ -215,6 +246,7 @@ export function renderSessionLine(ctx: RenderContext): string {
           } else if (sevenDayPart) {
             parts.push(sevenDayPart);
           }
+          parts.push(...scopedParts);
         } else if (fiveHour === null && sevenDay !== null) {
           const weeklyOnlyPart = formatUsageWindowPart({
             label: t('label.weekly'),
@@ -229,7 +261,8 @@ export function renderSessionLine(ctx: RenderContext): string {
             usageValueMode,
           });
           parts.push(weeklyOnlyPart);
-        } else {
+          parts.push(...scopedParts);
+        } else if (hasGenericWindowData || !hasWindowData) {
           const fiveHourPart = formatUsageWindowPart({
             label: '5h',
             percent: fiveHour,
@@ -261,6 +294,11 @@ export function renderSessionLine(ctx: RenderContext): string {
           } else {
             parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
           }
+          parts.push(...scopedParts);
+        } else if (scopedParts.length > 0) {
+          const [firstScopedPart, ...remainingScopedParts] = scopedParts;
+          parts.push(`${label(t('label.usage'), colors)} ${firstScopedPart}`);
+          parts.push(...remainingScopedParts);
         }
       }
     }
@@ -393,6 +431,7 @@ function formatUsageWindowPart({
   showResetLabel,
   forceLabel = false,
   usageValueMode = 'percent',
+  windowDurationLabel,
 }: {
   label: string;
   percent: number | null;
@@ -404,6 +443,7 @@ function formatUsageWindowPart({
   showResetLabel: boolean;
   forceLabel?: boolean;
   usageValueMode?: UsageValueMode;
+  windowDurationLabel?: string;
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors, usageValueMode);
   const reset = formatResetTime(resetAt, timeFormat);
@@ -415,7 +455,7 @@ function formatUsageWindowPart({
     // Relative mode keeps the upstream "(duration / windowLabel)" pattern (e.g. "2h 30m / 5h").
     // Absolute/both modes use the preposition form instead — "(at 14:30 / 5h)" is incoherent.
     const barReset = timeFormat === 'relative'
-      ? (reset ? `${reset} / ${windowLabel}` : null)
+      ? (reset ? `${reset} / ${windowDurationLabel ?? windowLabel}` : null)
       : (reset ? (showResetLabel ? `${t(resetsKey)} ${reset}` : reset) : null);
     const body = barReset
       ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${barReset})`

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -1,8 +1,9 @@
-import type { StdinData, UsageData, TranscriptData } from './types.js';
+import type { ScopedUsageWindow, StdinData, UsageData, TranscriptData } from './types.js';
 import type { ModelFormatMode } from './config.js';
 import { AUTOCOMPACT_BUFFER_PERCENT } from './constants.js';
 import { createDebug } from './debug.js';
 import { sanitizeTranscriptModel } from './model-source.js';
+import { sanitizeDisplayText } from './utils/sanitize.js';
 
 const debug = createDebug('stdin');
 
@@ -356,7 +357,8 @@ export function getUsageFromStdin(stdin: StdinData): UsageData | null {
 
   const fiveHour = parseRateLimitPercent(rateLimits.five_hour?.used_percentage);
   const sevenDay = parseRateLimitPercent(rateLimits.seven_day?.used_percentage);
-  if (fiveHour === null && sevenDay === null) {
+  const scopedWindows = parseScopedWindows(rateLimits.model_scoped);
+  if (fiveHour === null && sevenDay === null && scopedWindows.length === 0) {
     return null;
   }
 
@@ -365,7 +367,38 @@ export function getUsageFromStdin(stdin: StdinData): UsageData | null {
     sevenDay,
     fiveHourResetAt: parseRateLimitResetAt(rateLimits.five_hour?.resets_at),
     sevenDayResetAt: parseRateLimitResetAt(rateLimits.seven_day?.resets_at),
+    ...(scopedWindows.length > 0 && { scopedWindows }),
   };
+}
+
+/**
+ * Parses `rate_limits.model_scoped` (model-scoped weekly windows, e.g. Fable).
+ * The upstream schema carries `utilization` as a 0-1 fraction — convert to the
+ * 0-100 percent scale the rest of UsageData uses. Malformed entries are dropped.
+ */
+function parseScopedWindows(modelScoped: unknown): ScopedUsageWindow[] {
+  if (!Array.isArray(modelScoped)) {
+    return [];
+  }
+  const windows: ScopedUsageWindow[] = [];
+  for (const raw of modelScoped) {
+    const entry = raw as { display_name?: unknown; utilization?: unknown; resets_at?: unknown } | null;
+    const label = typeof entry?.display_name === 'string' ? sanitizeDisplayText(entry.display_name).trim() : '';
+    const utilization = entry?.utilization;
+    if (!label || typeof utilization !== 'number' || !Number.isFinite(utilization)) {
+      continue;
+    }
+    const resetAtRaw = entry?.resets_at;
+    const resetAt = typeof resetAtRaw === 'string' && !Number.isNaN(Date.parse(resetAtRaw))
+      ? new Date(resetAtRaw)
+      : null;
+    windows.push({
+      label,
+      percent: Math.max(0, Math.min(100, utilization * 100)),
+      resetAt,
+    });
+  }
+  return windows;
 }
 
 /**

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -7,6 +7,10 @@ import { sanitizeDisplayText } from './utils/sanitize.js';
 
 const debug = createDebug('stdin');
 
+const SCOPED_USAGE_MAX_WINDOWS = 8;
+const SCOPED_USAGE_LABEL_MAX_LENGTH = 64;
+const SCOPED_USAGE_RESET_MAX_LENGTH = 64;
+
 type StdinStream = Pick<NodeJS.ReadStream, 'setEncoding' | 'on' | 'off' | 'pause'> & {
   isTTY?: boolean;
 };
@@ -373,8 +377,9 @@ export function getUsageFromStdin(stdin: StdinData): UsageData | null {
 
 /**
  * Parses `rate_limits.model_scoped` (model-scoped weekly windows, e.g. Fable).
- * The upstream schema carries `utilization` as a 0-1 fraction — convert to the
- * 0-100 percent scale the rest of UsageData uses. Malformed entries are dropped.
+ * The upstream schema carries `utilization` on the same 0-100 scale used by
+ * the generic rate-limit windows. Malformed entries are dropped, and both the
+ * retained entry count and label size are bounded because stdin is untrusted.
  */
 function parseScopedWindows(modelScoped: unknown): ScopedUsageWindow[] {
   if (!Array.isArray(modelScoped)) {
@@ -382,19 +387,32 @@ function parseScopedWindows(modelScoped: unknown): ScopedUsageWindow[] {
   }
   const windows: ScopedUsageWindow[] = [];
   for (const raw of modelScoped) {
+    if (windows.length >= SCOPED_USAGE_MAX_WINDOWS) {
+      break;
+    }
     const entry = raw as { display_name?: unknown; utilization?: unknown; resets_at?: unknown } | null;
-    const label = typeof entry?.display_name === 'string' ? sanitizeDisplayText(entry.display_name).trim() : '';
+    const label = typeof entry?.display_name === 'string'
+      ? sanitizeDisplayText(entry.display_name).trim().slice(0, SCOPED_USAGE_LABEL_MAX_LENGTH)
+      : '';
+    if (!label) {
+      continue;
+    }
     const utilization = entry?.utilization;
-    if (!label || typeof utilization !== 'number' || !Number.isFinite(utilization)) {
+    const percent = utilization === null
+      ? null
+      : parseRateLimitPercent(utilization as number | undefined);
+    if (utilization !== null && percent === null) {
       continue;
     }
     const resetAtRaw = entry?.resets_at;
-    const resetAt = typeof resetAtRaw === 'string' && !Number.isNaN(Date.parse(resetAtRaw))
+    const resetAt = typeof resetAtRaw === 'string'
+      && resetAtRaw.length <= SCOPED_USAGE_RESET_MAX_LENGTH
+      && !Number.isNaN(Date.parse(resetAtRaw))
       ? new Date(resetAtRaw)
       : null;
     windows.push({
       label,
-      percent: Math.max(0, Math.min(100, utilization * 100)),
+      percent,
       resetAt,
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export interface StdinData {
     /**
      * Model-scoped weekly windows (e.g. the Fable weekly quota shown on /usage).
      * Additive field — Claude Code's internal status schema defines it as
-     * { display_name, utilization (0-1 fraction), resets_at (ISO-8601) } and only
+     * { display_name, utilization (0-100 percent), resets_at (ISO-8601) } and only
      * includes it when the server returns per-model windows.
      */
     model_scoped?: Array<{
@@ -102,7 +102,7 @@ export interface UsageData {
 /** One model-scoped weekly quota window (e.g. label "Fable", used percent 0-100). */
 export interface ScopedUsageWindow {
   label: string;
-  percent: number;
+  percent: number | null;
   resetAt: Date | null;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,17 @@ export interface StdinData {
       used_percentage?: number | null;
       resets_at?: number | null;
     } | null;
+    /**
+     * Model-scoped weekly windows (e.g. the Fable weekly quota shown on /usage).
+     * Additive field — Claude Code's internal status schema defines it as
+     * { display_name, utilization (0-1 fraction), resets_at (ISO-8601) } and only
+     * includes it when the server returns per-model windows.
+     */
+    model_scoped?: Array<{
+      display_name?: string | null;
+      utilization?: number | null;
+      resets_at?: string | null;
+    }> | null;
   } | null;
   // Claude Code 2.1.115+ exposes effort as an object: { level: "max" }.
   // Earlier versions (≤2.1.114) did not send this field at all. The bare-string
@@ -84,6 +95,15 @@ export interface UsageData {
   fiveHourResetAt: Date | null;
   sevenDayResetAt: Date | null;
   balanceLabel?: string | null;  // optional raw balance text (e.g. "¥6.35")
+  /** Model-scoped weekly windows (e.g. Fable) from stdin rate_limits.model_scoped. */
+  scopedWindows?: ScopedUsageWindow[];
+}
+
+/** One model-scoped weekly quota window (e.g. label "Fable", used percent 0-100). */
+export interface ScopedUsageWindow {
+  label: string;
+  percent: number;
+  resetAt: Date | null;
 }
 
 export interface ExternalUsageSnapshot {

--- a/tests/external-usage.test.js
+++ b/tests/external-usage.test.js
@@ -252,6 +252,30 @@ test('writeExternalUsageSnapshot is a no-op without parsed stdin rate limits', a
   }
 });
 
+test('writeExternalUsageSnapshot does not replace shared limits with scoped-only usage', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-external-write-'));
+  const filePath = path.join(dir, 'usage.json');
+
+  try {
+    const wrote = writeExternalUsageSnapshot(
+      makeWriteConfig(filePath),
+      {
+        fiveHour: null,
+        sevenDay: null,
+        fiveHourResetAt: null,
+        sevenDayResetAt: null,
+        scopedWindows: [{ label: 'Fable', percent: 38, resetAt: null }],
+      },
+      Date.now(),
+    );
+
+    assert.equal(wrote, false);
+    assert.equal(fs.existsSync(filePath), false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('writeExternalUsageSnapshot removes temp files when atomic rename fails', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-external-usage-write-'));
   const filePath = path.join(dir, 'usage.json');

--- a/tests/scoped-usage.test.js
+++ b/tests/scoped-usage.test.js
@@ -1,20 +1,89 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { getUsageFromStdin } from '../dist/stdin.js';
+import { renderUsageLine } from '../dist/render/lines/usage.js';
+import { renderSessionLine } from '../dist/render/session-line.js';
 
 // Model-scoped weekly windows (rate_limits.model_scoped) — additive stdin field.
-// Upstream schema: { display_name, utilization (0-1 fraction), resets_at (ISO-8601) }.
+// Upstream schema: { display_name, utilization (0-100 percent), resets_at (ISO-8601) }.
 
 function stdinWith(rateLimits) {
   return { rate_limits: rateLimits };
 }
 
-test('getUsageFromStdin maps model_scoped entries to scopedWindows (fraction → percent)', () => {
+function stripAnsi(value) {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+function renderContext(usageData, display = {}, colors = {}) {
+  return {
+    stdin: {
+      model: { display_name: 'Opus' },
+      context_window: {
+        context_window_size: 200000,
+        used_percentage: 10,
+        current_usage: {
+          input_tokens: 20000,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    },
+    transcript: { tools: [], skills: [], mcpServers: [], agents: [], todos: [] },
+    claudeMdCount: 0,
+    rulesCount: 0,
+    mcpCount: 0,
+    hooksCount: 0,
+    sessionDuration: '',
+    gitStatus: null,
+    usageData,
+    memoryUsage: null,
+    config: {
+      lineLayout: 'compact',
+      pathLevels: 1,
+      display: {
+        showModel: true,
+        showProject: false,
+        showContextBar: true,
+        showUsage: true,
+        usageBarEnabled: false,
+        showResetLabel: true,
+        usageThreshold: 0,
+        sevenDayThreshold: 80,
+        ...display,
+      },
+      colors: {
+        context: 'green',
+        warning: 'yellow',
+        usageWarning: 'brightMagenta',
+        critical: 'red',
+        model: 'cyan',
+        label: 'dim',
+        ...colors,
+      },
+    },
+  };
+}
+
+function scopedUsage(overrides = {}) {
+  return {
+    fiveHour: null,
+    sevenDay: null,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    scopedWindows: [{ label: 'Fable', percent: 38, resetAt: null }],
+    ...overrides,
+  };
+}
+
+test('getUsageFromStdin maps model_scoped entries on the upstream 0-100 scale', () => {
   const usage = getUsageFromStdin(stdinWith({
     five_hour: { used_percentage: 33, resets_at: 1784115000 },
     seven_day: { used_percentage: 21, resets_at: 1784613600 },
     model_scoped: [
-      { display_name: 'Fable', utilization: 0.38, resets_at: '2026-07-21T06:00:00.000Z' },
+      { display_name: 'Fable', utilization: 38, resets_at: '2026-07-21T06:00:00.000Z' },
     ],
   }));
 
@@ -35,7 +104,7 @@ test('getUsageFromStdin omits scopedWindows when model_scoped is absent', () => 
 
 test('getUsageFromStdin returns usage when only model_scoped is present', () => {
   const usage = getUsageFromStdin(stdinWith({
-    model_scoped: [{ display_name: 'Fable', utilization: 0.5, resets_at: null }],
+    model_scoped: [{ display_name: 'Fable', utilization: 50, resets_at: null }],
   }));
 
   assert.notEqual(usage, null);
@@ -48,24 +117,26 @@ test('getUsageFromStdin drops malformed model_scoped entries', () => {
   const usage = getUsageFromStdin(stdinWith({
     five_hour: { used_percentage: 10, resets_at: null },
     model_scoped: [
-      { display_name: '', utilization: 0.5 }, // empty label
-      { display_name: 'Fable', utilization: null }, // no utilization
+      { display_name: '', utilization: 50 }, // empty label
+      { display_name: 'Fable', utilization: null }, // valid unknown utilization
       { display_name: 'Fable', utilization: 'x' }, // non-numeric
-      { display_name: 'Sonnet', utilization: 0.2, resets_at: 'not-a-date' }, // bad date → null resetAt
+      { display_name: 'Sonnet', utilization: 20, resets_at: 'not-a-date' }, // bad date → null resetAt
       null,
     ],
   }));
 
-  assert.equal(usage.scopedWindows.length, 1);
-  assert.equal(usage.scopedWindows[0].label, 'Sonnet');
-  assert.equal(usage.scopedWindows[0].resetAt, null);
+  assert.equal(usage.scopedWindows.length, 2);
+  assert.equal(usage.scopedWindows[0].label, 'Fable');
+  assert.equal(usage.scopedWindows[0].percent, null);
+  assert.equal(usage.scopedWindows[1].label, 'Sonnet');
+  assert.equal(usage.scopedWindows[1].resetAt, null);
 });
 
 test('getUsageFromStdin clamps utilization into 0-100 percent', () => {
   const usage = getUsageFromStdin(stdinWith({
     model_scoped: [
-      { display_name: 'Over', utilization: 1.4 },
-      { display_name: 'Under', utilization: -0.1 },
+      { display_name: 'Over', utilization: 140 },
+      { display_name: 'Under', utilization: -10 },
     ],
   }));
 
@@ -73,9 +144,12 @@ test('getUsageFromStdin clamps utilization into 0-100 percent', () => {
   assert.equal(usage.scopedWindows[1].percent, 0);
 });
 
-test('getUsageFromStdin sanitizes display_name (no ANSI smuggling into the terminal)', () => {
+test('getUsageFromStdin sanitizes ANSI, OSC 8, controls, and bidi from display_name', () => {
   const usage = getUsageFromStdin(stdinWith({
-    model_scoped: [{ display_name: '[31mFable[0m', utilization: 0.3 }],
+    model_scoped: [{
+      display_name: '\x1b]8;;https://evil.test\x07\x1b[31mFa\n\u202Eble\x1b[0m\x1b]8;;\x07',
+      utilization: 30,
+    }],
   }));
 
   assert.equal(usage.scopedWindows[0].label, 'Fable');
@@ -88,4 +162,53 @@ test('getUsageFromStdin tolerates a non-array model_scoped', () => {
   }));
 
   assert.equal(usage.scopedWindows, undefined);
+});
+
+test('getUsageFromStdin bounds retained windows, labels, and reset parsing', () => {
+  const usage = getUsageFromStdin(stdinWith({
+    model_scoped: Array.from({ length: 12 }, (_, index) => ({
+      display_name: `${'x'.repeat(100)}${index}`,
+      utilization: index,
+      resets_at: 'x'.repeat(65),
+    })),
+  }));
+
+  assert.equal(usage.scopedWindows.length, 8);
+  assert.equal(usage.scopedWindows[0].label.length, 64);
+  assert.equal(usage.scopedWindows[0].resetAt, null);
+});
+
+test('renderUsageLine renders scoped-only usage without a ghost generic window', () => {
+  const line = stripAnsi(renderUsageLine(renderContext(scopedUsage())) ?? '');
+
+  assert.match(line, /Usage\s+Fable 38%/);
+  assert.doesNotMatch(line, /5h|--/);
+});
+
+test('renderUsageLine applies scoped thresholds, remaining mode, and balance', () => {
+  const ctx = renderContext(
+    scopedUsage({ balanceLabel: '$12 left' }),
+    { usageCompact: true, usageValue: 'remaining', usageThreshold: 30 },
+  );
+  const line = stripAnsi(renderUsageLine(ctx) ?? '');
+
+  assert.match(line, /Fable: 62%/);
+  assert.match(line, /\$12 left/);
+});
+
+test('renderSessionLine includes scoped usage and preserves a custom usage color', () => {
+  const line = renderSessionLine(renderContext(scopedUsage(), {}, { usage: 'cyan' }));
+
+  assert.match(stripAnsi(line), /Usage\s+Fable 38%/);
+  assert.match(line, /\x1b\[36m38%\x1b\[0m/);
+});
+
+test('shared limit warnings retain bounded scoped usage in both layouts', () => {
+  const usage = scopedUsage({ fiveHour: 100 });
+  const ctx = renderContext(usage);
+
+  const expanded = stripAnsi(renderUsageLine(ctx) ?? '');
+  const compactLayout = stripAnsi(renderSessionLine(ctx));
+  assert.match(expanded, /Limit reached.*Fable 38%/);
+  assert.match(compactLayout, /Limit reached.*Fable 38%/);
 });

--- a/tests/scoped-usage.test.js
+++ b/tests/scoped-usage.test.js
@@ -1,0 +1,91 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getUsageFromStdin } from '../dist/stdin.js';
+
+// Model-scoped weekly windows (rate_limits.model_scoped) — additive stdin field.
+// Upstream schema: { display_name, utilization (0-1 fraction), resets_at (ISO-8601) }.
+
+function stdinWith(rateLimits) {
+  return { rate_limits: rateLimits };
+}
+
+test('getUsageFromStdin maps model_scoped entries to scopedWindows (fraction → percent)', () => {
+  const usage = getUsageFromStdin(stdinWith({
+    five_hour: { used_percentage: 33, resets_at: 1784115000 },
+    seven_day: { used_percentage: 21, resets_at: 1784613600 },
+    model_scoped: [
+      { display_name: 'Fable', utilization: 0.38, resets_at: '2026-07-21T06:00:00.000Z' },
+    ],
+  }));
+
+  assert.equal(usage.fiveHour, 33);
+  assert.equal(usage.scopedWindows.length, 1);
+  assert.equal(usage.scopedWindows[0].label, 'Fable');
+  assert.equal(usage.scopedWindows[0].percent, 38);
+  assert.equal(usage.scopedWindows[0].resetAt.toISOString(), '2026-07-21T06:00:00.000Z');
+});
+
+test('getUsageFromStdin omits scopedWindows when model_scoped is absent', () => {
+  const usage = getUsageFromStdin(stdinWith({
+    five_hour: { used_percentage: 33, resets_at: null },
+  }));
+
+  assert.equal(usage.scopedWindows, undefined);
+});
+
+test('getUsageFromStdin returns usage when only model_scoped is present', () => {
+  const usage = getUsageFromStdin(stdinWith({
+    model_scoped: [{ display_name: 'Fable', utilization: 0.5, resets_at: null }],
+  }));
+
+  assert.notEqual(usage, null);
+  assert.equal(usage.fiveHour, null);
+  assert.equal(usage.scopedWindows[0].percent, 50);
+  assert.equal(usage.scopedWindows[0].resetAt, null);
+});
+
+test('getUsageFromStdin drops malformed model_scoped entries', () => {
+  const usage = getUsageFromStdin(stdinWith({
+    five_hour: { used_percentage: 10, resets_at: null },
+    model_scoped: [
+      { display_name: '', utilization: 0.5 }, // empty label
+      { display_name: 'Fable', utilization: null }, // no utilization
+      { display_name: 'Fable', utilization: 'x' }, // non-numeric
+      { display_name: 'Sonnet', utilization: 0.2, resets_at: 'not-a-date' }, // bad date → null resetAt
+      null,
+    ],
+  }));
+
+  assert.equal(usage.scopedWindows.length, 1);
+  assert.equal(usage.scopedWindows[0].label, 'Sonnet');
+  assert.equal(usage.scopedWindows[0].resetAt, null);
+});
+
+test('getUsageFromStdin clamps utilization into 0-100 percent', () => {
+  const usage = getUsageFromStdin(stdinWith({
+    model_scoped: [
+      { display_name: 'Over', utilization: 1.4 },
+      { display_name: 'Under', utilization: -0.1 },
+    ],
+  }));
+
+  assert.equal(usage.scopedWindows[0].percent, 100);
+  assert.equal(usage.scopedWindows[1].percent, 0);
+});
+
+test('getUsageFromStdin sanitizes display_name (no ANSI smuggling into the terminal)', () => {
+  const usage = getUsageFromStdin(stdinWith({
+    model_scoped: [{ display_name: '[31mFable[0m', utilization: 0.3 }],
+  }));
+
+  assert.equal(usage.scopedWindows[0].label, 'Fable');
+});
+
+test('getUsageFromStdin tolerates a non-array model_scoped', () => {
+  const usage = getUsageFromStdin(stdinWith({
+    five_hour: { used_percentage: 10, resets_at: null },
+    model_scoped: 'nope',
+  }));
+
+  assert.equal(usage.scopedWindows, undefined);
+});


### PR DESCRIPTION
## Problem

Claude Code defines an additive `rate_limits.model_scoped` array for weekly limits scoped to a specific model. These windows are not currently included in statusline stdin, so the HUD needs to remain inert until upstream starts sending them.

The verified schema is:

```ts
{
  display_name: string,
  utilization: number | null, // percentage on the 0-100 scale
  resets_at: string | null
}
```

## Fix

Parse bounded `rate_limits.model_scoped` entries into `UsageData.scopedWindows` and render them in the existing usage-window style in expanded and compact layouts.

- Pure stdin parsing: no network, credentials, child processes, dependencies, or generated artifacts.
- Preserves upstream `null`, rounds/clamps finite percentages, drops malformed values, and retains at most 8 windows.
- Caps and terminal-sanitizes display labels and bounds reset strings.
- Supports shared/scoped, scoped-only, compact, remaining, balance, threshold, limit, reset-time, and custom-color paths.
- Prevents scoped-only stdin from replacing the shared external snapshot with null generic limits.
- Uses the established usage color palette and user overrides.

## Tests

- Expanded parser and renderer regression coverage in `tests/scoped-usage.test.js`.
- External snapshot regression coverage in `tests/external-usage.test.js`.
- Full suite: 890 pass, 1 skip, 0 fail.
- Coverage: 95.16% statements, 87.32% branches, 96.44% functions.
- CI passed on the reviewed head.

Only `src/` and `tests/` are changed; `dist/` remains generated by the trusted repository workflow.