### PR TITLE
docs: update instructions for current Claude Code behavior

### DIFF
--- a/CLAUDE.README.md
+++ b/CLAUDE.README.md
@@ -16,12 +16,17 @@ Real-time statusline showing context usage, active tools, running agents, and to
 /plugin install claude-hud
 ```
 
+Then reload plugins (no restart needed):
+```
+/reload-plugins
+```
+
 **Step 3: Configure the statusline**
 ```
 /claude-hud:setup
 ```
 
-Done. Restart Claude Code to load the new statusLine config, then the HUD will appear.
+Done. Claude Code reloads settings automatically — the HUD appears after your next message, no restart needed. (On older Claude Code versions, restart if it doesn't show.)
 
 ---
 
@@ -67,7 +72,7 @@ This adds the statusLine configuration to the user's settings.json.
 
 Tell the user:
 - Installation complete
-- Restart Claude Code to load the statusline config, then the HUD will appear
+- Settings reload automatically — the HUD appears after their next message, no restart needed (on older Claude Code versions, restart if it doesn't show)
 - It shows: context usage, active tools, running agents, and todo progress
 
 ### Step 6: Ask About Starring (Optional)
@@ -378,7 +383,7 @@ Technical documentation for agents who need to understand, modify, or debug Clau
     1. Clone the repo or navigate to the plugin directory
     2. Make changes following the file_structure section
     3. Run npm run build to compile
-    4. Restart Claude Code to see changes
+    4. Changes appear on the next statusline refresh — send a message to trigger one (no restart needed; the statusLine command re-runs each refresh)
   </modify>
 
   <debug>

--- a/CLAUDE.README.md
+++ b/CLAUDE.README.md
@@ -113,7 +113,7 @@ Technical documentation for agents who need to understand, modify, or debug Clau
 
 <architecture>
   <overview>
-    Claude HUD is a statusline plugin invoked by Claude Code every ~300ms.
+    Claude HUD is a statusline plugin invoked by Claude Code after each interaction (debounced at 300ms).
     It reads official statusline data from stdin plus local transcript/config data, renders up to 4 lines, and outputs to stdout.
   </overview>
 

--- a/CLAUDE.README.md
+++ b/CLAUDE.README.md
@@ -59,6 +59,11 @@ Run this command in Claude Code:
 /plugin install claude-hud
 ```
 
+Then reload plugins so the setup skill is available in this session:
+```
+/reload-plugins
+```
+
 ### Step 4: Configure the Statusline
 
 Run this command in Claude Code:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Claude Code → stdin JSON → parse → render lines → stdout → Claude Code
            ↘ transcript_path → parse JSONL → tools/agents/todos
 ```
 
-**Key insight**: The statusline is invoked by Claude Code after each interaction (new assistant message, `/compact` finishing, permission-mode changes), debounced at 300ms — not on a fixed polling loop. Each invocation:
+**Key insight**: The statusline is invoked by Claude Code after each interaction (new assistant message, `/compact` finishing, permission-mode changes, vim-mode toggles), debounced at 300ms — not on a fixed polling loop. Each invocation:
 1. Receives JSON via stdin (model, context, tokens - native accurate data)
 2. Parses the transcript JSONL file for tools, agents, and todos
 3. Renders multi-line output to stdout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Claude Code → stdin JSON → parse → render lines → stdout → Claude Code
            ↘ transcript_path → parse JSONL → tools/agents/todos
 ```
 
-**Key insight**: The statusline is invoked every ~300ms by Claude Code. Each invocation:
+**Key insight**: The statusline is invoked by Claude Code after each interaction (new assistant message, `/compact` finishing, permission-mode changes), debounced at 300ms — not on a fixed polling loop. Each invocation:
 1. Receives JSON via stdin (model, context, tokens - native accurate data)
 2. Parses the transcript JSONL file for tools, agents, and todos
 3. Renders multi-line output to stdout

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Claude Code → stdin JSON → claude-hud → stdout → displayed in your termi
 - Native token data from Claude Code (not estimated)
 - Scales with Claude Code's reported context window size, including newer 1M-context sessions
 - Parses the transcript for tool/agent activity
-- Updates every ~300ms
+- Re-renders after each interaction (new messages, `/compact`, permission changes), debounced at 300ms
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Then run `/reload-plugins` inside your session (or start a new one).
 
 </details>
 
-
 **Step 3: Configure the statusline**
 ```
 /claude-hud:setup
@@ -124,7 +123,7 @@ Claude Code → stdin JSON → claude-hud → stdout → displayed in your termi
 - Native token data from Claude Code (not estimated)
 - Scales with Claude Code's reported context window size, including newer 1M-context sessions
 - Parses the transcript for tool/agent activity
-- Re-renders after each interaction (new messages, `/compact`, permission changes), debounced at 300ms
+- Re-renders after each interaction (new assistant messages, `/compact`, permission changes, vim-mode toggles), debounced at 300ms
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,19 +21,19 @@ Inside a Claude Code instance, run the following commands:
 **Step 2: Install the plugin**
 
 <details>
-<summary><strong>⚠️ Linux users: Click here first</strong></summary>
+<summary><strong>⚠️ Linux users: Click here if install fails with an EXDEV error</strong></summary>
 
-On Linux, `/tmp` is often a separate filesystem (tmpfs), which causes plugin installation to fail with:
+On older Claude Code versions, `/tmp` being a separate filesystem (tmpfs) caused plugin installation to fail with:
 ```
 EXDEV: cross-device link not permitted
 ```
 
-**Fix**: Set TMPDIR before installing:
+This [Claude Code bug](https://github.com/anthropics/claude-code/issues/14799) has since been fixed — if you hit it, update Claude Code first. If you can't update, set TMPDIR before installing:
 ```bash
 mkdir -p ~/.cache/tmp && TMPDIR=~/.cache/tmp claude
 ```
 
-Then run the install command below in that session. This is a [Claude Code platform limitation](https://github.com/anthropics/claude-code/issues/14799).
+Then run the install command below in that session.
 
 </details>
 
@@ -41,11 +41,23 @@ Then run the install command below in that session. This is a [Claude Code platf
 /plugin install claude-hud
 ```
 
-After that, reload plugins:
+After that, reload plugins (no restart needed):
 
 ```
 /reload-plugins
 ```
+
+<details>
+<summary><strong>Prefer the terminal?</strong></summary>
+
+Steps 1–2 can also be done outside a session with the Claude Code CLI:
+```bash
+claude plugin marketplace add jarrodwatts/claude-hud
+claude plugin install claude-hud@claude-hud
+```
+Then run `/reload-plugins` inside your session (or start a new one).
+
+</details>
 
 
 **Step 3: Configure the statusline**
@@ -64,9 +76,7 @@ Then restart your shell and run `/claude-hud:setup` again.
 
 </details>
 
-Done! Restart Claude Code to load the new statusLine config, then the HUD will appear.
-
-On Windows, make that a full Claude Code restart after setup writes the new `statusLine` config.
+Done! Claude Code reloads settings automatically — the HUD appears after your next message, no restart needed. If it doesn't show up, restart Claude Code (older versions require a restart to pick up statusLine changes).
 
 ---
 
@@ -393,8 +403,8 @@ Leaving it unset (or setting an explicit negative: `0`, `false`, `off`, `no`) ke
 - They also only appear when there's activity to show
 
 **HUD not appearing after setup?**
-- Restart Claude Code so it picks up the new statusLine config
-- On macOS, fully quit Claude Code and run `claude` again in your terminal
+- Send any message — settings reload automatically, but the statusline only renders after your next interaction
+- If it still doesn't appear, restart Claude Code (fully quit and run `claude` again) — older Claude Code versions require a restart to pick up statusLine changes
 - Make sure `CLAUDE_HUD_DISABLE` is not set in your environment (e.g. exported from a shell profile) — it silences the HUD entirely, including setup verification
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -123,7 +123,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 - 来自 Claude Code 的原生 Token 数据（非估算）
 - 适配 Claude Code 报告的上下文窗口大小，包括最新的 1M 上下文会话
 - 解析转录文件以获取工具/Agent 活动
-- 在每次交互后重新渲染（新消息、`/compact`、权限变更），带 300ms 防抖
+- 在每次交互后重新渲染（新的助手消息、`/compact`、权限变更、vim 模式切换），带 300ms 防抖
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -21,19 +21,19 @@
 **步骤 2：安装插件**
 
 <details>
-<summary><strong>⚠️ Linux 用户：请先点击此处</strong></summary>
+<summary><strong>⚠️ Linux 用户：如果安装报 EXDEV 错误，请点击此处</strong></summary>
 
-在 Linux 上，`/tmp` 通常是独立的文件系统（tmpfs），这会导致插件安装失败并报错：
+在较旧的 Claude Code 版本上，`/tmp` 作为独立文件系统（tmpfs）会导致插件安装失败并报错：
 ```
 EXDEV: cross-device link not permitted
 ```
 
-**修复方法**：在安装前设置 TMPDIR：
+这个 [Claude Code 缺陷](https://github.com/anthropics/claude-code/issues/14799)已经修复——如果遇到此错误，请先升级 Claude Code。如果无法升级，可在安装前设置 TMPDIR：
 ```bash
 mkdir -p ~/.cache/tmp && TMPDIR=~/.cache/tmp claude
 ```
 
-然后在该会话中运行下面的安装命令。这是 [Claude Code 平台的限制](https://github.com/anthropics/claude-code/issues/14799)。
+然后在该会话中运行下面的安装命令。
 
 </details>
 
@@ -41,11 +41,23 @@ mkdir -p ~/.cache/tmp && TMPDIR=~/.cache/tmp claude
 /plugin install claude-hud
 ```
 
-安装完成后，重新加载插件：
+安装完成后，重新加载插件（无需重启）：
 
 ```
 /reload-plugins
 ```
+
+<details>
+<summary><strong>更喜欢在终端操作？</strong></summary>
+
+步骤 1–2 也可以在会话之外用 Claude Code CLI 完成：
+```bash
+claude plugin marketplace add jarrodwatts/claude-hud
+claude plugin install claude-hud@claude-hud
+```
+然后在会话内运行 `/reload-plugins`（或开启新会话）。
+
+</details>
 
 **步骤 3：配置状态栏**
 ```
@@ -63,9 +75,7 @@ winget install OpenJS.NodeJS.LTS
 
 </details>
 
-完成！重启 Claude Code 以加载新的 statusLine 配置，HUD 将会出现。
-
-在 Windows 上，setup 写入新的 `statusLine` 配置后，请完整重启 Claude Code。
+完成！Claude Code 会自动重新加载设置——发送下一条消息后 HUD 就会出现，无需重启。如果没有显示，请重启 Claude Code（旧版 Claude Code 需要重启才能加载 statusLine 变更）。
 
 ---
 
@@ -366,8 +376,8 @@ CLAUDE_HUD_DISABLE=1 claude
 - 它们也仅在有活动可显示时才会出现
 
 **HUD 设置后不显示？**
-- 重启 Claude Code 以加载新的 statusLine 配置
-- 在 macOS 上，完全退出 Claude Code 并在终端中再次运行 `claude`
+- 发送任意一条消息——设置会自动重新加载，但状态栏只在下一次交互后才会渲染
+- 如果仍未出现，重启 Claude Code（完全退出并在终端中再次运行 `claude`）——旧版 Claude Code 需要重启才能加载 statusLine 变更
 - 确认环境中没有设置 `CLAUDE_HUD_DISABLE`（例如从 shell 配置文件中导出）——它会让 HUD 完全静默，包括安装验证
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -123,7 +123,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 - 来自 Claude Code 的原生 Token 数据（非估算）
 - 适配 Claude Code 报告的上下文窗口大小，包括最新的 1M 上下文会话
 - 解析转录文件以获取工具/Agent 活动
-- 约每 300ms 更新一次
+- 在每次交互后重新渲染（新消息、`/compact`、权限变更），带 300ms 防抖
 
 ---
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -77,21 +77,19 @@ Remove-Item -Recurse -Force (Join-Path $claudeDir "plugins\cache\temp_local_*") 
 '{"version": 2, "plugins": {}}' | Set-Content (Join-Path $claudeDir "plugins\installed_plugins.json")
 ```
 
-After cleanup, tell user to **restart Claude Code** and run `/plugin install claude-hud` again.
+After cleanup, tell user to run `/plugin install claude-hud` again followed by `/reload-plugins` — no restart needed. (Restart Claude Code only if the reinstall still misbehaves; the fresh session re-reads the plugin registry from scratch.)
 
 ### Linux: Cross-Device Filesystem Check
 
-**On Linux only**, if install keeps failing, check for EXDEV issue:
+**On Linux only**, if install fails with `EXDEV: cross-device link not permitted`, check whether `/tmp` and home are on different filesystems:
 ```bash
 [ "$(df --output=source ~ /tmp 2>/dev/null | tail -2 | uniq | wc -l)" = "2" ] && echo "CROSS_DEVICE"
 ```
 
-If this outputs `CROSS_DEVICE`, `/tmp` and home are on different filesystems. This causes `EXDEV: cross-device link not permitted` during installation. Workaround:
+The underlying Claude Code bug ([#14799](https://github.com/anthropics/claude-code/issues/14799)) has been fixed, so this mostly affects older Claude Code versions — suggest updating Claude Code first. If updating isn't an option and the check outputs `CROSS_DEVICE`, the workaround is:
 ```bash
 mkdir -p ~/.cache/tmp && TMPDIR=~/.cache/tmp claude /plugin install claude-hud
 ```
-
-This is a [Claude Code platform limitation](https://github.com/anthropics/claude-code/issues/14799).
 
 ---
 
@@ -158,9 +156,12 @@ echo $OSTYPE
 
    The command exports `COLUMNS` so the HUD knows the real terminal width.
    Claude Code pipes the subprocess stdout, so `process.stdout.columns` is
-   unavailable at runtime. Prefer Claude Code's inherited positive-integer
-   `COLUMNS`, then try `stty size </dev/tty`, then fall back to 120. The `- 4`
-   accounts for Claude Code's input area padding (2 columns on each side).
+   unavailable at runtime. Since Claude Code v2.1.153, `COLUMNS` and `LINES`
+   are set natively to the current terminal dimensions before the statusLine
+   command runs, so the inherited `COLUMNS` value is the primary source. The
+   `stty size </dev/tty` probe and the 120 fallback remain for older Claude
+   Code versions where `COLUMNS` may be absent. The `- 4` accounts for Claude
+   Code's input area padding (2 columns on each side).
 
    The grep pattern uses `[[:space:]]` rather than `\t` to match the tab
    separator emitted by awk. GNU grep (BRE/ERE) does **not** interpret
@@ -628,19 +629,21 @@ Verify the first bytes are `7B 0D 0A` (`{` + CRLF) or `7B 0A` (`{` + LF), not `E
 
 After successfully writing the config, tell the user:
 
-> ✅ Config written. **Please restart Claude Code now** — quit and run `claude` again in your terminal.
-> Once restarted, run `/claude-hud:setup` again to complete Step 4 and verify the HUD is working.
+> ✅ Config written. Claude Code reloads settings automatically — the HUD should appear below your input field after your next message in this session (no restart needed).
+> If it doesn't show up after your next interaction, restart Claude Code (quit and run `claude` again) — older Claude Code versions require a restart to pick up statusLine changes.
 
-**Windows note**: Keep the restart guidance separate from runtime installation guidance.
-- If the user just installed Node.js, they should restart their shell first so `node` is available in `PATH`.
-- After `statusLine` is written successfully, they should fully quit Claude Code and launch a fresh session before judging whether the HUD setup worked.
+Then continue directly to Step 4 in the same session.
+
+**Windows note**: Keep the settings-reload guidance separate from runtime installation guidance.
+- If the user just installed Node.js, they should restart their shell first so `node` is available in `PATH` — that shell restart is unrelated to Claude Code picking up the statusLine config.
+- The statusLine config itself reloads automatically on Windows too; a full Claude Code restart is only the fallback if the HUD doesn't appear after the next interaction.
 
 **Note**: The generated command dynamically finds and runs the latest installed plugin version. Updates are automatic - no need to re-run setup after plugin updates. If the HUD suddenly stops working, re-run `/claude-hud:setup` to verify the plugin is still installed.
 
 **Restoring a previous statusline**: If the user previously had a different statusline and wants to restore it, use the backup path printed in Step 2.5.3. The previous command is stored in `~/.claude/plugins/claude-hud/previous-statusline.txt`. To restore:
 1. Find the most recent backup: `ls -t ~/.claude/settings.json.bak.* | head -1`
 2. Copy it back: `cp ~/.claude/settings.json.bak.{timestamp} ~/.claude/settings.json`
-3. Restart Claude Code.
+3. The restored config applies automatically on the next interaction (restart Claude Code only if it doesn't).
 
 ## Step 4: Optional Features
 
@@ -675,8 +678,8 @@ Merge with existing config if the file already exists. Only write keys the user 
 
 ## Step 5: Verify & Finish
 
-**First, confirm the user has restarted Claude Code** since Step 3 wrote the config. If they haven't, ask them to restart before proceeding — the HUD cannot appear in the same session where setup was run.
- 
+Settings reload automatically, so the HUD can appear in the same session where setup was run — it renders after the user's next interaction (their answer to the question below counts as one). No restart is needed on current Claude Code versions.
+
 Use AskUserQuestion:
 - Question: "Setup complete! The HUD should appear below your input field. Is it working?"
 - Options: "Yes, it's working" / "No, something's wrong"
@@ -685,9 +688,9 @@ Use AskUserQuestion:
 
 **If no**: Debug systematically:
 
-1. **Restart Claude Code** (most common cause on macOS):
-    - The statusLine config requires a restart to take effect
-    - Quit Claude Code completely and run `claude` again, then re-run `/claude-hud:setup` to verify
+1. **Trigger an interaction, then restart if needed**:
+    - Settings reload automatically, but the HUD only renders after the next interaction (a new message, `/compact` finishing, a permission-mode change) — sending any message should make it appear
+    - If it still doesn't appear, restart Claude Code (quit and run `claude` again) — older Claude Code versions require a restart to pick up statusLine changes — then re-run `/claude-hud:setup` to verify
     - If you've already restarted, continue below
 
 2. **Verify config was applied**:

--- a/src/context-cache.ts
+++ b/src/context-cache.ts
@@ -12,7 +12,8 @@ const CACHE_DIRNAME = "context-cache";
 
 /**
  * Minimum interval between cache rewrites for the same session.
- * Status line runs every ~300ms so this keeps the steady-state write path cheap
+ * Status line refreshes are event-driven and can fire in rapid bursts
+ * (debounced at 300ms), so this keeps the steady-state write path cheap
  * while still refreshing the fallback snapshot regularly.
  */
 const WRITE_TTL_MS = 3_000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export function isHudDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
 export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
   if (isHudDisabled()) {
     // Print nothing so Claude Code renders an empty statusline, and skip all
-    // work (stdin parse, transcript scan, git) for the ~300ms polling loop.
+    // work (stdin parse, transcript scan, git) on each event-driven refresh.
     return;
   }
 


### PR DESCRIPTION
## Summary

Claude Code has changed quite a bit since the install/setup instructions were written. This PR updates them to match current behavior, verified against the official docs ([statusline](https://code.claude.com/docs/en/statusline.md), [plugins reference](https://code.claude.com/docs/en/plugins-reference.md)) rather than memory.

## Changes

**No more restart-after-setup** (`README.md`, `README.zh.md`, `CLAUDE.README.md`, `commands/setup.md`)
- Per current docs: *"Settings reload automatically, but changes won't appear until your next interaction with Claude Code."* The HUD appears after the next message — no restart needed, and no documented Windows difference.
- Restart is demoted to a fallback for older Claude Code versions everywhere it was previously required: the post-setup message, the Windows note, the troubleshooting sections, and the restore-previous-statusline steps.
- Setup's Step 5 no longer claims "the HUD cannot appear in the same session where setup was run" — setup now flows config → verify in one session.

**Native terminal width** (`commands/setup.md`)
- Claude Code v2.1.153+ sets `COLUMNS`/`LINES` natively before invoking the statusLine command. The generated-command rationale now documents this; the `stty size </dev/tty` probe is kept as a fallback for older versions (support floor is still v1.0.80+).

**Linux EXDEV bug is fixed upstream** (`README.md`, `README.zh.md`, `commands/setup.md`)
- [anthropics/claude-code#14799](https://github.com/anthropics/claude-code/issues/14799) is closed. The warning is demoted from "Linux users click here first" to error-triggered guidance that recommends updating Claude Code, with the `TMPDIR` workaround retained for older versions.

**Install-flow touch-ups**
- Ghost-install cleanup now points at `/reload-plugins` instead of a restart.
- Added a collapsible "Prefer the terminal?" section documenting the `claude plugin marketplace add` / `claude plugin install` CLI flow.
- `CLAUDE.README.md` was missing the `/reload-plugins` step entirely; added it.

## Notes

- Generated statusline commands are untouched — the `COLUMNS` fallback chain still matters for pre-2.1.153 versions.
- `CLAUDE_CONFIG_DIR` handling left as-is (couldn't confirm current docs mention it, but no evidence it stopped working).
- Follow-up PR planned: optionally offering `refreshInterval` during setup so time-based HUD data ticks without user interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)