### PR TITLE
build: prevent stale compiled artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "dist/",
     "src/",
     "commands/",
+    "scripts/clean-dist.mjs",
     ".claude-plugin/"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "node scripts/clean-dist.mjs && tsc",
     "dev": "tsc --watch",
     "test": "npm run build && node --test",
     "test:coverage": "npm run build && c8 --reporter=text --reporter=lcov node --test",

--- a/scripts/clean-dist.mjs
+++ b/scripts/clean-dist.mjs
@@ -1,0 +1,7 @@
+import { rmSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+rmSync(resolve(repositoryRoot, 'dist'), { recursive: true, force: true });

--- a/tests/build-output.test.js
+++ b/tests/build-output.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { existsSync, readdirSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const sourceRoot = join(repositoryRoot, 'src');
+const outputRoot = join(repositoryRoot, 'dist');
+
+function listFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? listFiles(path) : [path];
+  });
+}
+
+test('every compiled artifact has a current TypeScript source file', () => {
+  for (const outputPath of listFiles(outputRoot)) {
+    const relativeOutput = relative(outputRoot, outputPath);
+    const relativeSource = relativeOutput.replace(
+      /(?:\.d\.ts\.map|\.js\.map|\.d\.ts|\.js)$/,
+      '.ts',
+    );
+
+    assert.ok(
+      existsSync(join(sourceRoot, relativeSource)),
+      `orphaned compiled artifact: dist/${relativeOutput}`,
+    );
+  }
+});


### PR DESCRIPTION
## Security finding

The release package still contained eight tracked `dist` artifacts for source files removed months ago. The orphaned `dist/usage-api.js` retained old credential/keychain access, networking, subprocess, and cache-writing code. It is not imported by the current entrypoint, but remained directly package-addressable.

## Fix

- Clean the fixed repository `dist/` directory before every TypeScript build.
- Add a generic invariant test requiring every emitted JS, declaration, or map file to have a current `src/**/*.ts` source.
- Include the fixed-path cleaner in the package allowlist so the published build command is self-contained.
- Leave generated deletions out of this PR; the trusted Build dist workflow will stage them after merge.

## Safety

The cleaner derives the repository root from its own module URL, accepts no arguments/environment paths, and removes only `<repo>/dist`. A symlink test confirmed it removes a `dist` symlink without touching its external target.

## Validation

- Build passed.
- Full suite: 891 pass, 1 skip, 0 fail.
- Coverage passed at 95.16% statements.
- Package dry-run: 279 files; all eight orphans absent.
- Independent security, quality, and readability reviews passed.