### PR TITLE
feat: support pathLevels: "full" to show the entire absolute cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Support `pathLevels: "full"` to show the entire absolute working directory in the project badge, instead of being capped at the last 3 segments.
+
 ## [0.5.1] - 2026-07-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 |--------|------|---------|-------------|
 | `language` | `en` \| `zh` \| `zh-Hans` \| `zh-Hant` \| `zh-TW` | `en` | HUD label language. Use `zh` or `zh-Hans` for Simplified Chinese and `zh-Hant` or `zh-TW` for Traditional Chinese. |
 | `lineLayout` | string | `expanded` | Layout: `expanded` (multi-line) or `compact` (single line) |
-| `pathLevels` | 1-3 | 1 | Directory levels to show in project path |
+| `pathLevels` | 1-3 \| `full` | 1 | Directory levels to show in project path, or `full` to show the entire absolute path |
 | `maxWidth` | number \| `null` | `null` | Optional fallback width used only when terminal width detection fails completely |
 | `forceMaxWidth` | boolean | false | Always use `maxWidth` when it is set, even if terminal width detection returns a smaller value |
 | `elementOrder` | string[] | `["project","addedDirs","context","usage","promptCache","memory","environment","tools","skills","mcp","agents","todos","sessionTime"]` | Expanded-mode element order. Omit entries to hide them in expanded mode. Existing configs keep their explicit order until updated. |
@@ -406,7 +406,7 @@ Leaving it unset (or setting an explicit negative: `0`, `false`, `off`, `no`) ke
 
 **Config not applying?**
 - Check for JSON syntax errors: invalid JSON silently falls back to defaults
-- Ensure valid values: `pathLevels` must be 1, 2, or 3; `lineLayout` must be `expanded` or `compact`; `maxWidth` must be a positive number
+- Ensure valid values: `pathLevels` must be 1, 2, 3, or `full`; `lineLayout` must be `expanded` or `compact`; `maxWidth` must be a positive number
 - Delete config and run `/claude-hud:configure` to regenerate
 
 **Git status missing?**

--- a/README.zh.md
+++ b/README.zh.md
@@ -163,7 +163,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 |------|------|--------|------|
 | `language` | `en` \| `zh` \| `zh-Hans` \| `zh-Hant` \| `zh-TW` | `en` | HUD 标签语言。设为 `zh` 或 `zh-Hans` 启用简体中文，设为 `zh-Hant` 或 `zh-TW` 启用繁体中文 |
 | `lineLayout` | string | `expanded` | 布局：`expanded`（多行）或 `compact`（单行） |
-| `pathLevels` | 1-3 | 1 | 项目路径显示的目录层级数 |
+| `pathLevels` | 1-3 \| `full` | 1 | 项目路径显示的目录层级数，或设为 `full` 显示完整绝对路径 |
 | `maxWidth` | number \| `null` | `null` | 可选的回退宽度，仅在终端宽度检测完全失败时使用 |
 | `forceMaxWidth` | boolean | false | 当设置了 `maxWidth` 时始终使用它，即使终端宽度检测返回更小的值 |
 | `elementOrder` | string[] | `["project","context","usage","promptCache","memory","environment","tools","agents","todos","sessionTime"]` | 展开模式下元素的顺序。省略的条目在展开模式下隐藏。现有配置会保留其显式顺序直到更新 |
@@ -380,7 +380,7 @@ CLAUDE_HUD_DISABLE=1 claude
 
 **配置不生效？**
 - 检查 JSON 语法错误：无效的 JSON 会静默回退到默认值
-- 确保值有效：`pathLevels` 必须是 1、2 或 3；`lineLayout` 必须是 `expanded` 或 `compact`；`maxWidth` 必须是正数
+- 确保值有效：`pathLevels` 必须是 1、2、3 或 `full`；`lineLayout` 必须是 `expanded` 或 `compact`；`maxWidth` 必须是正数
 - 删除配置文件并运行 `/claude-hud:configure` 重新生成
 
 **Git 状态缺失？**

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,14 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
 export type ModelFormatMode = 'full' | 'compact' | 'short';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both' | 'elapsed' | 'elapsedAndAbsolute';
 export type CustomLinePosition = 'first' | 'last';
+
+/**
+ * Controls how many directory segments of cwd are shown in the project badge.
+ *
+ *   1 | 2 | 3: Show the last N segments (e.g. 2 -> "ai_workspace/knowledge-forge")
+ *   'full':    Show the entire absolute path from root (e.g. "/Users/name/…")
+ */
+export type PathLevels = 1 | 2 | 3 | 'full';
 export type HudElement =
   | 'project'
   | 'addedDirs'
@@ -95,7 +103,7 @@ export interface HudConfig {
   language: Language;
   lineLayout: LineLayoutType;
   showSeparators: boolean;
-  pathLevels: 1 | 2 | 3;
+  pathLevels: PathLevels;
   maxWidth: number | null;
   forceMaxWidth: boolean;
   elementOrder: HudElement[];
@@ -298,8 +306,8 @@ export function getConfigPath(): string {
   return path.join(getHudPluginDir(homeDir), 'config.json');
 }
 
-function validatePathLevels(value: unknown): value is 1 | 2 | 3 {
-  return value === 1 || value === 2 || value === 3;
+function validatePathLevels(value: unknown): value is PathLevels {
+  return value === 1 || value === 2 || value === 3 || value === 'full';
 }
 
 function validateLineLayout(value: unknown): value is LineLayoutType {
@@ -472,7 +480,7 @@ function migrateConfig(userConfig: Partial<HudConfig> & LegacyConfig): Partial<H
       const obj = userConfig.layout as Record<string, unknown>;
       if (typeof obj.lineLayout === 'string') migrated.lineLayout = obj.lineLayout as any;
       if (typeof obj.showSeparators === 'boolean') migrated.showSeparators = obj.showSeparators;
-      if (typeof obj.pathLevels === 'number') migrated.pathLevels = obj.pathLevels as any;
+      if (typeof obj.pathLevels === 'number' || obj.pathLevels === 'full') migrated.pathLevels = obj.pathLevels as any;
     }
     delete migrated.layout;
   }

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -11,6 +11,7 @@ import { normalizeAddedDirs, sanitize as sanitizeDisplayText, basenameOf, trunca
 import { hyperlink, getFileHref, safeHyperlink } from '../../utils/hyperlinks.js';
 import { formatModelDisplay } from '../model-display.js';
 import { formatAuthSegment } from '../../auth.js';
+import { formatProjectPath } from '../project-path.js';
 
 function resolvePathWithinCwd(cwd: string, candidatePath: string): string | null {
   const resolvedCwd = path.resolve(cwd);
@@ -41,14 +42,8 @@ export function renderProjectLine(ctx: RenderContext): string | null {
 
   let projectPart: string | null = null;
   if (display?.showProject !== false && ctx.stdin.cwd) {
-    const segments = ctx.stdin.cwd.split(/[/\\]/).filter(Boolean);
     const pathLevels = ctx.config?.pathLevels ?? 1;
-    const isAbsolute = /^[/\\]/.test(ctx.stdin.cwd);
-    const shown = pathLevels === 'full' ? segments : segments.slice(-pathLevels);
-    const showsFromRoot = isAbsolute && shown.length === segments.length;
-    const projectPath = sanitizeDisplayText(
-      shown.length > 0 ? `${showsFromRoot ? '/' : ''}${shown.join('/')}` : '/'
-    );
+    const projectPath = formatProjectPath(ctx.stdin.cwd, pathLevels);
     const coloredProject = projectColor(projectPath, colors);
     projectPart = safeHyperlink(getFileHref(ctx.stdin.cwd), coloredProject);
   }

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -43,7 +43,12 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   if (display?.showProject !== false && ctx.stdin.cwd) {
     const segments = ctx.stdin.cwd.split(/[/\\]/).filter(Boolean);
     const pathLevels = ctx.config?.pathLevels ?? 1;
-    const projectPath = sanitizeDisplayText(segments.length > 0 ? segments.slice(-pathLevels).join('/') : '/');
+    const isAbsolute = /^[/\\]/.test(ctx.stdin.cwd);
+    const shown = pathLevels === 'full' ? segments : segments.slice(-pathLevels);
+    const showsFromRoot = isAbsolute && shown.length === segments.length;
+    const projectPath = sanitizeDisplayText(
+      shown.length > 0 ? `${showsFromRoot ? '/' : ''}${shown.join('/')}` : '/'
+    );
     const coloredProject = projectColor(projectPath, colors);
     projectPart = safeHyperlink(getFileHref(ctx.stdin.cwd), coloredProject);
   }

--- a/src/render/project-path.ts
+++ b/src/render/project-path.ts
@@ -1,0 +1,28 @@
+import type { PathLevels } from '../config.js';
+import { sanitizeDisplayText } from '../utils/sanitize.js';
+
+/** Format an untrusted cwd consistently across POSIX and Windows hosts. */
+export function formatProjectPath(cwd: string, pathLevels: PathLevels): string {
+  const safeCwd = sanitizeDisplayText(cwd);
+  const segments = safeCwd.split(/[/\\]/).filter(Boolean);
+
+  if (pathLevels !== 'full') {
+    const shown = segments.slice(-pathLevels).join('/');
+    return shown || (/^[/\\]/.test(safeCwd) ? '/' : safeCwd);
+  }
+
+  if (/^[\\/]{2}/.test(safeCwd)) {
+    return segments.length > 0 ? `//${segments.join('/')}` : '//';
+  }
+
+  if (/^[A-Za-z]:[\\/]/.test(safeCwd)) {
+    const normalized = segments.join('/');
+    return segments.length === 1 ? `${normalized}/` : normalized;
+  }
+
+  if (/^[\\/]/.test(safeCwd)) {
+    return segments.length > 0 ? `/${segments.join('/')}` : '/';
+  }
+
+  return segments.join('/') || safeCwd;
+}

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -78,9 +78,12 @@ export function renderSessionLine(ctx: RenderContext): string {
     // Split by both Unix (/) and Windows (\) separators for cross-platform support
     const segments = ctx.stdin.cwd.split(/[/\\]/).filter(Boolean);
     const pathLevels = ctx.config?.pathLevels ?? 1;
+    const isAbsolute = /^[/\\]/.test(ctx.stdin.cwd);
+    const shown = pathLevels === 'full' ? segments : segments.slice(-pathLevels);
+    const showsFromRoot = isAbsolute && shown.length === segments.length;
     // Always join with forward slash for consistent display
     // Handle root path (/) which results in empty segments
-    const projectPath = segments.length > 0 ? segments.slice(-pathLevels).join('/') : '/';
+    const projectPath = shown.length > 0 ? `${showsFromRoot ? '/' : ''}${shown.join('/')}` : '/';
     projectPart = projectColor(projectPath, colors);
   }
 

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -17,6 +17,7 @@ import { createDebug } from '../debug.js';
 import { formatModelDisplay } from './model-display.js';
 import { formatSessionTokenSummary } from './lines/session-tokens.js';
 import { sanitizeDisplayText } from '../utils/sanitize.js';
+import { formatProjectPath } from './project-path.js';
 
 const debug = createDebug('session-line');
 
@@ -75,15 +76,8 @@ export function renderSessionLine(ctx: RenderContext): string {
   // Project path + git status
   let projectPart: string | null = null;
   if (display?.showProject !== false && ctx.stdin.cwd) {
-    // Split by both Unix (/) and Windows (\) separators for cross-platform support
-    const segments = ctx.stdin.cwd.split(/[/\\]/).filter(Boolean);
     const pathLevels = ctx.config?.pathLevels ?? 1;
-    const isAbsolute = /^[/\\]/.test(ctx.stdin.cwd);
-    const shown = pathLevels === 'full' ? segments : segments.slice(-pathLevels);
-    const showsFromRoot = isAbsolute && shown.length === segments.length;
-    // Always join with forward slash for consistent display
-    // Handle root path (/) which results in empty segments
-    const projectPath = shown.length > 0 ? `${showsFromRoot ? '/' : ''}${shown.join('/')}` : '/';
+    const projectPath = formatProjectPath(ctx.stdin.cwd, pathLevels);
     projectPart = projectColor(projectPath, colors);
   }
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -24,8 +24,8 @@ function restoreEnvVar(name, value) {
 test('loadConfig returns valid config structure', async () => {
   const config = await loadConfig();
 
-  // pathLevels must be 1, 2, or 3
-  assert.ok([1, 2, 3].includes(config.pathLevels), 'pathLevels should be 1, 2, or 3');
+  // pathLevels must be 1, 2, 3, or 'full'
+  assert.ok([1, 2, 3, 'full'].includes(config.pathLevels), 'pathLevels should be 1, 2, 3, or "full"');
 
   // lineLayout must be valid
   const validLineLayouts = ['compact', 'expanded'];
@@ -463,6 +463,16 @@ test('loadConfig reads user config from CLAUDE_CONFIG_DIR', async () => {
     restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
     await rm(customConfigDir, { recursive: true, force: true });
   }
+});
+
+test('mergeConfig accepts pathLevels: "full"', () => {
+  const config = mergeConfig({ pathLevels: 'full' });
+  assert.equal(config.pathLevels, 'full');
+});
+
+test('mergeConfig rejects invalid pathLevels, falls back to default', () => {
+  const config = mergeConfig({ pathLevels: 4 });
+  assert.equal(config.pathLevels, DEFAULT_CONFIG.pathLevels);
 });
 
 // --- migrateConfig tests (via mergeConfig) ---

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -358,6 +358,22 @@ test('renderSessionLine handles root path gracefully', () => {
   assert.ok(line.includes('[Opus]'));
 });
 
+test('renderSessionLine displays full absolute path when pathLevels is "full"', () => {
+  const ctx = baseContext();
+  ctx.config.pathLevels = 'full';
+  ctx.stdin.cwd = '/Users/jarrod/dev/my-project';
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('/Users/jarrod/dev/my-project'));
+});
+
+test('renderSessionLine full path on Windows cwd omits leading slash', { skip: process.platform !== 'win32' }, () => {
+  const ctx = baseContext();
+  ctx.config.pathLevels = 'full';
+  ctx.stdin.cwd = 'C:\\Users\\jarrod\\my-project';
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('Users/jarrod/my-project'));
+});
+
 test('renderSessionLine supports token-based context display', () => {
   const ctx = baseContext();
   ctx.config.display.contextValue = 'tokens';
@@ -545,6 +561,14 @@ test('renderSessionLine renders a sanitized opt-in transcript model', () => {
   assert.ok(line.includes('[proxy-redlink]'), `got: ${line}`);
   assert.ok(!line.includes('Claude Opus'));
   assert.doesNotMatch(line, /[\x1b\u202E]/u);
+});
+
+test('renderProjectLine displays full absolute path when pathLevels is "full"', () => {
+  const ctx = baseContext();
+  ctx.config.pathLevels = 'full';
+  ctx.stdin.cwd = '/Users/jarrod/dev/my-project';
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(line.includes('/Users/jarrod/dev/my-project'));
 });
 
 test('renderProjectLine includes session name when showSessionName is true', () => {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -343,7 +343,7 @@ test('renderSessionLine displays project name from POSIX cwd', () => {
   assert.ok(!line.includes('/Users/jarrod'));
 });
 
-test('renderSessionLine displays project name from Windows cwd', { skip: process.platform !== 'win32' }, () => {
+test('renderSessionLine displays project name from Windows cwd on every host', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = 'C:\\Users\\jarrod\\my-project';
   const line = renderSessionLine(ctx);
@@ -366,12 +366,29 @@ test('renderSessionLine displays full absolute path when pathLevels is "full"', 
   assert.ok(line.includes('/Users/jarrod/dev/my-project'));
 });
 
-test('renderSessionLine full path on Windows cwd omits leading slash', { skip: process.platform !== 'win32' }, () => {
+test('renderSessionLine normalizes a full Windows path on every host', () => {
   const ctx = baseContext();
   ctx.config.pathLevels = 'full';
   ctx.stdin.cwd = 'C:\\Users\\jarrod\\my-project';
   const line = stripAnsi(renderSessionLine(ctx));
-  assert.ok(line.includes('Users/jarrod/my-project'));
+  assert.ok(line.includes('C:/Users/jarrod/my-project'));
+});
+
+test('renderSessionLine preserves numeric pathLevels behavior for shallow roots', () => {
+  const ctx = baseContext();
+  ctx.config.pathLevels = 1;
+  ctx.stdin.cwd = '/project';
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('project'));
+  assert.ok(!line.includes('/project'));
+});
+
+test('renderSessionLine preserves UNC roots in full mode', () => {
+  const ctx = baseContext();
+  ctx.config.pathLevels = 'full';
+  ctx.stdin.cwd = '\\\\server\\share\\project';
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('//server/share/project'));
 });
 
 test('renderSessionLine supports token-based context display', () => {
@@ -569,6 +586,29 @@ test('renderProjectLine displays full absolute path when pathLevels is "full"', 
   ctx.stdin.cwd = '/Users/jarrod/dev/my-project';
   const line = stripAnsi(renderProjectLine(ctx) ?? '');
   assert.ok(line.includes('/Users/jarrod/dev/my-project'));
+});
+
+test('renderProjectLine normalizes Windows and UNC full paths on every host', () => {
+  const ctx = baseContext();
+  ctx.config.pathLevels = 'full';
+
+  ctx.stdin.cwd = 'C:\\Users\\jarrod\\my-project';
+  assert.ok(stripAnsi(renderProjectLine(ctx) ?? '').includes('C:/Users/jarrod/my-project'));
+
+  ctx.stdin.cwd = '\\\\server\\share\\project';
+  assert.ok(stripAnsi(renderProjectLine(ctx) ?? '').includes('//server/share/project'));
+});
+
+test('project paths strip terminal escapes and bidi overrides in both layouts', () => {
+  const ctx = baseContext();
+  ctx.config.pathLevels = 'full';
+  ctx.stdin.cwd = '/safe/\u001b]8;;https://evil.example\u0007project\u202E';
+
+  for (const line of [renderSessionLine(ctx), renderProjectLine(ctx) ?? '']) {
+    const plain = stripAnsi(line);
+    assert.ok(plain.includes('/safe/project'));
+    assert.doesNotMatch(plain, /[\u001b\u202E]/u);
+  }
 });
 
 test('renderProjectLine includes session name when showSessionName is true', () => {


### PR DESCRIPTION
## Summary
- `pathLevels` was hard-capped at `1 | 2 | 3` segments, so there was no way to display the full absolute working directory in the project badge.
- Adds a `pathLevels: "full"` option that shows the entire path from root.
- Fixes a related bug surfaced by this change: splitting `cwd` on `/` and rejoining drops the leading empty segment, so an absolute path like `/Users/name/project` would render as `Users/name/project` (missing leading slash) once more than the available segments are requested. Only applies the leading slash back when the full path is actually being shown from root, so the existing `1|2|3` truncated views are unaffected.

## Test plan
- Added tests: `mergeConfig` accepts/rejects `pathLevels: "full"`; `renderSessionLine`/`renderProjectLine` render the full absolute path with the leading slash preserved (POSIX + Windows cases).
- Ran the full suite on a clean checkout of `main` first to establish a baseline: **36 pre-existing failures**, unrelated to this change (customLine positioning, advisor model sanitization, scoped usage rendering, OSC8 hyperlink width, etc.).
- Ran the full suite again on this branch: same 36 pre-existing failures, **no new failures**, plus 5 new passing tests for the added behavior.
- Updated `README.md` (config table + troubleshooting section) and `CHANGELOG.md`.