### PR TITLE
release: 0.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-    "version": "0.4.2"
+    "version": "0.5.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hud",
   "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-16
+
+### Added
+- Render bounded model-scoped weekly usage windows from Claude Code statusline input in expanded and compact layouts, including remaining-value, reset-time, threshold, and custom-color modes (#669).
+
+### Security
+- Sanitize and bound model-scoped usage labels and values before terminal rendering, and keep scoped-only input from overwriting shared external usage snapshots (#669).
+- Clean compiled output before every build and enforce source-to-artifact parity so removed modules cannot remain in release packages (#670).
+
 ## [0.4.2] - 2026-07-15
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hud",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hud",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hud",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Real-time statusline HUD for Claude Code",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release

Ship Claude HUD 0.5.0.

### Added
- Render bounded model-scoped weekly usage windows from Claude Code statusline input in expanded and compact layouts (#669).

### Security
- Sanitize and bound model-scoped labels/values and protect shared external snapshots (#669).
- Clean compiled output before every build and enforce source-to-artifact parity so removed modules cannot remain packaged (#670).

### Validation
- `npm ci`
- `npm test`: 891 pass, 1 skip, 0 fail
- `npm run test:coverage`: 95.16% statements, 87.29% branches, 96.44% functions
- `npm pack --dry-run`: 279 files, 226.2 kB, no bundled dependencies or orphaned artifacts
- Independent security, quality, and readability reviews passed

Version metadata is aligned at 0.5.0 in the plugin manifest, marketplace metadata, package manifest, and lockfile.