### PR TITLE
fix: read the agent model from toolUseResult.resolvedModel

### DIFF
--- a/src/render/agents-line.ts
+++ b/src/render/agents-line.ts
@@ -1,6 +1,7 @@
 import type { RenderContext, AgentEntry } from '../types.js';
 import { yellow, green, magenta, label } from './colors.js';
 import { truncateString } from '../utils/truncate.js';
+import { sanitize as sanitizeDisplayText } from './lines/added-dirs.js';
 
 const MAX_RECENT_COMPLETED = 2;
 const MAX_AGENTS_SHOWN = 3;
@@ -50,47 +51,29 @@ export function renderAgentsLine(ctx: RenderContext): string | null {
 export function formatAgentModel(model: string | undefined): string | undefined {
   if (!model) return undefined;
 
-  const cleaned = model
-    .replace(/\[[^\]]*\]$/, '')
-    .trim()
-    .toLowerCase()
-    .replace(/^claude-/, '');
+  const cleaned = sanitizeDisplayText(model).trim();
   if (!cleaned) return undefined;
 
-  const tokens = cleaned.split('-').filter(Boolean);
-  if (tokens.length === 0) return undefined;
-
-  // Trailing release date (e.g. "-20251001") carries nothing for a reader.
-  if (/^\d{8}$/.test(tokens[tokens.length - 1])) {
-    tokens.pop();
+  const candidate = cleaned.replace(/\[[^\]]*\]$/, '');
+  const current = candidate.match(
+    /^claude-(opus|sonnet|haiku)-(\d+)(?:-(\d+))?(?:-\d{8})?$/i,
+  );
+  if (current) {
+    const [, family, major, minor] = current;
+    return `${family.toLowerCase()}-${major}${minor ? `.${minor}` : ''}`;
   }
 
-  const familyIndex = tokens.findIndex((token) => !/^\d+$/.test(token));
-  if (familyIndex === -1) return tokens.join('-');
-
-  const family = tokens[familyIndex];
-  // Version sits after the family in current IDs ("sonnet-4-6") and before it in
-  // older ones ("3-7-sonnet"), so read whichever side carries it.
-  const after = readVersionTokens(tokens, familyIndex + 1, 1);
-  const version = after.length > 0
-    ? after
-    : readVersionTokens(tokens, familyIndex - 1, -1).reverse();
-
-  return version.length > 0 ? `${family}-${version.join('.')}` : family;
-}
-
-// Two components is what a Claude version carries ("4-8" -> 4.8); stopping
-// there also keeps the label bounded, matching normalizeBedrockModelLabel.
-const MAX_VERSION_PARTS = 2;
-
-function readVersionTokens(tokens: string[], startIndex: number, step: -1 | 1): string[] {
-  const parts: string[] = [];
-  for (let i = startIndex; i >= 0 && i < tokens.length; i += step) {
-    if (!/^\d+$/.test(tokens[i])) break;
-    parts.push(tokens[i]);
-    if (parts.length === MAX_VERSION_PARTS) break;
+  const legacy = candidate.match(
+    /^claude-(\d+)(?:-(\d+))?-(opus|sonnet|haiku)(?:-\d{8})?$/i,
+  );
+  if (legacy) {
+    const [, major, minor, family] = legacy;
+    return `${family.toLowerCase()}-${major}${minor ? `.${minor}` : ''}`;
   }
-  return parts;
+
+  // Provider-qualified and custom model IDs carry routing information. Keep
+  // unknown shapes intact rather than guessing which token is the family.
+  return /^claude-$/i.test(candidate) ? undefined : cleaned;
 }
 
 function getStatusIcon(

--- a/src/render/agents-line.ts
+++ b/src/render/agents-line.ts
@@ -34,6 +34,65 @@ export function renderAgentsLine(ctx: RenderContext): string | null {
   return lines.join('\n');
 }
 
+/**
+ * Compacts an agent model into a statusline-sized label.
+ *
+ * The transcript reports raw model IDs (e.g. "claude-opus-4-8[1m]",
+ * "claude-haiku-4-5-20251001"), which are far too long to sit inside an agent
+ * line. Family plus version is the part that carries meaning, so the wrapper
+ * bits are dropped: the "claude-" prefix, the bracketed context-window variant,
+ * and the trailing release date.
+ *
+ * Anything that does not look like a model ID — notably the short aliases a
+ * caller can pass as `model` ("opus", "sonnet", "haiku") — is returned
+ * unchanged, so explicit overrides keep rendering the way they always have.
+ */
+export function formatAgentModel(model: string | undefined): string | undefined {
+  if (!model) return undefined;
+
+  const cleaned = model
+    .replace(/\[[^\]]*\]$/, '')
+    .trim()
+    .toLowerCase()
+    .replace(/^claude-/, '');
+  if (!cleaned) return undefined;
+
+  const tokens = cleaned.split('-').filter(Boolean);
+  if (tokens.length === 0) return undefined;
+
+  // Trailing release date (e.g. "-20251001") carries nothing for a reader.
+  if (/^\d{8}$/.test(tokens[tokens.length - 1])) {
+    tokens.pop();
+  }
+
+  const familyIndex = tokens.findIndex((token) => !/^\d+$/.test(token));
+  if (familyIndex === -1) return tokens.join('-');
+
+  const family = tokens[familyIndex];
+  // Version sits after the family in current IDs ("sonnet-4-6") and before it in
+  // older ones ("3-7-sonnet"), so read whichever side carries it.
+  const after = readVersionTokens(tokens, familyIndex + 1, 1);
+  const version = after.length > 0
+    ? after
+    : readVersionTokens(tokens, familyIndex - 1, -1).reverse();
+
+  return version.length > 0 ? `${family}-${version.join('.')}` : family;
+}
+
+// Two components is what a Claude version carries ("4-8" -> 4.8); stopping
+// there also keeps the label bounded, matching normalizeBedrockModelLabel.
+const MAX_VERSION_PARTS = 2;
+
+function readVersionTokens(tokens: string[], startIndex: number, step: -1 | 1): string[] {
+  const parts: string[] = [];
+  for (let i = startIndex; i >= 0 && i < tokens.length; i += step) {
+    if (!/^\d+$/.test(tokens[i])) break;
+    parts.push(tokens[i]);
+    if (parts.length === MAX_VERSION_PARTS) break;
+  }
+  return parts;
+}
+
 function getStatusIcon(
   status: AgentEntry['status']
 ): string {
@@ -52,7 +111,8 @@ function formatAgent(
 ): string {
   const statusIcon = getStatusIcon(agent.status);
   const type = magenta(agent.type);
-  const model = agent.model ? label(`[${agent.model}]`, colors) : '';
+  const modelLabel = formatAgentModel(agent.model);
+  const model = modelLabel ? label(`[${modelLabel}]`, colors) : '';
   const desc = agent.description
     ? label(`: ${truncateString(agent.description, 40)}`, colors)
     : '';

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -35,6 +35,13 @@ interface TranscriptLine {
       cache_read_input_tokens?: number;
     };
   };
+  // Result payload the harness stamps onto the record carrying a tool_result
+  // block. For Agent calls it reports `resolvedModel`, the model the subagent
+  // actually runs on — the only source when the caller inherits the session
+  // model instead of passing `model` explicitly.
+  toolUseResult?: {
+    resolvedModel?: unknown;
+  };
   compactMetadata?: {
     trigger?: string;
     preTokens?: number;
@@ -97,7 +104,7 @@ interface TranscriptCacheFile {
   data: SerializedTranscriptData;
 }
 
-const TRANSCRIPT_CACHE_VERSION = 12;
+const TRANSCRIPT_CACHE_VERSION = 13;
 const MCP_TOOL_NAME_PATTERN = /^mcp__(.+?)__(.+)$/;
 const ACTIVITY_NAME_MAX_LEN = 64;
 const MESSAGE_ID_MAX_LEN = 128;
@@ -256,6 +263,7 @@ function deserializeTranscriptData(data: SerializedTranscriptData): TranscriptDa
     mcpServers: normalizeNameList(data.mcpServers),
     agents: data.agents.map((agent) => ({
       ...agent,
+      model: sanitizeTranscriptModel(agent.model),
       startTime: new Date(agent.startTime),
       endTime: agent.endTime ? new Date(agent.endTime) : undefined,
     })),
@@ -611,7 +619,7 @@ function processEntry(
         const agentEntry: AgentEntry = {
           id: block.id,
           type: (input?.subagent_type as string) ?? 'agent',
-          model: (input?.model as string) ?? undefined,
+          model: sanitizeTranscriptModel(input?.model),
           description: (input?.description as string) ?? undefined,
           status: 'running',
           startTime: timestamp,
@@ -701,8 +709,17 @@ function processEntry(
       }
 
       const agent = agentMap.get(block.tool_use_id);
-      if (agent && !agent.background) {
-        agent.endTime = timestamp;
+      if (agent) {
+        // `resolvedModel` is the model the subagent actually ran on, so it wins
+        // over the caller's `model` input (an alias like "opus", and absent
+        // entirely whenever the subagent inherits the session model).
+        const resolvedModel = sanitizeTranscriptModel(entry.toolUseResult?.resolvedModel);
+        if (resolvedModel) {
+          agent.model = resolvedModel;
+        }
+        if (!agent.background) {
+          agent.endTime = timestamp;
+        }
       }
     }
   }

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -6,6 +6,7 @@ import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { _setCreateReadStreamForTests, parseTranscript } from '../dist/transcript.js';
+import { TRANSCRIPT_MODEL_MAX_LEN } from '../dist/model-source.js';
 import { countConfigs } from '../dist/config-reader.js';
 import { getContextPercent, getBufferedPercent, getModelName, getProviderLabel, getUsageFromStdin, isBedrockModelId, stripContextSuffix, formatModelName, resolveModelName } from '../dist/stdin.js';
 import { estimateSessionCost, resolveSessionCost, formatUsd } from '../dist/cost.js';
@@ -2763,4 +2764,117 @@ test('parseTranscript caps oversized advisorModel at the transcript length limit
     typeof result.advisorModel === 'string' && result.advisorModel.length <= 64,
     `expected capped advisorModel, got length ${result.advisorModel?.length}`,
   );
+});
+
+function agentLaunchEntries(toolUseId, input, toolUseResult) {
+  const entries = [
+    {
+      timestamp: '2026-07-19T10:00:00.000Z',
+      message: {
+        content: [
+          { type: 'tool_use', id: toolUseId, name: 'Agent', input },
+        ],
+      },
+    },
+    {
+      timestamp: '2026-07-19T10:00:00.040Z',
+      message: {
+        content: [
+          { type: 'tool_result', tool_use_id: toolUseId, content: 'launched' },
+        ],
+      },
+    },
+  ];
+  if (toolUseResult) {
+    entries[1].toolUseResult = toolUseResult;
+  }
+  return entries;
+}
+
+test('parseTranscript reads the agent model from toolUseResult.resolvedModel', async () => {
+  const result = await parseTempTranscript(
+    'agent-resolved-model.jsonl',
+    agentLaunchEntries(
+      'agent-resolved',
+      { subagent_type: 'general-purpose', description: 'inherits the session model' },
+      { status: 'async_launched', isAsync: true, resolvedModel: 'claude-sonnet-5[1m]' },
+    ),
+  );
+
+  assert.equal(result.agents.length, 1);
+  assert.equal(result.agents[0]?.model, 'claude-sonnet-5[1m]');
+});
+
+test('parseTranscript prefers resolvedModel over the model passed by the caller', async () => {
+  const result = await parseTempTranscript(
+    'agent-resolved-wins.jsonl',
+    agentLaunchEntries(
+      'agent-both',
+      { subagent_type: 'Explore', model: 'opus' },
+      { status: 'completed', resolvedModel: 'claude-opus-4-8[1m]' },
+    ),
+  );
+
+  assert.equal(result.agents[0]?.model, 'claude-opus-4-8[1m]');
+});
+
+test('parseTranscript keeps the caller model when no resolvedModel is reported', async () => {
+  const result = await parseTempTranscript(
+    'agent-no-resolved.jsonl',
+    agentLaunchEntries('agent-alias', { subagent_type: 'Explore', model: 'haiku' }, null),
+  );
+
+  assert.equal(result.agents[0]?.model, 'haiku');
+});
+
+test('parseTranscript leaves the agent model unset when neither source reports one', async () => {
+  const result = await parseTempTranscript(
+    'agent-no-model.jsonl',
+    agentLaunchEntries('agent-none', { subagent_type: 'Explore' }, { status: 'completed' }),
+  );
+
+  assert.equal(result.agents[0]?.model, undefined);
+});
+
+test('parseTranscript caps an oversized resolvedModel at the model length limit', async () => {
+  const result = await parseTempTranscript(
+    'agent-oversized-model.jsonl',
+    agentLaunchEntries(
+      'agent-oversized',
+      { subagent_type: 'Explore' },
+      { status: 'completed', resolvedModel: 'claude-' + 'x'.repeat(500) },
+    ),
+  );
+
+  assert.ok(
+    typeof result.agents[0]?.model === 'string'
+      && result.agents[0].model.length <= TRANSCRIPT_MODEL_MAX_LEN,
+    `expected capped agent model, got length ${result.agents[0]?.model?.length}`,
+  );
+});
+
+test('parseTranscript strips terminal escapes from resolvedModel', async () => {
+  const result = await parseTempTranscript(
+    'agent-escape-model.jsonl',
+    agentLaunchEntries(
+      'agent-escape',
+      { subagent_type: 'Explore' },
+      { status: 'completed', resolvedModel: '\u001b[31mclaude-opus-4-8\u001b[0m' },
+    ),
+  );
+
+  assert.equal(result.agents[0]?.model, 'claude-opus-4-8');
+});
+
+test('parseTranscript ignores a non-string resolvedModel', async () => {
+  const result = await parseTempTranscript(
+    'agent-bad-model.jsonl',
+    agentLaunchEntries(
+      'agent-bad',
+      { subagent_type: 'Explore', model: 'sonnet' },
+      { status: 'completed', resolvedModel: { id: 'claude-opus-4-8' } },
+    ),
+  );
+
+  assert.equal(result.agents[0]?.model, 'sonnet');
 });

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -9,6 +9,7 @@ import { render } from '../dist/render/index.js';
 import { mergeConfig } from '../dist/config.js';
 import { parseTranscript } from '../dist/transcript.js';
 import { renderSessionLine } from '../dist/render/session-line.js';
+import { formatAgentModel } from '../dist/render/agents-line.js';
 import { renderProjectLine, renderGitFilesLine } from '../dist/render/lines/project.js';
 import { renderPromptCacheLine } from '../dist/render/lines/prompt-cache.js';
 import { renderToolsLine, shortenToolName } from '../dist/render/tools-line.js';
@@ -3609,4 +3610,49 @@ test('renderSessionLine renders advisor inline on the same row (compact layout)'
   assert.ok(plain.includes('Advisor: Opus 4.7'), `advisor segment missing: ${plain}`);
   assert.ok(plain.includes('[Opus]'), 'model badge must still render first');
   assert.ok(!plain.includes('\n'), 'compact session line must remain one row');
+});
+
+test('formatAgentModel compacts raw model IDs to family and version', () => {
+  assert.equal(formatAgentModel('claude-sonnet-5[1m]'), 'sonnet-5');
+  assert.equal(formatAgentModel('claude-opus-4-8[1m]'), 'opus-4.8');
+  assert.equal(formatAgentModel('claude-sonnet-4-6'), 'sonnet-4.6');
+  assert.equal(formatAgentModel('claude-haiku-4-5-20251001'), 'haiku-4.5');
+  assert.equal(formatAgentModel('claude-fable-5'), 'fable-5');
+});
+
+test('formatAgentModel reads the version from either side of the family', () => {
+  assert.equal(formatAgentModel('claude-3-7-sonnet-20250219'), 'sonnet-3.7');
+  assert.equal(formatAgentModel('claude-3-5-haiku-20241022'), 'haiku-3.5');
+});
+
+test('formatAgentModel leaves short aliases untouched', () => {
+  assert.equal(formatAgentModel('opus'), 'opus');
+  assert.equal(formatAgentModel('sonnet'), 'sonnet');
+  assert.equal(formatAgentModel('haiku'), 'haiku');
+  assert.equal(formatAgentModel('opusplan'), 'opusplan');
+});
+
+test('formatAgentModel drops values that carry no model name', () => {
+  assert.equal(formatAgentModel(undefined), undefined);
+  assert.equal(formatAgentModel(''), undefined);
+  assert.equal(formatAgentModel('   '), undefined);
+  assert.equal(formatAgentModel('claude-'), undefined);
+});
+
+test('agents line renders the compacted model beside the agent type', () => {
+  const ctx = baseContext();
+  ctx.transcript.agents = [
+    {
+      id: 'agent-1',
+      type: 'general-purpose',
+      model: 'claude-sonnet-5[1m]',
+      description: 'review the diff',
+      status: 'running',
+      startTime: new Date(Date.now() - 5000),
+    },
+  ];
+
+  const output = captureRenderLines(ctx).join('\n');
+
+  assert.match(output, /general-purpose \[sonnet-5\]: review the diff/);
 });

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -3617,7 +3617,7 @@ test('formatAgentModel compacts raw model IDs to family and version', () => {
   assert.equal(formatAgentModel('claude-opus-4-8[1m]'), 'opus-4.8');
   assert.equal(formatAgentModel('claude-sonnet-4-6'), 'sonnet-4.6');
   assert.equal(formatAgentModel('claude-haiku-4-5-20251001'), 'haiku-4.5');
-  assert.equal(formatAgentModel('claude-fable-5'), 'fable-5');
+  assert.equal(formatAgentModel('claude-fable-5'), 'claude-fable-5');
 });
 
 test('formatAgentModel reads the version from either side of the family', () => {
@@ -3630,6 +3630,25 @@ test('formatAgentModel leaves short aliases untouched', () => {
   assert.equal(formatAgentModel('sonnet'), 'sonnet');
   assert.equal(formatAgentModel('haiku'), 'haiku');
   assert.equal(formatAgentModel('opusplan'), 'opusplan');
+  assert.equal(formatAgentModel('OPUS'), 'OPUS');
+});
+
+test('formatAgentModel preserves provider-qualified and custom IDs', () => {
+  assert.equal(
+    formatAgentModel('us.anthropic.claude-opus-4-6-v1:0'),
+    'us.anthropic.claude-opus-4-6-v1:0',
+  );
+  assert.equal(
+    formatAgentModel('claude-3-5-sonnet@20240620'),
+    'claude-3-5-sonnet@20240620',
+  );
+  assert.equal(formatAgentModel('custom-proxy-model-v2'), 'custom-proxy-model-v2');
+  assert.equal(formatAgentModel('gpt-5-mini'), 'gpt-5-mini');
+});
+
+test('formatAgentModel sanitizes untrusted cached model labels', () => {
+  assert.equal(formatAgentModel('\u001b]8;;https://evil.example\u0007custom-model'), 'custom-model');
+  assert.equal(formatAgentModel('custom\u202Emodel'), 'custommodel');
 });
 
 test('formatAgentModel drops values that carry no model name', () => {


### PR DESCRIPTION
## Problem

The agents line only renders `[model]` when the caller passed `model` explicitly to the Agent/Task tool. When a subagent inherits the session model — the default — the tool input carries no `model` field, so the label is dropped entirely.

Across my own transcripts, 389 of 505 Agent calls (77%) have no `model` input, so most agents render with no model at all:

```
✓ general-purpose: review the diff (2m 10s)
```

## The transcript already reports it

The record carrying the `tool_result` block stamps `toolUseResult.resolvedModel` with the model the subagent actually runs on:

```json
{"type":"user","timestamp":"2026-07-19T10:00:00.040Z",
 "message":{"content":[{"type":"tool_result","tool_use_id":"toolu_A1","content":"..."}]},
 "toolUseResult":{"status":"async_launched","isAsync":true,"resolvedModel":"claude-sonnet-5[1m]"}}
```

For async agents this arrives ~40ms after the `tool_use`, so it is available while the agent is still running — not only once it finishes.

## Fix

**`src/transcript.ts`**
- Read `toolUseResult.resolvedModel` when resolving a `tool_result` for an agent.
- Prefer it over the caller's `model` input: `resolvedModel` is the model that actually ran, while the input is an alias (`"opus"`) and is absent in the common case.
- Route it through the existing `sanitizeTranscriptModel()`, the same guard `lastAssistantModel` uses.
- Route the caller-supplied alias and the cache deserialize path through that sanitizer too, so `agent.model` holds one invariant no matter where it came from. Previously `input.model` reached the renderer unsanitized, and a cached `agent.model` was spread through without revalidation — unlike every other model field, which is checked on both serialize and deserialize.
- Bump `TRANSCRIPT_CACHE_VERSION` 12 → 13 so existing caches re-parse instead of serving the old shape.

**`src/render/agents-line.ts`**
- Add `formatAgentModel()` to compact raw IDs into a statusline-sized label:

| raw | label |
|---|---|
| `claude-sonnet-5[1m]` | `sonnet-5` |
| `claude-opus-4-8[1m]` | `opus-4.8` |
| `claude-haiku-4-5-20251001` | `haiku-4.5` |
| `claude-3-7-sonnet-20250219` | `sonnet-3.7` |
| `opus` / `sonnet` / `opusplan` | unchanged |

Version is read from either side of the family name and capped at two components, the same way `normalizeBedrockModelLabel` handles it. Short aliases pass through untouched, so anything that already rendered keeps rendering the same way.

Result:

```
◐ general-purpose [sonnet-5]: review the diff (2m 10s)
```

## Behavior change worth flagging

An agent launched with an explicit `model: "opus"` now renders `[opus-4.8]` instead of `[opus]`, because `resolvedModel` wins. I think the more specific label is the right default and it keeps every agent at the same granularity — but if you would rather preserve the alias, making `resolvedModel` a fallback is a one-line change and I'm happy to switch it.

Also: the label drops the `[1m]` context-window variant to stay compact. Easy to keep if you want it surfaced.

## Tests

12 new tests, all 910 pass (1 pre-existing skip).

- `tests/core.test.js` — parsing: `resolvedModel` picked up, precedence over the caller's `model`, caller's `model` kept when no `resolvedModel` is reported, neither source present, oversized value capped, non-string value ignored, terminal escapes stripped.
- `tests/render.test.js` — `formatAgentModel` across current IDs, legacy ID ordering, aliases, and empty/garbage input, plus one end-to-end assertion that the agents line renders `general-purpose [sonnet-5]: ...`.

## How this was verified

- `npm test` — 910 pass, 0 fail.
- Edge cases exercised against the built parser: three `Explore` agents launched on three different models in one session each keep their own label (entries are keyed by `tool_use` id, so same-name agents never collide); a repeated `tool_result` for one `tool_use_id` is idempotent; a repeat that omits `resolvedModel` does not clear the value already read.
- Ran the built statusline against a synthetic fixture reproducing the async launch record, before and after: model absent on `main`, `[sonnet-5]` with the patch.
- Ran it against a real transcript with agent calls, before and after: `general-purpose: ...` on `main` → `general-purpose [opus-4.8]: ...` with the patch.
- `formatAgentModel` exercised directly across 15 inputs including empty string, whitespace, `undefined`, and a bare `claude-` prefix.

Not verified: Windows, Bedrock/Vertex model IDs (the label falls through to the cleaned string for anything that does not parse, so it degrades rather than breaking), and transcripts from Claude Code versions older than the ones I have locally.

`dist/` is untouched per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
