### PR TITLE
feat: accept model_scoped windows (e.g. Fable) from the external usage snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 | `display.showResetLabel` | boolean | true | Show the `resets in` prefix before usage countdowns |
 | `display.timeFormat` | `relative` \| `absolute` \| `both` \| `elapsed` \| `elapsedAndAbsolute` | `relative` | How usage-window time is shown: countdown only (`resets in 2h 30m`), wall-clock reset (`resets at 14:30`), both, elapsed window percentage (`53% elapsed`), or elapsed plus wall-clock reset |
 | `display.sevenDayThreshold` | 0-100 | 80 | Show 7-day usage when >= threshold (0 = always) |
-| `display.externalUsagePath` | string | `""` | Optional absolute path to a local usage snapshot file. Relative paths are ignored. When stdin `rate_limits` are present, only `balance_label` is appended; when they are missing, valid usage windows can be used as a fallback |
+| `display.externalUsagePath` | string | `""` | Optional absolute path to a local usage snapshot file. Relative paths are ignored. When stdin `rate_limits` are present, `balance_label` is appended and `model_scoped` windows fill in when stdin lacks them; when stdin windows are missing, valid usage windows can be used as a fallback |
 | `display.externalUsageWritePath` | string | `""` | Optional absolute `.json` path in an existing directory. When stdin `rate_limits` exists, ClaudeHUD writes a private snapshot for other local tools. Relative paths, non-json files, and missing parent directories are ignored |
 | `display.externalUsageFreshnessMs` | number | `300000` | Maximum allowed age for the external usage snapshot before it is ignored |
 | `display.showTokenBreakdown` | boolean | true | Show token details at high context (85%+) |
@@ -262,7 +262,20 @@ Set `display.usageValue` to `remaining` to show quota left instead of quota used
 
 ClaudeHUD prefers the official statusline stdin payload for rate-limit windows. If `display.externalUsagePath` points to a fresh local sidecar snapshot, ClaudeHUD can append its `balance_label` alongside stdin windows. If stdin `rate_limits` are missing, the same snapshot can provide fallback usage windows.
 
-The fallback snapshot path must be absolute. The snapshot must be fresh enough (`display.externalUsageFreshnessMs`) and include valid `updated_at`, plus a `five_hour` window, `seven_day` window, or `balance_label`. `balance_label` is optional text for prepaid provider balances; it is trimmed, length-limited, and sanitized before display. Relative paths, invalid JSON, stale files, or invalid timestamps are ignored quietly.
+The fallback snapshot path must be absolute. The snapshot must be fresh enough (`display.externalUsageFreshnessMs`) and include valid `updated_at`, plus a `five_hour` window, `seven_day` window, `balance_label`, or `model_scoped` array. `balance_label` is optional text for prepaid provider balances; it is trimmed, length-limited, and sanitized before display. Relative paths, invalid JSON, stale files, or invalid timestamps are ignored quietly.
+
+The snapshot may also carry `model_scoped` windows using the same shape Claude Code defines for stdin (`display_name`, `utilization` on the 0-100 scale, ISO `resets_at`). They render exactly like stdin scoped windows (see the model-scoped usage section) and stdin always wins when it carries its own `model_scoped` data. This lets a local feeder surface per-model weekly quotas (e.g. Fable) that the statusline payload does not include yet:
+
+```json
+{
+  "updated_at": "2026-07-24T14:12:37Z",
+  "model_scoped": [
+    { "display_name": "Fable", "utilization": 89, "resets_at": "2026-07-27T11:00:00Z" }
+  ]
+}
+```
+
+One zero-credential way to produce such a snapshot is Claude Code's own `get_usage` control request, which returns `rate_limits.model_scoped` without spending tokens; a scheduled job can pipe it through `jq` into the snapshot file. The HUD itself never fetches anything: it only reads the file.
 
 Set `display.externalUsageWritePath` if you want ClaudeHUD to write the official stdin `rate_limits` into a local snapshot for other tools. The path must be absolute, end in `.json`, and live in an existing directory. ClaudeHUD writes the file with private permissions and ignores invalid paths quietly.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -198,7 +198,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `display.showResetLabel` | boolean | true | 在使用率倒计时前显示 `resets in` 前缀 |
 | `display.timeFormat` | `relative` \| `absolute` \| `both` \| `elapsed` \| `elapsedAndAbsolute` | `relative` | 控制使用率窗口时间的显示方式：仅倒计时（`resets in 2h 30m`）、墙钟重置时间（`resets at 14:30`）、两者同时显示、窗口已过百分比（`53% elapsed`），或已过百分比加墙钟重置时间 |
 | `display.sevenDayThreshold` | 0-100 | 80 | 当 7 天使用率 ≥ 阈值时显示（0 = 始终显示） |
-| `display.externalUsagePath` | string | `""` | 可选的本地使用率快照文件路径，仅在 stdin `rate_limits` 缺失时使用 |
+| `display.externalUsagePath` | string | `""` | 可选的本地使用率快照文件路径。stdin `rate_limits` 存在时会附加 `balance_label`，并在 stdin 缺少 `model_scoped` 窗口时用快照补齐；stdin 窗口缺失时可整体作为回退 |
 | `display.externalUsageWritePath` | string | `""` | 可选的绝对 `.json` 路径，父目录必须已存在。当 stdin `rate_limits` 存在时，ClaudeHUD 会写入私有权限快照供其他本地工具读取。相对路径、非 json 文件和缺失父目录会被忽略 |
 | `display.externalUsageFreshnessMs` | number | `300000` | 外部使用率快照允许的最长存活时间，超时后会被忽略 |
 | `display.showTokenBreakdown` | boolean | true | 在高上下文时（85%+）显示 Token 详情 |
@@ -249,7 +249,20 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 
 ClaudeHUD 优先使用官方 statusline stdin 负载中的使用率数据。如果 `rate_limits` 缺失，你可以通过 `display.externalUsagePath` 显式启用本地 sidecar 快照回退，例如让代理程序写入 JSON 文件。只要 stdin 和 sidecar 同时存在，stdin 始终优先。
 
-回退快照必须足够新（由 `display.externalUsageFreshnessMs` 控制），并且包含有效的 `updated_at`、以及 `five_hour` 窗口、`seven_day` 窗口或 `balance_label`。`balance_label` 是预付费提供商余额的可选文本；显示前会进行裁剪、长度限制和清理。非法 JSON、过期文件或非法时间戳都会被静默忽略。
+回退快照必须足够新（由 `display.externalUsageFreshnessMs` 控制），并且包含有效的 `updated_at`、以及 `five_hour` 窗口、`seven_day` 窗口、`balance_label` 或 `model_scoped` 数组。`balance_label` 是预付费提供商余额的可选文本；显示前会进行裁剪、长度限制和清理。非法 JSON、过期文件或非法时间戳都会被静默忽略。
+
+快照还可以携带 `model_scoped` 窗口，格式与 Claude Code 为 stdin 定义的 schema 相同（`display_name`、0-100 的 `utilization`、ISO 格式 `resets_at`），渲染方式与 stdin 提供的按模型窗口完全一致，且 stdin 自带 `model_scoped` 数据时始终优先。借此本地喂送程序可以显示 statusline 负载暂未包含的按模型每周配额（例如 Fable）：
+
+```json
+{
+  "updated_at": "2026-07-24T14:12:37Z",
+  "model_scoped": [
+    { "display_name": "Fable", "utilization": 89, "resets_at": "2026-07-27T11:00:00Z" }
+  ]
+}
+```
+
+生成此类快照的一种零凭证方式是 Claude Code 自带的 `get_usage` 控制请求：它会返回 `rate_limits.model_scoped` 且不消耗任何 token，定时任务可将其经 `jq` 写入快照文件。HUD 本身从不发起任何请求，只读取该文件。
 
 如果希望 ClaudeHUD 将官方 stdin `rate_limits` 写入本地快照供其他工具使用，可设置 `display.externalUsageWritePath`。该路径必须为绝对路径、以 `.json` 结尾，并位于已存在的目录中。ClaudeHUD 会使用私有权限写入该文件，并静默忽略无效路径。
 

--- a/src/external-usage.ts
+++ b/src/external-usage.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import type { HudConfig } from './config.js';
 import { createDebug } from './debug.js';
 import type { ExternalUsageSnapshot, UsageData } from './types.js';
+import { parseScopedWindows } from './stdin.js';
 import { sanitizeDisplayText } from './utils/sanitize.js';
 
 const debug = createDebug('external-usage');
@@ -289,7 +290,13 @@ export function getUsageFromExternalSnapshot(
     const fiveHour = parseUsagePercent(parsed.five_hour?.used_percentage);
     const sevenDay = parseUsagePercent(parsed.seven_day?.used_percentage);
     const balanceLabel = sanitizeBalanceLabel(parsed.balance_label);
-    if (fiveHour === null && sevenDay === null && balanceLabel === null) {
+    const scopedWindows = parseScopedWindows(parsed.model_scoped);
+    if (
+      fiveHour === null
+      && sevenDay === null
+      && balanceLabel === null
+      && scopedWindows.length === 0
+    ) {
       return null;
     }
 
@@ -311,6 +318,9 @@ export function getUsageFromExternalSnapshot(
     };
     if (balanceLabel !== null) {
       usage.balanceLabel = balanceLabel;
+    }
+    if (scopedWindows.length > 0) {
+      usage.scopedWindows = scopedWindows;
     }
     return usage;
   } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,13 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
               sevenDay: ext.sevenDay,
               sevenDayResetAt: ext.sevenDayResetAt ?? null,
             }),
+            // Likewise, model-scoped windows (e.g. Fable) are absent from stdin
+            // today (see #669); let an external feeder supply them until
+            // Claude Code forwards rate_limits.model_scoped itself. Stdin wins
+            // whenever it does carry scoped windows.
+            ...(usageData.scopedWindows == null && ext.scopedWindows != null && {
+              scopedWindows: ext.scopedWindows,
+            }),
           };
         }
       }

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -381,7 +381,7 @@ export function getUsageFromStdin(stdin: StdinData): UsageData | null {
  * the generic rate-limit windows. Malformed entries are dropped, and both the
  * retained entry count and label size are bounded because stdin is untrusted.
  */
-function parseScopedWindows(modelScoped: unknown): ScopedUsageWindow[] {
+export function parseScopedWindows(modelScoped: unknown): ScopedUsageWindow[] {
   if (!Array.isArray(modelScoped)) {
     return [];
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,16 @@ export interface ExternalUsageSnapshot {
   } | null;
   updated_at?: string | number | null;
   balance_label?: string | null;
+  /**
+   * Model-scoped weekly windows (e.g. Fable). Mirrors the stdin
+   * `rate_limits.model_scoped` schema so external feeders can pass through
+   * the same shape Claude Code emits (e.g. from a get_usage response).
+   */
+  model_scoped?: Array<{
+    display_name?: string | null;
+    utilization?: number | null;
+    resets_at?: string | null;
+  }> | null;
 }
 
 export interface MemoryInfo {

--- a/tests/external-usage.test.js
+++ b/tests/external-usage.test.js
@@ -418,3 +418,86 @@ test('getUsageFromExternalSnapshot returns null for invalid JSON', async () => {
     await cleanup();
   }
 });
+
+test('getUsageFromExternalSnapshot parses model-scoped windows', async () => {
+  const updatedAt = Date.UTC(2026, 3, 20, 12, 0, 0);
+  const { filePath, cleanup } = await withTempFile(JSON.stringify({
+    updated_at: new Date(updatedAt).toISOString(),
+    five_hour: { used_percentage: 42.4, resets_at: '2026-04-20T15:00:00.000Z' },
+    model_scoped: [
+      { display_name: 'Fable', utilization: 89.4, resets_at: '2026-04-27T12:00:00.000Z' },
+    ],
+  }));
+
+  try {
+    const usage = getUsageFromExternalSnapshot(makeConfig(filePath), updatedAt + 60_000);
+    assert.deepEqual(usage?.scopedWindows, [{
+      label: 'Fable',
+      percent: 89,
+      resetAt: new Date('2026-04-27T12:00:00.000Z'),
+    }]);
+    assert.equal(usage?.fiveHour, 42);
+  } finally {
+    await cleanup();
+  }
+});
+
+test('getUsageFromExternalSnapshot accepts a scoped-only snapshot', async () => {
+  const updatedAt = Date.UTC(2026, 3, 20, 12, 0, 0);
+  const { filePath, cleanup } = await withTempFile(JSON.stringify({
+    updated_at: new Date(updatedAt).toISOString(),
+    model_scoped: [
+      { display_name: 'Fable', utilization: 57, resets_at: null },
+    ],
+  }));
+
+  try {
+    const usage = getUsageFromExternalSnapshot(makeConfig(filePath), updatedAt + 60_000);
+    assert.deepEqual(usage, {
+      fiveHour: null,
+      sevenDay: null,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      scopedWindows: [{ label: 'Fable', percent: 57, resetAt: null }],
+    });
+  } finally {
+    await cleanup();
+  }
+});
+
+test('getUsageFromExternalSnapshot drops malformed scoped entries and sanitizes labels', async () => {
+  const updatedAt = Date.UTC(2026, 3, 20, 12, 0, 0);
+  const { filePath, cleanup } = await withTempFile(JSON.stringify({
+    updated_at: new Date(updatedAt).toISOString(),
+    model_scoped: [
+      { display_name: '[31mFable[0m', utilization: 12, resets_at: null },
+      { display_name: '', utilization: 50, resets_at: null },
+      { display_name: 'Bad', utilization: 'oops', resets_at: null },
+      'not-an-object',
+    ],
+  }));
+
+  try {
+    const usage = getUsageFromExternalSnapshot(makeConfig(filePath), updatedAt + 60_000);
+    assert.deepEqual(usage?.scopedWindows, [{ label: 'Fable', percent: 12, resetAt: null }]);
+  } finally {
+    await cleanup();
+  }
+});
+
+test('getUsageFromExternalSnapshot ignores a non-array model_scoped value', async () => {
+  const updatedAt = Date.UTC(2026, 3, 20, 12, 0, 0);
+  const { filePath, cleanup } = await withTempFile(JSON.stringify({
+    updated_at: new Date(updatedAt).toISOString(),
+    five_hour: { used_percentage: 10, resets_at: null },
+    model_scoped: { display_name: 'Fable', utilization: 12 },
+  }));
+
+  try {
+    const usage = getUsageFromExternalSnapshot(makeConfig(filePath), updatedAt + 60_000);
+    assert.equal(usage?.scopedWindows, undefined);
+    assert.equal(usage?.fiveHour, 10);
+  } finally {
+    await cleanup();
+  }
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -799,3 +799,97 @@ test("main skips auth file I/O when auth segments are disabled", async () => {
   assert.equal(lookupCalls, 0);
   assert.equal(renderedContext?.authInfo, null);
 });
+
+test("main merges scoped windows from the external snapshot when stdin lacks them", async () => {
+  let renderedContext;
+  const scopedWindows = [{ label: "Fable", percent: 89, resetAt: new Date("2026-04-27T12:00:00.000Z") }];
+
+  await main({
+    readStdin: async () => makeStdin({
+      rate_limits: {
+        five_hour: { used_percentage: 49.6, resets_at: 1710000000 },
+        seven_day: { used_percentage: 25.2, resets_at: 1710600000 },
+      },
+    }),
+    parseTranscript: async () => makeTranscript(),
+    countConfigs: async () => makeCounts(),
+    loadConfig: async () => makeConfig({
+      display: { externalUsagePath: "/tmp/usage.json" },
+    }),
+    getGitStatus: async () => null,
+    getUsageFromExternalSnapshot: () => ({
+      fiveHour: null,
+      sevenDay: null,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      scopedWindows,
+    }),
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.deepEqual(renderedContext?.usageData?.scopedWindows, scopedWindows);
+  assert.equal(renderedContext?.usageData?.fiveHour, 50);
+  assert.equal(renderedContext?.usageData?.sevenDay, 25);
+});
+
+test("main prefers stdin scoped windows over the external snapshot", async () => {
+  let renderedContext;
+
+  await main({
+    readStdin: async () => makeStdin({
+      rate_limits: {
+        five_hour: { used_percentage: 49.6, resets_at: 1710000000 },
+        model_scoped: [
+          { display_name: "Fable", utilization: 41, resets_at: "2026-04-27T12:00:00.000Z" },
+        ],
+      },
+    }),
+    parseTranscript: async () => makeTranscript(),
+    countConfigs: async () => makeCounts(),
+    loadConfig: async () => makeConfig({
+      display: { externalUsagePath: "/tmp/usage.json" },
+    }),
+    getGitStatus: async () => null,
+    getUsageFromExternalSnapshot: () => ({
+      fiveHour: null,
+      sevenDay: null,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      scopedWindows: [{ label: "Fable", percent: 99, resetAt: null }],
+    }),
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.deepEqual(renderedContext?.usageData?.scopedWindows, [
+    { label: "Fable", percent: 41, resetAt: new Date("2026-04-27T12:00:00.000Z") },
+  ]);
+});
+
+test("main uses a scoped-only external snapshot when stdin has no rate limits", async () => {
+  let renderedContext;
+  const scopedOnly = {
+    fiveHour: null,
+    sevenDay: null,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    scopedWindows: [{ label: "Fable", percent: 89, resetAt: null }],
+  };
+
+  await main({
+    readStdin: async () => makeStdin({ rate_limits: null }),
+    parseTranscript: async () => makeTranscript(),
+    countConfigs: async () => makeCounts(),
+    loadConfig: async () => makeConfig(),
+    getGitStatus: async () => null,
+    getUsageFromExternalSnapshot: () => scopedOnly,
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.deepEqual(renderedContext?.usageData, scopedOnly);
+});


### PR DESCRIPTION
## Summary

#669 added complete rendering for model-scoped weekly windows (`rate_limits.model_scoped`, e.g. Fable) but Claude Code's statusline payload does not forward them (only `five_hour` / `seven_day`; see anthropics/claude-code#77846), so the feature has no live data source. Reading credentials to fetch them was rightly withdrawn in #668.

This PR lets the external usage snapshot (`display.externalUsagePath`) carry a `model_scoped` array using exactly the stdin schema:

```json
{
  "updated_at": "2026-07-24T14:12:37Z",
  "model_scoped": [
    { "display_name": "Fable", "utilization": 95, "resets_at": "2026-07-27T11:00:00Z" }
  ]
}
```

- Parsed by the same bounded parser stdin uses (`parseScopedWindows`, now exported): max 8 windows, sanitized 64-char labels, clamped percentages, malformed entries dropped.
- Rendered through the existing #669 paths unchanged (bars, thresholds, compact/expanded, remaining mode, custom colors, reset times).
- Precedence mirrors the existing merge semantics: stdin wins whenever it carries its own `model_scoped`; the snapshot fills in only when stdin lacks them. Scoped-only snapshots are accepted as fallback when stdin has no `rate_limits` at all.
- Freshness, absolute-path, and sanitization rules of the snapshot are unchanged and apply to the new field.
- No network, no credentials, no child processes, no new dependencies. Core logic is ~31 lines across `src/`; the rest is tests and docs.

**Why this trust boundary**: the snapshot file is the HUD's existing integration point for external usage data (`balance_label` works the same way). A zero-credential feeder exists: Claude Code's own `get_usage` control request returns `rate_limits.model_scoped` without consuming tokens, with OAuth handled entirely by the `claude` binary:

```sh
printf '%s\n' '{"type":"control_request","request_id":"1","request":{"subtype":"get_usage"}}' \
  | claude -p --input-format stream-json --output-format stream-json --verbose \
  | jq -c 'select(.type=="control_response") | .response.response.rate_limits
           | {updated_at: (now|todate), model_scoped}' > ~/.claude/hud/usage-snapshot.json
```

Running on my machine via a 10-minute launchd job: multi-cycle refresh verified, zero token cost, empty error log. Once upstream forwards `model_scoped` in the statusline payload, stdin precedence makes this feature retire gracefully.

### Demo

*Snapshot-fed when stdin lacks scoped windows; the critical color and reset time come from the existing #669 paths:*

<img width="900" alt="HUD with snapshot-fed Fable window at 95%" src="https://github.com/user-attachments/assets/ff211ff1-304b-4d99-aee0-41fe669d179a" />

*Stdin carries `model_scoped`: stdin wins over the snapshot:*

<img width="900" alt="HUD with stdin-fed Fable window at 57%" src="https://github.com/user-attachments/assets/e607efce-f949-4fcb-ac1d-00c410ecf5c9" />

## Testing

- [x] `npm test` (974 pass, 5 skip, 0 fail)
- [x] `npm run test:coverage` (all files 95.37% statements)

New tests: scoped parsing from the snapshot, scoped-only snapshots, malformed-entry dropping and ANSI label sanitization, non-array rejection (`tests/external-usage.test.js`); merge precedence in both directions and scoped-only fallback (`tests/index.test.js`).

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed (README.md + README.zh.md, snapshot schema and feeder example)

Only `src/`, `tests/`, and the two READMEs are touched; no `dist/` changes per CONTRIBUTING.

## Possible follow-up (not in this PR)

A convenience layer could make the HUD refresh the snapshot itself: an opt-in (default off) that, when the snapshot is stale, spawns a detached `claude -p` get_usage child behind a marker-file throttle, so no OS scheduler is needed. That crosses into process spawning on the render path, so I kept it out of this PR; happy to open a separate one if there is appetite.