### PR TITLE
fix: align CJK progress labels

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -22,6 +22,7 @@ import {
 import { dim, RESET } from './colors.js';
 import { getTerminalWidth, UNKNOWN_TERMINAL_WIDTH } from '../utils/terminal.js';
 import { codePointCellWidth, isCjkAmbiguousWide } from './width.js';
+import type { ProgressLabelOptions } from './lines/label-align.js';
 
 // eslint-disable-next-line no-control-regex
 const ANSI_ESCAPE_PATTERN = /^(?:\x1b\[[0-9;]*m|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\))/;
@@ -389,10 +390,9 @@ function collectActivityLines(ctx: RenderContext): string[] {
 function renderElementLine(
   ctx: RenderContext,
   element: HudElement,
-  options?: { alignProgressLabels?: boolean },
+  labelOptions: ProgressLabelOptions = {},
 ): string | null {
   const display = ctx.config?.display;
-  const alignProgressLabels = options?.alignProgressLabels ?? false;
 
   switch (element) {
     case 'project':
@@ -400,13 +400,13 @@ function renderElementLine(
     case 'addedDirs':
       return renderAddedDirsLine(ctx);
     case 'context':
-      return renderIdentityLine(ctx, alignProgressLabels);
+      return renderIdentityLine(ctx, labelOptions);
     case 'usage':
-      return renderUsageLine(ctx, alignProgressLabels);
+      return renderUsageLine(ctx, labelOptions);
     case 'promptCache':
       return renderPromptCacheLine(ctx);
     case 'memory':
-      return renderMemoryLine(ctx);
+      return renderMemoryLine(ctx, labelOptions);
     case 'environment':
       return renderEnvironmentLine(ctx);
     case 'tools':
@@ -439,6 +439,15 @@ function renderExpanded(ctx: RenderContext, terminalWidth: number | null = null)
   const elementOrder = ctx.config?.elementOrder ?? DEFAULT_ELEMENT_ORDER;
   const mergeGroups = ctx.config?.display?.mergeGroups ?? DEFAULT_MERGE_GROUPS;
   const mergeGroupLookup = buildMergeGroupLookup(mergeGroups);
+  const memoryLineVisible = elementOrder.includes('memory')
+    && ctx.config?.display?.showMemoryUsage === true
+    && ctx.memoryUsage != null;
+  const otherProgressLineVisible = elementOrder.includes('context')
+    || (elementOrder.includes('usage') && renderUsageLine(ctx) != null);
+  const separateMemoryLabelOptions: ProgressLabelOptions | undefined = memoryLineVisible
+    && otherProgressLineVisible
+    ? { align: true, includeMemoryInWidth: true }
+    : undefined;
   const seen = new Set<HudElement>();
   const lines: Array<{ line: string; isActivity: boolean }> = [];
 
@@ -458,10 +467,17 @@ function renderExpanded(ctx: RenderContext, terminalWidth: number | null = null)
           seen.add(groupedElement);
         }
 
+        // A memory label only needs to influence a group's padding when its
+        // progress bar is rendered on a different row. If memory is part of
+        // this combined row, keep the candidate compact and align only if the
+        // row is later forced to stack.
+        const groupLabelOptions = memoryLineVisible && !mergeSequence.includes('memory')
+          ? separateMemoryLabelOptions
+          : undefined;
         const renderedGroupLines = mergeSequence
           .map(groupedElement => ({
             element: groupedElement,
-            line: renderElementLine(ctx, groupedElement),
+            line: renderElementLine(ctx, groupedElement, groupLabelOptions),
           }))
           .filter(
             (entry): entry is { element: HudElement; line: string } =>
@@ -481,7 +497,8 @@ function renderExpanded(ctx: RenderContext, terminalWidth: number | null = null)
           } else {
             for (const { element: groupedElement, line } of renderedGroupLines) {
               const stackedLine = renderElementLine(ctx, groupedElement, {
-                alignProgressLabels: true,
+                align: true,
+                includeMemoryInWidth: memoryLineVisible,
               }) ?? line;
               lines.push({
                 line: stackedLine,
@@ -491,8 +508,13 @@ function renderExpanded(ctx: RenderContext, terminalWidth: number | null = null)
           }
         } else if (renderedGroupLines.length === 1) {
           const [{ element: groupedElement, line }] = renderedGroupLines;
+          const separateLine = renderElementLine(
+            ctx,
+            groupedElement,
+            separateMemoryLabelOptions,
+          ) ?? line;
           lines.push({
-            line,
+            line: separateLine,
             isActivity: ACTIVITY_ELEMENTS.has(groupedElement),
           });
         }
@@ -503,7 +525,7 @@ function renderExpanded(ctx: RenderContext, terminalWidth: number | null = null)
 
     seen.add(element);
 
-    const line = renderElementLine(ctx, element);
+    const line = renderElementLine(ctx, element, separateMemoryLabelOptions);
     if (!line) {
       continue;
     }

--- a/src/render/lines/identity.ts
+++ b/src/render/lines/identity.ts
@@ -6,7 +6,10 @@ import {
 import { coloredBar, label, getContextColor, RESET } from "../colors.js";
 import { getAdaptiveBarWidth } from "../../utils/terminal.js";
 import { t } from "../../i18n/index.js";
-import { progressLabel } from "./label-align.js";
+import {
+  progressLabel,
+  type ProgressLabelInput,
+} from "./label-align.js";
 import { formatTokens, formatContextValue } from "../../utils/format.js";
 import { createDebug } from "../../debug.js";
 
@@ -14,7 +17,7 @@ const debug = createDebug("context");
 
 export function renderIdentityLine(
   ctx: RenderContext,
-  alignLabels = false,
+  labelOptions: ProgressLabelInput = {},
 ): string {
   const autoCompactWindow = ctx.config?.display?.autoCompactWindow ?? null;
   const rawPercent = getContextPercent(ctx.stdin, autoCompactWindow);
@@ -40,8 +43,8 @@ export function renderIdentityLine(
 
   let line =
     display?.showContextBar !== false
-      ? `${progressLabel("label.context", colors, alignLabels)} ${coloredBar(percent, getAdaptiveBarWidth(), colors, contextThresholds)} ${contextValueDisplay}`
-      : `${progressLabel("label.context", colors, alignLabels)} ${contextValueDisplay}`;
+      ? `${progressLabel("label.context", colors, labelOptions)} ${coloredBar(percent, getAdaptiveBarWidth(), colors, contextThresholds)} ${contextValueDisplay}`
+      : `${progressLabel("label.context", colors, labelOptions)} ${contextValueDisplay}`;
 
   if (display?.showTokenBreakdown !== false && percent >= (display?.contextCriticalThreshold ?? 85)) {
     const usage = ctx.stdin.context_window?.current_usage;
@@ -60,5 +63,3 @@ export function renderIdentityLine(
 
   return line;
 }
-
-

--- a/src/render/lines/label-align.ts
+++ b/src/render/lines/label-align.ts
@@ -9,7 +9,15 @@ const PROGRESS_LABEL_KEYS: MessageKey[] = [
   "label.context",
   "label.usage",
   "label.weekly",
+  "label.approxRam",
 ];
+
+export interface ProgressLabelOptions {
+  align?: boolean;
+  includeMemoryInWidth?: boolean;
+}
+
+export type ProgressLabelInput = boolean | ProgressLabelOptions;
 
 /**
  * Compute the visual width of a plain-text string (no ANSI).
@@ -30,10 +38,13 @@ function plainTextWidth(str: string): number {
   return width;
 }
 
-/** Compute the max visual width across the three progress-bar labels. */
-function maxLabelWidth(): number {
+/** Compute the max visual width across the progress-bar labels in view. */
+function maxLabelWidth(includeMemory = false): number {
   let max = 0;
   for (const key of PROGRESS_LABEL_KEYS) {
+    if (key === "label.approxRam" && !includeMemory) {
+      continue;
+    }
     const w = plainTextWidth(t(key));
     if (w > max) max = w;
   }
@@ -48,9 +59,10 @@ function maxLabelWidth(): number {
 export function paddedLabel(
   key: MessageKey,
   colors?: Partial<HudColorOverrides>,
+  options: Pick<ProgressLabelOptions, "includeMemoryInWidth"> = {},
 ): string {
   const text = t(key);
-  const pad = maxLabelWidth() - plainTextWidth(text);
+  const pad = maxLabelWidth(options.includeMemoryInWidth) - plainTextWidth(text);
   const padded = pad > 0 ? text + " ".repeat(pad) : text;
   return label(padded, colors);
 }
@@ -58,9 +70,12 @@ export function paddedLabel(
 export function progressLabel(
   key: MessageKey,
   colors?: Partial<HudColorOverrides>,
-  align = false,
+  options: ProgressLabelInput = {},
 ): string {
-  return align ? paddedLabel(key, colors) : label(t(key), colors);
+  const normalized = typeof options === "boolean" ? { align: options } : options;
+  return normalized.align
+    ? paddedLabel(key, colors, normalized)
+    : label(t(key), colors);
 }
 
 // Exported for testing only.

--- a/src/render/lines/memory.ts
+++ b/src/render/lines/memory.ts
@@ -1,10 +1,16 @@
 import type { RenderContext } from "../../types.js";
 import { formatBytes } from "../../memory.js";
-import { label, getQuotaColor, quotaBar, RESET } from "../colors.js";
+import { getQuotaColor, quotaBar, RESET } from "../colors.js";
 import { getAdaptiveBarWidth } from "../../utils/terminal.js";
-import { t } from "../../i18n/index.js";
+import {
+  progressLabel,
+  type ProgressLabelOptions,
+} from "./label-align.js";
 
-export function renderMemoryLine(ctx: RenderContext): string | null {
+export function renderMemoryLine(
+  ctx: RenderContext,
+  labelOptions: ProgressLabelOptions = {},
+): string | null {
   const display = ctx.config?.display;
   const colors = ctx.config?.colors;
 
@@ -20,7 +26,11 @@ export function renderMemoryLine(ctx: RenderContext): string | null {
     return null;
   }
 
-  const memoryLabel = label(t("label.approxRam"), colors);
+  const memoryLabel = progressLabel(
+    "label.approxRam",
+    colors,
+    { ...labelOptions, includeMemoryInWidth: true },
+  );
   const percentColor = getQuotaColor(ctx.memoryUsage.usedPercent, colors);
   const percent = `${percentColor}${ctx.memoryUsage.usedPercent}%${RESET}`;
   const bar = quotaBar(

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -5,7 +5,10 @@ import { shouldHideUsage } from "../../stdin.js";
 import { critical, label, getQuotaColor, quotaBar, RESET } from "../colors.js";
 import { getAdaptiveBarWidth } from "../../utils/terminal.js";
 import { t } from "../../i18n/index.js";
-import { progressLabel } from "./label-align.js";
+import {
+  progressLabel,
+  type ProgressLabelInput,
+} from "./label-align.js";
 import type { TimeFormatMode, UsageValueMode } from "../../config.js";
 import { formatResetTime } from "../format-reset-time.js";
 
@@ -14,7 +17,7 @@ const SEVEN_DAY_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 export function renderUsageLine(
   ctx: RenderContext,
-  alignLabels = false,
+  labelOptions: ProgressLabelInput = {},
 ): string | null {
   const display = ctx.config?.display;
   const colors = ctx.config?.colors;
@@ -31,7 +34,7 @@ export function renderUsageLine(
     return null;
   }
 
-  const usageLabel = progressLabel("label.usage", colors, alignLabels);
+  const usageLabel = progressLabel("label.usage", colors, labelOptions);
   const balanceLabel = ctx.usageData.balanceLabel ?? null;
   const scopedWindows = ctx.usageData.scopedWindows ?? [];
   const hasWindowData = ctx.usageData.fiveHour !== null
@@ -64,7 +67,7 @@ export function renderUsageLine(
                 timeFormat,
                 showResetLabel,
                 forceLabel: true,
-                alignLabels,
+                labelOptions,
                 usageValueMode,
               }),
         )
@@ -145,7 +148,7 @@ export function renderUsageLine(
       timeFormat,
       showResetLabel,
       forceLabel: true,
-      alignLabels,
+      labelOptions,
       usageValueMode,
     });
     return appendBalance(`${usageLabel} ${weeklyOnlyPart}${scopedSuffix}`, balanceLabel);
@@ -177,7 +180,7 @@ export function renderUsageLine(
       timeFormat,
       showResetLabel,
       forceLabel: true,
-      alignLabels,
+      labelOptions,
       usageValueMode,
     });
     return appendBalance(`${usageLabel} ${fiveHourPart} | ${sevenDayPart}${scopedSuffix}`, balanceLabel);
@@ -232,7 +235,7 @@ function formatUsageWindowPart({
   timeFormat = 'relative',
   showResetLabel,
   forceLabel = false,
-  alignLabels = false,
+  labelOptions = {},
   usageValueMode = 'percent',
 }: {
   label: string;
@@ -246,13 +249,13 @@ function formatUsageWindowPart({
   timeFormat?: TimeFormatMode;
   showResetLabel: boolean;
   forceLabel?: boolean;
-  alignLabels?: boolean;
+  labelOptions?: ProgressLabelInput;
   usageValueMode?: UsageValueMode;
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors, usageValueMode);
   const reset = formatWindowTime(resetAt, windowMs, timeFormat);
   const styledLabel = labelKey
-    ? progressLabel(labelKey, colors, alignLabels)
+    ? progressLabel(labelKey, colors, labelOptions)
     : label(windowLabel, colors);
   const showResetWording = timeFormat !== 'elapsed' && timeFormat !== 'elapsedAndAbsolute';
   const resetsKey = timeFormat === 'absolute' ? "format.resets" : "format.resetsIn";

--- a/tests/identity-coverage.test.js
+++ b/tests/identity-coverage.test.js
@@ -145,13 +145,15 @@ test('renderIdentityLine uses autoCompactWindow for token display', () => {
   assert.ok(line.includes('10k/100k'));
 });
 
-test('renderIdentityLine supports alignLabels parameter', () => {
+test('renderIdentityLine supports progress label alignment options', () => {
   const ctx = baseContext();
   const lineNoAlign = stripAnsi(renderIdentityLine(ctx, false));
   const lineAlign = stripAnsi(renderIdentityLine(ctx, true));
+  const lineAlignOptions = stripAnsi(renderIdentityLine(ctx, { align: true }));
   // Both should contain Context label
   assert.ok(lineNoAlign.includes('Context'));
   assert.ok(lineAlign.includes('Context'));
+  assert.equal(lineAlignOptions, lineAlign);
 });
 
 test('renderIdentityLine disables autocompact buffer when set to disabled', () => {

--- a/tests/label-align.test.js
+++ b/tests/label-align.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { setLanguage } from "../dist/i18n/index.js";
 import {
   paddedLabel,
+  progressLabel,
   _plainTextWidth,
   _maxLabelWidth,
 } from "../dist/render/lines/label-align.js";
@@ -47,6 +48,34 @@ test("English labels are right-padded to equal visual width (7)", () => {
   assert.equal(_plainTextWidth(context), 7);
   assert.equal(_plainTextWidth(usage), 7);
   assert.equal(_plainTextWidth(weekly), 7);
+});
+
+test("memory label participates in alignment only when memory is visible", () => {
+  setLanguage("en");
+
+  assert.equal(_maxLabelWidth(), 7);
+  assert.equal(_maxLabelWidth(true), 10);
+
+  const options = { includeMemoryInWidth: true };
+  const context = stripAnsi(paddedLabel("label.context", undefined, options));
+  const usage = stripAnsi(paddedLabel("label.usage", undefined, options));
+  const memory = stripAnsi(paddedLabel("label.approxRam", undefined, options));
+
+  assert.equal(context, "Context   ");
+  assert.equal(usage, "Usage     ");
+  assert.equal(memory, "Approx RAM");
+  assert.equal(_plainTextWidth(context), 10);
+  assert.equal(_plainTextWidth(usage), 10);
+  assert.equal(_plainTextWidth(memory), 10);
+});
+
+test("progressLabel preserves the legacy boolean alignment argument", () => {
+  setLanguage("en");
+
+  assert.equal(
+    stripAnsi(progressLabel("label.usage", undefined, true)),
+    stripAnsi(progressLabel("label.usage", undefined, { align: true })),
+  );
 });
 
 test("Chinese labels are right-padded correctly (CJK awareness)", () => {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -595,6 +595,136 @@ test('renderMemoryLine stays hidden in compact layout even when enabled', () => 
   assert.equal(renderMemoryLine(ctx), null);
 });
 
+test('render expanded layout aligns context and memory bars in CJK locales', () => {
+  const ctx = baseContext();
+  ctx.config.language = 'zh-Hans';
+  ctx.config.lineLayout = 'expanded';
+  ctx.config.elementOrder = ['context', 'memory'];
+  ctx.config.display.showMemoryUsage = true;
+  ctx.memoryUsage = {
+    totalBytes: 16 * 1024 ** 3,
+    usedBytes: 10 * 1024 ** 3,
+    freeBytes: 6 * 1024 ** 3,
+    usedPercent: 63,
+  };
+
+  setLanguage('zh-Hans');
+  try {
+    const lines = captureRenderLines(ctx).map(stripAnsi);
+    const contextLine = lines.find(line => line.includes('上下文'));
+    const memoryLine = lines.find(line => line.includes('内存'));
+
+    assert.ok(contextLine?.startsWith('上下文 '), `got: ${contextLine}`);
+    assert.ok(memoryLine?.startsWith('内存   '), `got: ${memoryLine}`);
+  } finally {
+    setLanguage('en');
+  }
+});
+
+test('render expanded layout aligns a combined progress row with separate memory', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.config.elementOrder = ['context', 'usage', 'memory'];
+  ctx.config.display.showMemoryUsage = true;
+  ctx.usageData = {
+    planName: 'Team',
+    fiveHour: 45,
+    sevenDay: 20,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+  };
+  ctx.memoryUsage = {
+    totalBytes: 16 * 1024 ** 3,
+    usedBytes: 10 * 1024 ** 3,
+    freeBytes: 6 * 1024 ** 3,
+    usedPercent: 63,
+  };
+
+  const lines = withTerminal(160, () => captureRenderLines(ctx)).map(stripAnsi);
+  const combinedLine = lines.find(line => line.includes('Context') && line.includes('Usage'));
+  const memoryLine = lines.find(line => line.includes('Approx RAM'));
+
+  assert.ok(combinedLine?.startsWith('Context    '), `got: ${combinedLine}`);
+  assert.ok(combinedLine?.includes('Usage     '), `got: ${combinedLine}`);
+  assert.ok(memoryLine?.startsWith('Approx RAM '), `got: ${memoryLine}`);
+});
+
+test('render expanded layout aligns memory only after a custom merged row wraps', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.config.elementOrder = ['context', 'memory'];
+  ctx.config.display.showMemoryUsage = true;
+  ctx.config.display.mergeGroups = [['context', 'memory']];
+  ctx.memoryUsage = {
+    totalBytes: 16 * 1024 ** 3,
+    usedBytes: 10 * 1024 ** 3,
+    freeBytes: 6 * 1024 ** 3,
+    usedPercent: 63,
+  };
+
+  const combined = withTerminal(160, () => captureRenderLines(ctx)).map(stripAnsi);
+  assert.equal(combined.length, 1);
+  assert.ok(combined[0].startsWith('Context '), `got: ${combined[0]}`);
+  assert.ok(!combined[0].startsWith('Context    '), `wide merged labels should stay compact: ${combined[0]}`);
+
+  const stacked = withTerminal(24, () => captureRenderLines(ctx)).map(stripAnsi);
+  const contextLine = stacked.find(line => line.includes('Context'));
+  const memoryLine = stacked.find(line => line.includes('Approx RAM'));
+  assert.ok(contextLine?.startsWith('Context    '), `got: ${contextLine}`);
+  assert.ok(memoryLine?.startsWith('Approx RAM '), `got: ${memoryLine}`);
+});
+
+test('render expanded layout aligns memory when a hidden merge peer leaves it alone', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.config.elementOrder = ['context', 'usage', 'memory'];
+  ctx.config.display.showMemoryUsage = true;
+  ctx.config.display.mergeGroups = [['usage', 'memory']];
+  ctx.usageData = null;
+  ctx.memoryUsage = {
+    totalBytes: 16 * 1024 ** 3,
+    usedBytes: 10 * 1024 ** 3,
+    freeBytes: 6 * 1024 ** 3,
+    usedPercent: 63,
+  };
+
+  setLanguage('zh-Hans');
+  try {
+    const lines = captureRenderLines(ctx).map(stripAnsi);
+    const contextLine = lines.find(line => line.includes('上下文'));
+    const memoryLine = lines.find(line => line.includes('内存'));
+
+    assert.ok(contextLine?.startsWith('上下文 '), `got: ${contextLine}`);
+    assert.ok(memoryLine?.startsWith('内存   '), `got: ${memoryLine}`);
+  } finally {
+    setLanguage('en');
+  }
+});
+
+test('render expanded layout keeps a lone memory progress label compact', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'expanded';
+  ctx.config.elementOrder = ['usage', 'memory'];
+  ctx.config.display.showMemoryUsage = true;
+  ctx.config.display.mergeGroups = [['usage', 'memory']];
+  ctx.usageData = null;
+  ctx.memoryUsage = {
+    totalBytes: 16 * 1024 ** 3,
+    usedBytes: 10 * 1024 ** 3,
+    freeBytes: 6 * 1024 ** 3,
+    usedPercent: 63,
+  };
+
+  setLanguage('zh-Hans');
+  try {
+    const [memoryLine] = captureRenderLines(ctx).map(stripAnsi);
+    assert.ok(memoryLine.startsWith('内存 '), `got: ${memoryLine}`);
+    assert.ok(!memoryLine.startsWith('内存   '), `lone labels should not pad: ${memoryLine}`);
+  } finally {
+    setLanguage('en');
+  }
+});
+
 test('renderProjectLine includes extraLabel when present', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = '/tmp/my-project';
@@ -906,6 +1036,7 @@ test('label color overrides apply across shared secondary text surfaces', () => 
   assert.ok(renderIdentityLine(ctx).includes(`${expected}Context\x1b[0m`));
   assert.ok(renderUsageLine(ctx)?.includes(`${expected}Usage\x1b[0m`));
   assert.ok(renderUsageLine(ctx, true)?.includes(`${expected}Usage  \x1b[0m`));
+  assert.ok(renderUsageLine(ctx, { align: true })?.includes(`${expected}Usage  \x1b[0m`));
   assert.ok(renderEnvironmentLine(ctx)?.includes(`${expected}2 CLAUDE.md | 1 rules\x1b[0m`));
   assert.ok(renderMemoryLine({ ...ctx, config: { ...ctx.config, lineLayout: 'expanded', display: { ...ctx.config.display, showMemoryUsage: true } } })?.includes(`${expected}Approx RAM\x1b[0m`));
   assert.ok(renderToolsLine(ctx)?.includes(`${expected}: src/index.ts\x1b[0m`));


### PR DESCRIPTION
## Summary

- align context, usage, weekly, and optional memory progress labels by terminal cell width
- keep merged wide rows compact while aligning labels when rows stack
- preserve the existing boolean alignment API and the default memory-disabled layout
- add English and CJK regression coverage for standalone, merged, hidden-peer, and narrow layouts

## Validation

- npm run build
- npm run test:coverage — 898 passed, 1 skipped; 95.19% statements, 87.32% branches
- dedicated adversarial security review: pass
- quality/regression review: pass
- readability/maintainability review: pass
- generated dist files excluded from this PR

Closes #672