### PR TITLE
feat: offer statusLine refreshInterval during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Example fallback snapshot:
 
 ### Auto-Refresh
 
-Claude Code only re-runs the statusline after an interaction (a new message, `/compact` finishing, a permission-mode change), so time-based HUD info — session duration, usage reset countdowns, the prompt-cache countdown — goes stale between messages. To keep it ticking, add `refreshInterval` (seconds, minimum 1) to the `statusLine` entry in `~/.claude/settings.json`:
+Claude Code only re-runs the statusline after an interaction (a new assistant message, `/compact` finishing, a permission-mode change, or a vim-mode toggle), so time-based HUD info — session duration, usage reset countdowns, the prompt-cache countdown — goes stale between messages. To keep it ticking, add `refreshInterval` (seconds, minimum 1) to the `statusLine` entry in `~/.claude/settings.json`:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -367,6 +367,22 @@ Example fallback snapshot:
 - `!` = modified files, `+` = added/staged, `✘` = deleted, `?` = untracked
 - Counts of 0 are omitted for cleaner display
 
+### Auto-Refresh
+
+Claude Code only re-runs the statusline after an interaction (a new message, `/compact` finishing, a permission-mode change), so time-based HUD info — session duration, usage reset countdowns, the prompt-cache countdown — goes stale between messages. To keep it ticking, add `refreshInterval` (seconds, minimum 1) to the `statusLine` entry in `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "...",
+    "refreshInterval": 5
+  }
+}
+```
+
+`/claude-hud:setup` offers this during installation. Each refresh re-runs the HUD command, so 5 seconds is a good default; use 1 second only if you want visibly smooth countdowns.
+
 ### Disabling the HUD Temporarily
 
 Set the `CLAUDE_HUD_DISABLE` environment variable to launch a session without the HUD — no need to remove the `statusLine` entry from `settings.json`:

--- a/README.zh.md
+++ b/README.zh.md
@@ -342,7 +342,7 @@ ClaudeHUD 优先使用官方 statusline stdin 负载中的使用率数据。如�
 
 ### 自动刷新
 
-Claude Code 只在交互之后（新消息、`/compact` 完成、权限模式变更）才会重新运行状态栏，因此与时间相关的 HUD 信息——会话时长、使用量重置倒计时、提示词缓存倒计时——在消息之间会停止更新。要让它们持续跳动，可以在 `~/.claude/settings.json` 的 `statusLine` 条目中添加 `refreshInterval`（秒，最小值 1）：
+Claude Code 只在交互之后（新的助手消息、`/compact` 完成、权限模式变更、vim 模式切换）才会重新运行状态栏，因此与时间相关的 HUD 信息——会话时长、使用量重置倒计时、提示词缓存倒计时——在消息之间会停止更新。要让它们持续跳动，可以在 `~/.claude/settings.json` 的 `statusLine` 条目中添加 `refreshInterval`（秒，最小值 1）：
 
 ```json
 {

--- a/README.zh.md
+++ b/README.zh.md
@@ -340,6 +340,22 @@ ClaudeHUD 优先使用官方 statusline stdin 负载中的使用率数据。如�
 - `!` = 修改的文件，`+` = 新增/暂存，`✘` = 删除，`?` = 未跟踪
 - 计数为 0 的项会被省略，以保持显示整洁
 
+### 自动刷新
+
+Claude Code 只在交互之后（新消息、`/compact` 完成、权限模式变更）才会重新运行状态栏，因此与时间相关的 HUD 信息——会话时长、使用量重置倒计时、提示词缓存倒计时——在消息之间会停止更新。要让它们持续跳动，可以在 `~/.claude/settings.json` 的 `statusLine` 条目中添加 `refreshInterval`（秒，最小值 1）：
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "...",
+    "refreshInterval": 5
+  }
+}
+```
+
+`/claude-hud:setup` 会在安装时提供此选项。每次刷新都会重新运行 HUD 命令，因此推荐 5 秒；只有在需要平滑倒计时时才用 1 秒。
+
 ### 临时关闭 HUD
 
 设置环境变量 `CLAUDE_HUD_DISABLE`，即可在本次会话中关闭 HUD，无需从 `settings.json` 中移除 `statusLine` 配置：

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -673,7 +673,9 @@ Merge with existing config if the file already exists. Only write keys the user 
 
 ### Step 4.5: Auto-Refresh (Optional)
 
-Claude Code only re-runs the statusline after an interaction (a new assistant message, `/compact` finishing, a permission-mode change). Time-based HUD data — session duration, usage reset countdowns, the prompt-cache countdown — therefore goes stale between messages. Claude Code supports an optional `refreshInterval` key (seconds, minimum 1) on the `statusLine` settings object that re-runs the command every N seconds.
+Claude Code only re-runs the statusline after an interaction (a new assistant message, `/compact` finishing, a permission-mode change, or a vim-mode toggle). Time-based HUD data — session duration, usage reset countdowns, the prompt-cache countdown — therefore goes stale between messages. Claude Code supports an optional `refreshInterval` key (seconds, minimum 1) on the `statusLine` settings object that re-runs the command every N seconds.
+
+Of those, only the usage reset countdown is shown by default — session duration and the prompt-cache countdown tick only if the user enabled them (e.g. "Session info" in Step 4, or via config). Mention this if the user seems unsure whether the timer is worth it.
 
 Ask with AskUserQuestion:
 - header: "Auto-refresh"
@@ -685,7 +687,11 @@ Ask with AskUserQuestion:
 
 **If the user picks an interval**, merge `refreshInterval: <N>` into the **existing** `statusLine` object in `settings.json` — preserve `type`, `command`, and any other keys. Follow the same rules as Step 3: real JSON serializer, no BOM on Windows, retry once on a concurrent-modification error. Do not re-create the backup; the Step 2.5.3 backup already covers this session.
 
-**If the user picks "No timer"** (or "Other" / skip), do not write the key. If a `refreshInterval` key already exists in `statusLine` from a previous run and the user explicitly chose "No timer", remove it.
+**If the user picks "Other" and gives a numeric interval** (e.g. "10" or "10 seconds"), use that value, clamped to a minimum of 1. Treat a non-numeric "Other" answer that declines (skip/none/no) like "No timer".
+
+**If the user picks "No timer"**, do not write the key. If a `refreshInterval` key already exists in `statusLine` from a previous run and the user explicitly chose "No timer", remove it.
+
+`refreshInterval` lives in `settings.json`, which Claude Code reloads automatically — ticking should start after the user's next interaction. If countdowns don't tick in the current session, tell the user it will take effect after a Claude Code restart; do not treat a non-ticking timer as a setup failure in Step 5.
 
 Each refresh re-runs the full HUD command (runtime startup, transcript parse, git status), so 5 seconds is the recommended default; only suggest 1 second when the user wants visibly smooth countdowns.
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -671,6 +671,24 @@ Merge with existing config if the file already exists. Only write keys the user 
 
 **If user selects nothing** (or picks "Other" and says skip/none), do not create a config file. The defaults are fine.
 
+### Step 4.5: Auto-Refresh (Optional)
+
+Claude Code only re-runs the statusline after an interaction (a new assistant message, `/compact` finishing, a permission-mode change). Time-based HUD data — session duration, usage reset countdowns, the prompt-cache countdown — therefore goes stale between messages. Claude Code supports an optional `refreshInterval` key (seconds, minimum 1) on the `statusLine` settings object that re-runs the command every N seconds.
+
+Ask with AskUserQuestion:
+- header: "Auto-refresh"
+- question: "Re-run the HUD on a timer so time-based info (session duration, usage countdowns) stays current between messages?"
+- options:
+  - "Every 5 seconds (Recommended)" — Keeps countdowns fresh with negligible overhead
+  - "Every 1 second" — Smoothest ticking; re-runs the HUD command far more often
+  - "No timer" — HUD updates only after interactions (Claude Code's default)
+
+**If the user picks an interval**, merge `refreshInterval: <N>` into the **existing** `statusLine` object in `settings.json` — preserve `type`, `command`, and any other keys. Follow the same rules as Step 3: real JSON serializer, no BOM on Windows, retry once on a concurrent-modification error. Do not re-create the backup; the Step 2.5.3 backup already covers this session.
+
+**If the user picks "No timer"** (or "Other" / skip), do not write the key. If a `refreshInterval` key already exists in `statusLine` from a previous run and the user explicitly chose "No timer", remove it.
+
+Each refresh re-runs the full HUD command (runtime startup, transcript parse, git status), so 5 seconds is the recommended default; only suggest 1 second when the user wants visibly smooth countdowns.
+
 ---
 
 ## Step 5: Verify & Finish


### PR DESCRIPTION
## Summary

Claude Code supports an optional [`refreshInterval`](https://code.claude.com/docs/en/statusline.md) key (seconds, minimum 1) on the `statusLine` settings object that re-runs the statusline command on a timer. Without it, the HUD only re-renders after an interaction — so time-based data (session duration, usage reset countdowns, the prompt-cache countdown) goes stale between messages.

Follow-up to #681.

## Changes

- **`commands/setup.md`**: new Step 4.5 asks the user whether to enable auto-refresh (every 5s recommended / every 1s / no timer) and merges `refreshInterval` into the existing `statusLine` object — preserving `type`/`command`, reusing Step 3's JSON-safety and no-BOM rules, and removing the key if the user explicitly opts out on a re-run.
- **`README.md` / `README.zh.md`**: new "Auto-Refresh" section under Configuration with an example snippet.

## Notes

- 5 seconds is the recommended default since each refresh re-runs the full HUD command (runtime startup, transcript parse, git status); 1 second is offered for visibly smooth countdowns.
- A `hideVimModeIndicator` follow-up was considered but skipped: the HUD doesn't render `vim.mode`, so there's nothing to hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)