### PR TITLE
release: 0.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hud",
   "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-17
+
+### Fixed
+- Align context, usage, and opt-in memory progress bars by terminal cell width in CJK locales, including merged and narrow layouts (#673).
+
 ## [0.5.0] - 2026-07-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hud",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hud",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hud",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Real-time statusline HUD for Claude Code",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- release the CJK progress-label alignment fix from #673 as version 0.5.1
- keep package, lockfile, plugin manifest, and marketplace metadata aligned
- add the 0.5.1 changelog entry

## Validation

- npm ci
- npm run test:coverage — 898 passed, 1 skipped; 95.19% statements, 87.32% branches
- npm pack --dry-run — claude-hud@0.5.1, 279 expected files
- dedicated adversarial security review: pass
- quality/regression review: pass
- readability/maintainability review: pass
- exactly five metadata/changelog files; no source, dependency, script, or generated dist changes