### PR TITLE
feat: add Jujutsu (jj) status indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 | `gitStatus.pushCriticalThreshold` | number | 0 | Color the ahead count with the critical color at or above this unpushed-commit count (`0` disables it) |
 | `gitStatus.showFileStats` | boolean | false | Show file change counts `!M +A ✘D ?U` |
 | `gitStatus.branchOverflow` | `truncate` \| `wrap` | `truncate` | Keep current truncation behavior or let the git block wrap onto its own line boundary when possible |
+| `jjStatus.enabled` | boolean | true | Show jj (Jujutsu) status in HUD. When a `.jj` directory is found, jj is used instead of git for that repo — never both |
+| `jjStatus.showDirty` | boolean | true | Show `*` when the working-copy commit differs from its parent |
+| `jjStatus.showConflicts` | boolean | true | Show a `!conflict` marker when the working-copy commit has an unresolved conflict |
 | `display.showModel` | boolean | true | Show model name `[Opus]` |
 | `display.modelSource` | `stdin` \| `auto` \| `transcript` | `stdin` | Controls which source the model name comes from. `stdin` preserves the default behavior and always uses what Claude Code reports. `auto` opts into proxy redirect detection by using transcript models only for non-Claude models. `transcript` always uses the model from the API response. Transcript model values are terminal-sanitized and capped at 80 characters |
 | `display.showProvider` | boolean | false | Show the provider label *before* the model name, e.g. `[Bedrock \| Opus 4.6]`. Useful when a custom proxy serves identically-named models from different providers. When off, an auto-detected provider still trails the model as before |
@@ -336,6 +339,11 @@ Example fallback snapshot:
     "showAheadBehind": true,
     "showFileStats": true
   },
+  "jjStatus": {
+    "enabled": true,
+    "showDirty": true,
+    "showConflicts": true
+  },
   "display": {
     "showTools": true,
     "showSkills": true,
@@ -378,6 +386,25 @@ Example fallback snapshot:
 - `!` = modified files, `+` = added/staged, `✘` = deleted, `?` = untracked
 - Counts of 0 are omitted for cleaner display
 
+### Jujutsu (jj) support
+
+When a `.jj` directory is found in (or above) the working directory, the HUD
+shows jj-native status instead of git — the two are mutually exclusive per
+invocation, even in a colocated jj+git repo.
+
+**With a bookmark:** `[Opus] │ my-project jj:(mybookmark)`
+
+**Anonymous change (no bookmark at `@`):** `[Opus] │ my-project jj:(wrulwzyw)`
+
+**Dirty working copy:** `[Opus] │ my-project jj:(mybookmark*)`
+
+**Unresolved conflict:** `[Opus] │ my-project jj:(mybookmark !conflict)`
+
+Ahead/behind counts and per-file change stats are git-only in this version —
+jj's equivalent requires more expensive revset queries against
+`remote_bookmarks()`, so they're left out to keep the jj status fetch to a
+single subprocess call.
+
 ### Auto-Refresh
 
 Claude Code only re-runs the statusline after an interaction (a new assistant message, `/compact` finishing, a permission-mode change, or a vim-mode toggle), so time-based HUD info — session duration, usage reset countdowns, the prompt-cache countdown — goes stale between messages. To keep it ticking, add `refreshInterval` (seconds, minimum 1) to the `statusLine` entry in `~/.claude/settings.json`:
@@ -414,6 +441,11 @@ Leaving it unset (or setting an explicit negative: `0`, `false`, `off`, `no`) ke
 **Git status missing?**
 - Verify you're in a git repository
 - Check `gitStatus.enabled` is not `false` in config
+
+**jj status missing, or seeing `git:(...)` in a jj repo?**
+- Verify a `.jj` directory exists at or above the working directory
+- Check `jjStatus.enabled` is not `false` in config
+- Verify the `jj` binary is installed and on `PATH`
 
 **Tool/skill/MCP/agent/todo lines missing?**
 - These are hidden by default — enable with `showTools`, `showSkills`, `showMcp`, `showAgents`, `showTodos` in config

--- a/src/config.ts
+++ b/src/config.ts
@@ -163,6 +163,11 @@ export interface HudConfig {
     pushWarningThreshold: number;
     pushCriticalThreshold: number;
   };
+  jjStatus: {
+    enabled: boolean;
+    showDirty: boolean;
+    showConflicts: boolean;
+  };
   display: {
     showModel: boolean;
     showProject: boolean;
@@ -270,6 +275,11 @@ export const DEFAULT_CONFIG: HudConfig = {
     branchOverflow: 'truncate',
     pushWarningThreshold: 0,
     pushCriticalThreshold: 0,
+  },
+  jjStatus: {
+    enabled: true,
+    showDirty: true,
+    showConflicts: true,
   },
   display: {
     showModel: true,
@@ -662,6 +672,18 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     pushCriticalThreshold: validateCountThreshold(migrated.gitStatus?.pushCriticalThreshold),
   };
 
+  const jjStatus = {
+    enabled: typeof migrated.jjStatus?.enabled === 'boolean'
+      ? migrated.jjStatus.enabled
+      : DEFAULT_CONFIG.jjStatus.enabled,
+    showDirty: typeof migrated.jjStatus?.showDirty === 'boolean'
+      ? migrated.jjStatus.showDirty
+      : DEFAULT_CONFIG.jjStatus.showDirty,
+    showConflicts: typeof migrated.jjStatus?.showConflicts === 'boolean'
+      ? migrated.jjStatus.showConflicts
+      : DEFAULT_CONFIG.jjStatus.showConflicts,
+  };
+
   const display = {
     showModel: typeof migrated.display?.showModel === 'boolean'
       ? migrated.display.showModel
@@ -883,7 +905,7 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
       : DEFAULT_CONFIG.colors.barEmpty,
   };
 
-  return { language, lineLayout, showSeparators, pathLevels, maxWidth, forceMaxWidth, elementOrder, projectLineOrder, gitStatus, display, colors };
+  return { language, lineLayout, showSeparators, pathLevels, maxWidth, forceMaxWidth, elementOrder, projectLineOrder, gitStatus, jjStatus, display, colors };
 }
 
 export async function loadConfig(): Promise<HudConfig> {

--- a/src/git.ts
+++ b/src/git.ts
@@ -33,6 +33,10 @@ export interface GitStatus {
   fileStats?: FileStats;
   lineDiff?: LineDiff;
   branchUrl?: string;
+  /** Which VCS produced this status. Omitted (undefined) means 'git'. */
+  vcs?: 'git' | 'jj';
+  /** jj-native: true when the working-copy commit has an unresolved conflict. */
+  conflict?: boolean;
 }
 
 export async function getGitBranch(cwd?: string): Promise<string | null> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { parseTranscript } from "./transcript.js";
 import { render } from "./render/index.js";
 import { countConfigs } from "./config-reader.js";
 import { getGitStatus } from "./git.js";
+import { getJjStatus, isJjRepo } from "./jj.js";
 import { loadConfig } from "./config.js";
 import { parseExtraCmdArg, runExtraCmd } from "./extra-cmd.js";
 import { getClaudeCodeVersion } from "./version.js";
@@ -13,6 +14,8 @@ import { applyContextWindowFallback } from "./context-cache.js";
 import { getUsageFromExternalSnapshot, writeExternalUsageSnapshot } from "./external-usage.js";
 import { setLanguage, t } from "./i18n/index.js";
 import type { RenderContext } from "./types.js";
+import type { GitStatus } from "./git.js";
+import type { HudConfig } from "./config.js";
 
 export { getUsageFromExternalSnapshot, writeExternalUsageSnapshot } from "./external-usage.js";
 import { fileURLToPath } from "node:url";
@@ -26,6 +29,8 @@ export type MainDeps = {
   parseTranscript: typeof parseTranscript;
   countConfigs: typeof countConfigs;
   getGitStatus: typeof getGitStatus;
+  getJjStatus: typeof getJjStatus;
+  isJjRepo: typeof isJjRepo;
   loadConfig: typeof loadConfig;
   parseExtraCmdArg: typeof parseExtraCmdArg;
   runExtraCmd: typeof runExtraCmd;
@@ -53,6 +58,26 @@ export function isHudDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return value !== "0" && value !== "false" && value !== "off" && value !== "no";
 }
 
+/**
+ * Picks exactly one VCS backend per invocation: jj when a `.jj` marker is
+ * found (cheap, subprocess-free check) and enabled, otherwise git. Never runs
+ * both, so colocated jj+git repos only pay for one subprocess call.
+ */
+export async function resolveVcsStatus(
+  deps: Pick<MainDeps, "getGitStatus" | "getJjStatus" | "isJjRepo">,
+  config: HudConfig,
+  cwd?: string,
+): Promise<GitStatus | null> {
+  if (!cwd) return null;
+  if (config.jjStatus.enabled && deps.isJjRepo(cwd)) {
+    return deps.getJjStatus(cwd);
+  }
+  if (config.gitStatus.enabled) {
+    return deps.getGitStatus(cwd);
+  }
+  return null;
+}
+
 export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
   if (isHudDisabled()) {
     // Print nothing so Claude Code renders an empty statusline, and skip all
@@ -68,6 +93,8 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     parseTranscript,
     countConfigs,
     getGitStatus,
+    getJjStatus,
+    isJjRepo,
     loadConfig,
     parseExtraCmdArg,
     runExtraCmd,
@@ -109,9 +136,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
 
     const config = await deps.loadConfig();
     setLanguage(config.language);
-    const gitStatus = config.gitStatus.enabled
-      ? await deps.getGitStatus(stdin.cwd)
-      : null;
+    const gitStatus = await resolveVcsStatus(deps, config, stdin.cwd);
 
     let usageData: RenderContext["usageData"] = null;
     const shouldReadUsage = config.display.showUsage !== false;

--- a/src/jj.ts
+++ b/src/jj.ts
@@ -1,0 +1,80 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createDebug } from './debug.js';
+import type { GitStatus } from './git.js';
+
+const debug = createDebug('jj');
+const execFileAsync = promisify(execFile);
+
+// Defensive bound against pathological/symlink cases; real repo trees never
+// nest this deep.
+const MAX_WALK_DEPTH = 64;
+
+/**
+ * Cheap, synchronous, subprocess-free check: walk upward from cwd looking for
+ * a `.jj` directory, the same way jj's own CLI locates a repo root. Runs
+ * before any subprocess is spawned so non-jj users pay ~zero cost per
+ * invocation (a few fs.statSync calls, never an execFile).
+ */
+export function isJjRepo(cwd?: string): boolean {
+  if (!cwd) return false;
+
+  let dir = path.resolve(cwd);
+  for (let i = 0; i < MAX_WALK_DEPTH; i++) {
+    try {
+      if (fs.statSync(path.join(dir, '.jj')).isDirectory()) return true;
+    } catch {
+      // no .jj here; keep walking up
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  return false;
+}
+
+// Four \x1f-delimited fields collected in a single `jj log` call:
+//   change id (short) | bookmarks at @ | dirty flag | conflict flag
+const JJ_TEMPLATE = [
+  'change_id.shortest(8)',
+  '"\\x1f"',
+  'self.bookmarks().join(",")',
+  '"\\x1f"',
+  'if(self.empty(), "0", "1")',
+  '"\\x1f"',
+  'if(self.conflict(), "1", "0")',
+].join(' ++ ');
+
+export async function getJjStatus(cwd?: string): Promise<GitStatus | null> {
+  if (!cwd) return null;
+
+  try {
+    const { stdout } = await execFileAsync(
+      'jj',
+      ['log', '-r', '@', '--no-graph', '--color', 'never', '-T', JJ_TEMPLATE],
+      { cwd, timeout: 2000, encoding: 'utf8', windowsHide: true }
+    );
+
+    const [changeId, bookmarksRaw, dirtyFlag, conflictFlag] = stdout.trim().split('\x1f');
+    if (!changeId) return null;
+
+    const bookmarks = bookmarksRaw ? bookmarksRaw.split(',').filter(Boolean) : [];
+
+    return {
+      branch: bookmarks[0] ?? changeId,
+      isDirty: dirtyFlag === '1',
+      ahead: 0,
+      behind: 0,
+      vcs: 'jj',
+      conflict: conflictFlag === '1',
+    };
+  } catch (err) {
+    // Covers: jj binary missing (ENOENT), not in a jj repo, or a template
+    // incompatible with the installed jj version — all treated the same as
+    // git.ts's failure handling: return null, render nothing.
+    debug('getJjStatus failed (jj missing/incompatible?):', err instanceof Error ? err.message : err);
+    return null;
+  }
+}

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -72,12 +72,15 @@ export function renderProjectLine(ctx: RenderContext): string | null {
 
   let gitPart = '';
   const gitConfig = ctx.config?.gitStatus;
-  const showGit = gitConfig?.enabled ?? true;
+  const jjConfig = ctx.config?.jjStatus;
+  const isJj = ctx.gitStatus?.vcs === 'jj';
+  const showGit = isJj ? (jjConfig?.enabled ?? true) : (gitConfig?.enabled ?? true);
   const branchOverflow = gitConfig?.branchOverflow ?? 'truncate';
 
   if (showGit && ctx.gitStatus) {
+    const showDirty = isJj ? (jjConfig?.showDirty ?? true) : (gitConfig?.showDirty ?? true);
     const branchText = sanitizeDisplayText(
-      ctx.gitStatus.branch + ((gitConfig?.showDirty ?? true) && ctx.gitStatus.isDirty ? '*' : '')
+      ctx.gitStatus.branch + (showDirty && ctx.gitStatus.isDirty ? '*' : '')
     );
     const coloredBranch = gitBranchColor(branchText, colors);
     const linkedBranch = safeHyperlink(ctx.gitStatus.branchUrl, coloredBranch);
@@ -100,7 +103,12 @@ export function renderProjectLine(ctx: RenderContext): string | null {
       }
     }
 
-    gitPart = `${gitColor('git:(', colors)}${gitInner.join(' ')}${gitColor(')', colors)}`;
+    if (isJj && (jjConfig?.showConflicts ?? true) && ctx.gitStatus.conflict) {
+      gitInner.push(criticalColor('!conflict', colors));
+    }
+
+    const vcsLabel = isJj ? 'jj:(' : 'git:(';
+    gitPart = `${gitColor(vcsLabel, colors)}${gitInner.join(' ')}${gitColor(')', colors)}`;
   }
 
   const projectWithDirs = projectPart && addedDirsPart

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { DEFAULT_CONFIG } from "../dist/config.js";
 import { setLanguage } from "../dist/i18n/index.js";
-import { formatSessionDuration, main } from "../dist/index.js";
+import { formatSessionDuration, main, resolveVcsStatus } from "../dist/index.js";
 
 function restoreEnvVar(name, value) {
   if (value === undefined) {
@@ -23,6 +23,10 @@ function makeConfig(overrides = {}) {
     gitStatus: {
       ...DEFAULT_CONFIG.gitStatus,
       ...(overrides.gitStatus ?? {}),
+    },
+    jjStatus: {
+      ...DEFAULT_CONFIG.jjStatus,
+      ...(overrides.jjStatus ?? {}),
     },
     display: {
       ...DEFAULT_CONFIG.display,
@@ -262,6 +266,106 @@ test("main includes git status in render context", async () => {
   });
 
   assert.equal(renderedContext?.gitStatus?.branch, "feature/test");
+});
+
+test("resolveVcsStatus returns null without a cwd", async () => {
+  const result = await resolveVcsStatus(
+    {
+      getGitStatus: async () => { throw new Error("should not be called"); },
+      getJjStatus: async () => { throw new Error("should not be called"); },
+      isJjRepo: () => { throw new Error("should not be called"); },
+    },
+    makeConfig(),
+    undefined,
+  );
+  assert.equal(result, null);
+});
+
+test("resolveVcsStatus prefers jj over git and never calls getGitStatus", async () => {
+  let gitCalled = false;
+
+  const result = await resolveVcsStatus(
+    {
+      getGitStatus: async () => {
+        gitCalled = true;
+        return null;
+      },
+      getJjStatus: async (cwd) => ({
+        branch: "mybookmark",
+        isDirty: false,
+        ahead: 0,
+        behind: 0,
+        vcs: "jj",
+        conflict: false,
+      }),
+      isJjRepo: () => true,
+    },
+    makeConfig(),
+    "/some/jj/repo",
+  );
+
+  assert.equal(gitCalled, false);
+  assert.equal(result?.vcs, "jj");
+  assert.equal(result?.branch, "mybookmark");
+});
+
+test("resolveVcsStatus falls back to git when isJjRepo is false", async () => {
+  let jjCalled = false;
+
+  const result = await resolveVcsStatus(
+    {
+      getGitStatus: async () => ({
+        branch: "main",
+        isDirty: false,
+        ahead: 0,
+        behind: 0,
+      }),
+      getJjStatus: async () => {
+        jjCalled = true;
+        return null;
+      },
+      isJjRepo: () => false,
+    },
+    makeConfig(),
+    "/some/git/repo",
+  );
+
+  assert.equal(jjCalled, false);
+  assert.equal(result?.branch, "main");
+});
+
+test("resolveVcsStatus skips jj entirely when jjStatus.enabled is false", async () => {
+  let jjCalled = false;
+
+  const result = await resolveVcsStatus(
+    {
+      getGitStatus: async () => ({ branch: "main", isDirty: false, ahead: 0, behind: 0 }),
+      getJjStatus: async () => {
+        jjCalled = true;
+        return null;
+      },
+      isJjRepo: () => true,
+    },
+    makeConfig({ jjStatus: { enabled: false } }),
+    "/some/repo",
+  );
+
+  assert.equal(jjCalled, false);
+  assert.equal(result?.branch, "main");
+});
+
+test("resolveVcsStatus returns null when both git and jj are disabled", async () => {
+  const result = await resolveVcsStatus(
+    {
+      getGitStatus: async () => { throw new Error("should not be called"); },
+      getJjStatus: async () => { throw new Error("should not be called"); },
+      isJjRepo: () => false,
+    },
+    makeConfig({ gitStatus: { enabled: false } }),
+    "/some/repo",
+  );
+
+  assert.equal(result, null);
 });
 
 test("main includes usageData from stdin when available", async () => {

--- a/tests/jj.test.js
+++ b/tests/jj.test.js
@@ -1,0 +1,133 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { isJjRepo, getJjStatus } from '../dist/jj.js';
+
+function hasJj() {
+  try {
+    execFileSync('jj', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+const jjAvailable = hasJj();
+const skipReason = jjAvailable ? false : 'jj binary not installed';
+
+test('isJjRepo returns false when cwd is undefined', () => {
+  assert.equal(isJjRepo(undefined), false);
+});
+
+test('isJjRepo returns false for a non-jj directory', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-nojj-'));
+  try {
+    assert.equal(isJjRepo(dir), false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('getJjStatus returns null when cwd is undefined', async () => {
+  const result = await getJjStatus(undefined);
+  assert.equal(result, null);
+});
+
+test('getJjStatus returns null for a non-jj directory', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-nojj-'));
+  try {
+    const result = await getJjStatus(dir);
+    assert.equal(result, null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('isJjRepo and getJjStatus detect a real jj repo', { skip: skipReason }, async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-jj-'));
+  try {
+    execFileSync('jj', ['git', 'init'], { cwd: dir, stdio: 'ignore' });
+
+    assert.equal(isJjRepo(dir), true);
+
+    const result = await getJjStatus(dir);
+    assert.equal(result?.vcs, 'jj');
+    assert.equal(result?.conflict, false);
+    assert.equal(result?.isDirty, false);
+    assert.ok(result?.branch, `expected an anonymous change id, got ${JSON.stringify(result)}`);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('getJjStatus reports isDirty after an uncommitted change', { skip: skipReason }, async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-jj-'));
+  try {
+    execFileSync('jj', ['git', 'init'], { cwd: dir, stdio: 'ignore' });
+    await writeFile(path.join(dir, 'a.txt'), 'hello');
+
+    const result = await getJjStatus(dir);
+    assert.equal(result?.isDirty, true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('getJjStatus reports the bookmark name at @ when one exists', { skip: skipReason }, async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-jj-'));
+  try {
+    execFileSync('jj', ['git', 'init'], { cwd: dir, stdio: 'ignore' });
+    execFileSync('jj', ['bookmark', 'create', 'mybookmark', '-r', '@'], { cwd: dir, stdio: 'ignore' });
+
+    const result = await getJjStatus(dir);
+    assert.equal(result?.branch, 'mybookmark');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('isJjRepo detects a jj repo from a nested subdirectory', { skip: skipReason }, async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-jj-'));
+  try {
+    execFileSync('jj', ['git', 'init'], { cwd: dir, stdio: 'ignore' });
+    const nested = path.join(dir, 'a', 'b', 'c');
+    execFileSync('mkdir', ['-p', nested]);
+
+    assert.equal(isJjRepo(nested), true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('getJjStatus detects a genuine conflict', { skip: skipReason }, async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-jj-'));
+  try {
+    execFileSync('jj', ['git', 'init'], { cwd: dir, stdio: 'ignore' });
+    await writeFile(path.join(dir, 'f.txt'), 'original\n');
+    execFileSync('jj', ['commit', '-m', 'initial'], { cwd: dir, stdio: 'ignore' });
+
+    const initialId = execFileSync(
+      'jj',
+      ['log', '-r', 'heads(::@- ~ root())', '--no-graph', '-T', 'change_id.shortest(8)'],
+      { cwd: dir, encoding: 'utf8' }
+    ).trim();
+
+    execFileSync('jj', ['new', initialId, '-m', 'A'], { cwd: dir, stdio: 'ignore' });
+    await writeFile(path.join(dir, 'f.txt'), 'A-version\n');
+    const aId = execFileSync('jj', ['log', '-r', '@', '--no-graph', '-T', 'change_id.shortest(8)'], { cwd: dir, encoding: 'utf8' }).trim();
+
+    execFileSync('jj', ['new', initialId, '-m', 'B'], { cwd: dir, stdio: 'ignore' });
+    await writeFile(path.join(dir, 'f.txt'), 'B-version\n');
+    const bId = execFileSync('jj', ['log', '-r', '@', '--no-graph', '-T', 'change_id.shortest(8)'], { cwd: dir, encoding: 'utf8' }).trim();
+
+    execFileSync('jj', ['rebase', '-r', bId, '-d', aId], { cwd: dir, stdio: 'ignore' });
+    execFileSync('jj', ['edit', bId], { cwd: dir, stdio: 'ignore' });
+
+    const result = await getJjStatus(dir);
+    assert.equal(result?.conflict, true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1418,6 +1418,60 @@ test('renderProjectLine can give git its own segment for wrapping', () => {
   assert.ok(line.includes('my-project │ git:(feature/add-auth)'), 'git should render as a separate segment');
 });
 
+test('renderProjectLine shows jj:( label with bookmark when vcs is jj', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.gitStatus = { branch: 'mybookmark', isDirty: false, ahead: 0, behind: 0, vcs: 'jj', conflict: false };
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(line.includes('jj:(mybookmark)'), `expected jj:( label, got ${line}`);
+  assert.ok(!line.includes('git:('), 'should not use the git label for jj status');
+});
+
+test('renderProjectLine shows dirty marker for jj status', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.gitStatus = { branch: 'mybookmark', isDirty: true, ahead: 0, behind: 0, vcs: 'jj', conflict: false };
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(line.includes('jj:(mybookmark*)'), `expected dirty marker, got ${line}`);
+});
+
+test('renderProjectLine shows !conflict marker for a conflicted jj status', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.gitStatus = { branch: 'mybookmark', isDirty: false, ahead: 0, behind: 0, vcs: 'jj', conflict: true };
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(line.includes('jj:(mybookmark !conflict)'), `expected conflict marker, got ${line}`);
+});
+
+test('renderProjectLine hides !conflict marker when jjStatus.showConflicts is false', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.gitStatus = { branch: 'mybookmark', isDirty: false, ahead: 0, behind: 0, vcs: 'jj', conflict: true };
+  ctx.config.jjStatus = { enabled: true, showDirty: true, showConflicts: false };
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(!line.includes('!conflict'), `expected no conflict marker, got ${line}`);
+});
+
+test('renderProjectLine hides jj status entirely when jjStatus.enabled is false', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.gitStatus = { branch: 'mybookmark', isDirty: false, ahead: 0, behind: 0, vcs: 'jj', conflict: false };
+  ctx.config.jjStatus = { enabled: false, showDirty: true, showConflicts: true };
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(!line.includes('jj:('), `expected no jj status, got ${line}`);
+});
+
+test('renderProjectLine ignores gitStatus.showAheadBehind/showFileStats for jj status', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.gitStatus = { branch: 'mybookmark', isDirty: false, ahead: 0, behind: 0, vcs: 'jj', conflict: false };
+  ctx.config.gitStatus.showAheadBehind = true;
+  ctx.config.gitStatus.showFileStats = true;
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.equal(line.includes('↑'), false);
+  assert.equal(/\[[+-]/.test(line), false, `expected no file-stats bracket, got ${line}`);
+});
+
 test('renderSessionLine shows the enabled auth segment in compact layout', () => {
   const ctx = baseContext();
   ctx.authInfo = { method: 'Claude Max 20x', user: 'someone.long' };


### PR DESCRIPTION
Adds jj support to the statusline alongside git, prioritizing performance: detection is a subprocess-free `.jj` directory walk, and status is fetched via a single `jj log` template call (vs git's five). jj and git are mutually exclusive per invocation, even in colocated repos. Surfaces bookmark/change id, dirty state, and conflicts (a jj-native signal with no git equivalent).

## Summary

## Testing

- [x] `npm test`
- [x] `npm run test:coverage`
- [x] Locally tested

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed
