### PR TITLE
feat: configurable hour cycle and seconds for wall-clock reset times

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 | `display.usageCompact` | boolean | false | Display usage in a shorter text form such as `5h: 25% (1h 30m)`; takes precedence over `display.usageBarEnabled` |
 | `display.showResetLabel` | boolean | true | Show the `resets in` prefix before usage countdowns |
 | `display.timeFormat` | `relative` \| `absolute` \| `both` \| `elapsed` \| `elapsedAndAbsolute` | `relative` | How usage-window time is shown: countdown only (`resets in 2h 30m`), wall-clock reset (`resets at 14:30`), both, elapsed window percentage (`53% elapsed`), or elapsed plus wall-clock reset |
+| `display.hourCycle` | `auto` \| `h11` \| `h12` \| `h23` \| `h24` | `auto` | Hour cycle for wall-clock reset times (`absolute`/`both`/`elapsedAndAbsolute` modes). `auto` defers to the system locale; `h23` forces 24-hour time (`14:30`) regardless of locale |
+| `display.showClockSeconds` | boolean | false | Show seconds in wall-clock reset times, e.g. `at 14:30:07` |
 | `display.sevenDayThreshold` | 0-100 | 80 | Show 7-day usage when >= threshold (0 = always) |
 | `display.externalUsagePath` | string | `""` | Optional absolute path to a local usage snapshot file. Relative paths are ignored. When stdin `rate_limits` are present, only `balance_label` is appended; when they are missing, valid usage windows can be used as a fallback |
 | `display.externalUsageWritePath` | string | `""` | Optional absolute `.json` path in an existing directory. When stdin `rate_limits` exists, ClaudeHUD writes a private snapshot for other local tools. Relative paths, non-json files, and missing parent directories are ignored |
@@ -280,6 +282,11 @@ Reset times use relative countdowns by default. Set `display.timeFormat` to `abs
 times, `both` to show both forms, `elapsed` to show how far through each usage window you are, or
 `elapsedAndAbsolute` to show elapsed window progress plus the wall-clock reset time. This setting is
 manual-only today; `/claude-hud:configure` preserves it without editing it.
+
+Wall-clock reset times (`absolute`/`both`/`elapsedAndAbsolute`) default to your system locale for 12-
+vs 24-hour formatting. Set `display.hourCycle` to `h23` to force 24-hour time regardless of locale, or
+to `h12`/`h11` to force 12-hour time with AM/PM. Set `display.showClockSeconds` to `true` to include
+seconds in the wall-clock time, e.g. `at 14:30:07`.
 
 Set `display.showResetLabel` to `false` if you want shorter usage countdowns such as `(3h 17m)` instead of `(resets in 3h 17m)`.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -197,6 +197,8 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `display.usageCompact` | boolean | false | 以较短的文本形式显示使用率，如 `5h: 25% (1h 30m)`；优先于 `display.usageBarEnabled` |
 | `display.showResetLabel` | boolean | true | 在使用率倒计时前显示 `resets in` 前缀 |
 | `display.timeFormat` | `relative` \| `absolute` \| `both` \| `elapsed` \| `elapsedAndAbsolute` | `relative` | 控制使用率窗口时间的显示方式：仅倒计时（`resets in 2h 30m`）、墙钟重置时间（`resets at 14:30`）、两者同时显示、窗口已过百分比（`53% elapsed`），或已过百分比加墙钟重置时间 |
+| `display.hourCycle` | `auto` \| `h11` \| `h12` \| `h23` \| `h24` | `auto` | 墙钟重置时间（`absolute`/`both`/`elapsedAndAbsolute` 模式）的时制。`auto` 跟随系统区域设置；`h23` 强制使用 24 小时制（`14:30`），不受区域设置影响 |
+| `display.showClockSeconds` | boolean | false | 在墙钟重置时间中显示秒数，如 `at 14:30:07` |
 | `display.sevenDayThreshold` | 0-100 | 80 | 当 7 天使用率 ≥ 阈值时显示（0 = 始终显示） |
 | `display.externalUsagePath` | string | `""` | 可选的本地使用率快照文件路径，仅在 stdin `rate_limits` 缺失时使用 |
 | `display.externalUsageWritePath` | string | `""` | 可选的绝对 `.json` 路径，父目录必须已存在。当 stdin `rate_limits` 存在时，ClaudeHUD 会写入私有权限快照供其他本地工具读取。相对路径、非 json 文件和缺失父目录会被忽略 |
@@ -264,6 +266,8 @@ ClaudeHUD 优先使用官方 statusline stdin 负载中的使用率数据。如�
 如需禁用，请将 `display.showUsage` 设为 `false`。
 
 重置时间默认显示为相对倒计时。将 `display.timeFormat` 设为 `absolute` 可显示墙钟时间，设为 `both` 可同时显示两种形式，设为 `elapsed` 可显示当前使用率窗口已过百分比，设为 `elapsedAndAbsolute` 可同时显示已过百分比和墙钟重置时间。该设置目前只能手动编辑；`/claude-hud:configure` 会保留它，但不会修改它。
+
+墙钟重置时间（`absolute`/`both`/`elapsedAndAbsolute`）默认跟随系统区域设置决定 12/24 小时制。将 `display.hourCycle` 设为 `h23` 可强制使用 24 小时制，不受区域设置影响；设为 `h12`/`h11` 可强制使用带 AM/PM 的 12 小时制。将 `display.showClockSeconds` 设为 `true` 可在墙钟时间中显示秒数，如 `at 14:30:07`。
 
 将 `display.showResetLabel` 设为 `false` 可使用较短的使用率倒计时格式，如 `(3h 17m)` 而非 `(resets in 3h 17m)`。
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,8 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
 export type ModelFormatMode = 'full' | 'compact' | 'short';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both' | 'elapsed' | 'elapsedAndAbsolute';
 export type CustomLinePosition = 'first' | 'last';
+// Hour cycle for wall-clock time display; 'auto' defers to the system locale.
+export type HourCycleMode = 'auto' | 'h11' | 'h12' | 'h23' | 'h24';
 
 /**
  * Controls how many directory segments of cwd are shown in the project badge.
@@ -245,6 +247,8 @@ export interface HudConfig {
     customLine: string;
     customLinePosition: CustomLinePosition;
     timeFormat: TimeFormatMode;
+    hourCycle: HourCycleMode;
+    showClockSeconds: boolean;
     // Show the advisor model when `/advisor` is configured for the session.
     // The model ID is read from the transcript (see TranscriptData.advisorModel)
     // so it reflects the actual current choice, not a global default.
@@ -338,6 +342,8 @@ export const DEFAULT_CONFIG: HudConfig = {
     customLine: '',
     customLinePosition: 'last',
     timeFormat: 'relative',
+    hourCycle: 'auto',
+    showClockSeconds: false,
     showAdvisor: false,
     advisorOverride: '',
     autoCompactWindow: null,
@@ -406,6 +412,10 @@ function validateTimeFormat(value: unknown): value is TimeFormatMode {
 
 function validateCustomLinePosition(value: unknown): value is CustomLinePosition {
   return value === 'first' || value === 'last';
+}
+
+function validateHourCycle(value: unknown): value is HourCycleMode {
+  return value === 'auto' || value === 'h11' || value === 'h12' || value === 'h23' || value === 'h24';
 }
 
 function validateColorName(value: unknown): value is HudColorName {
@@ -854,6 +864,12 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     timeFormat: validateTimeFormat(migrated.display?.timeFormat)
       ? migrated.display.timeFormat
       : DEFAULT_CONFIG.display.timeFormat,
+    hourCycle: validateHourCycle(migrated.display?.hourCycle)
+      ? migrated.display.hourCycle
+      : DEFAULT_CONFIG.display.hourCycle,
+    showClockSeconds: typeof migrated.display?.showClockSeconds === 'boolean'
+      ? migrated.display.showClockSeconds
+      : DEFAULT_CONFIG.display.showClockSeconds,
     showAdvisor: typeof migrated.display?.showAdvisor === 'boolean'
       ? migrated.display.showAdvisor
       : DEFAULT_CONFIG.display.showAdvisor,

--- a/src/render/format-reset-time.ts
+++ b/src/render/format-reset-time.ts
@@ -1,5 +1,13 @@
-import type { TimeFormatMode } from '../config.js';
+import type { HourCycleMode, TimeFormatMode } from '../config.js';
 import { interpolate, t } from '../i18n/index.js';
+
+/** Options controlling how wall-clock time is rendered. */
+export interface WallClockOptions {
+  hourCycle: HourCycleMode;
+  showSeconds: boolean;
+}
+
+const DEFAULT_WALL_CLOCK_OPTIONS: WallClockOptions = { hourCycle: 'auto', showSeconds: false };
 
 /**
  * Formats a usage-window reset timestamp for display in the HUD.
@@ -9,10 +17,15 @@ import { interpolate, t } from '../i18n/index.js';
  *   - `'relative'` (default) — duration until reset, e.g. `2h 30m`
  *   - `'absolute'`           — wall-clock time,       e.g. `at 14:30` (locale-aware)
  *   - `'both'`               — both combined,          e.g. `2h 30m, at 14:30` (locale-aware)
+ * @param opts    - Wall-clock rendering options (hourCycle, showSeconds); defaults preserve existing behavior.
  * @returns A formatted string, or an empty string when the reset is in the past
  *          or the date is unknown.
  */
-export function formatResetTime(resetAt: Date | null, mode: TimeFormatMode = 'relative'): string {
+export function formatResetTime(
+  resetAt: Date | null,
+  mode: TimeFormatMode = 'relative',
+  opts: WallClockOptions = DEFAULT_WALL_CLOCK_OPTIONS,
+): string {
   if (!resetAt) return '';
 
   const now = new Date();
@@ -23,7 +36,7 @@ export function formatResetTime(resetAt: Date | null, mode: TimeFormatMode = 're
     return formatRelative(diffMs);
   }
 
-  const absolute = formatAbsolute(resetAt, now);
+  const absolute = formatAbsolute(resetAt, now, opts);
 
   if (mode === 'absolute') {
     return absolute;
@@ -53,10 +66,13 @@ function formatRelative(diffMs: number): string {
   return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
 }
 
-function formatAbsolute(resetAt: Date, now: Date): string {
+function formatAbsolute(resetAt: Date, now: Date, opts: WallClockOptions): string {
   // The preposition + spacing live in each locale's "format.absoluteTime"
   // pattern (en: "at {time}", zh: "{time}" — bare, preposition baked elsewhere).
-  const timeStr = resetAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const timeOpts: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit' };
+  if (opts.showSeconds) timeOpts.second = '2-digit';
+  if (opts.hourCycle !== 'auto') timeOpts.hourCycle = opts.hourCycle;
+  const timeStr = resetAt.toLocaleTimeString([], timeOpts);
 
   // Show the date only when the reset falls on a different calendar day
   if (resetAt.toDateString() === now.toDateString()) {

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -10,7 +10,7 @@ import {
   type ProgressLabelInput,
 } from "./label-align.js";
 import type { TimeFormatMode, UsageValueMode } from "../../config.js";
-import { formatResetTime } from "../format-reset-time.js";
+import { formatResetTime, type WallClockOptions } from "../format-reset-time.js";
 
 const FIVE_HOUR_WINDOW_MS = 5 * 60 * 60 * 1000;
 const SEVEN_DAY_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
@@ -46,6 +46,10 @@ export function renderUsageLine(
   }
 
   const timeFormat = normalizeTimeFormat(display?.timeFormat);
+  const wallClockOpts: WallClockOptions = {
+    hourCycle: display?.hourCycle ?? 'auto',
+    showSeconds: display?.showClockSeconds ?? false,
+  };
   const showResetLabel = display?.showResetLabel ?? true;
   const resetsKey = limitResetTimeFormat(timeFormat) === 'absolute' ? "format.resets" : "format.resetsIn";
   const usageCompact = display?.usageCompact ?? false;
@@ -55,7 +59,7 @@ export function renderUsageLine(
     ? ' | ' + scopedWindows
         .map((w) =>
           usageCompact
-            ? formatCompactWindowPart(w.label, w.percent, w.resetAt, SEVEN_DAY_WINDOW_MS, timeFormat, colors, usageValueMode)
+            ? formatCompactWindowPart(w.label, w.percent, w.resetAt, SEVEN_DAY_WINDOW_MS, timeFormat, colors, usageValueMode, wallClockOpts)
             : formatUsageWindowPart({
                 label: w.label,
                 percent: w.percent,
@@ -69,6 +73,7 @@ export function renderUsageLine(
                 forceLabel: true,
                 labelOptions,
                 usageValueMode,
+                wallClockOpts,
               }),
         )
         .join(' | ')
@@ -78,8 +83,8 @@ export function renderUsageLine(
     const limitTimeFormat = limitResetTimeFormat(timeFormat);
     const resetTime =
       ctx.usageData.fiveHour === 100
-        ? formatResetTime(ctx.usageData.fiveHourResetAt, limitTimeFormat)
-        : formatResetTime(ctx.usageData.sevenDayResetAt, limitTimeFormat);
+        ? formatResetTime(ctx.usageData.fiveHourResetAt, limitTimeFormat, wallClockOpts)
+        : formatResetTime(ctx.usageData.sevenDayResetAt, limitTimeFormat, wallClockOpts);
     if (usageCompact) {
       return appendBalance(`${critical(`⚠ Limit${resetTime ? ` (${resetTime})` : ""}`, colors)}${scopedSuffix}`, balanceLabel);
     }
@@ -150,6 +155,7 @@ export function renderUsageLine(
       forceLabel: true,
       labelOptions,
       usageValueMode,
+      wallClockOpts,
     });
     return appendBalance(`${usageLabel} ${weeklyOnlyPart}${scopedSuffix}`, balanceLabel);
   }
@@ -165,6 +171,7 @@ export function renderUsageLine(
     timeFormat,
     showResetLabel,
     usageValueMode,
+    wallClockOpts,
   });
 
   if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
@@ -182,6 +189,7 @@ export function renderUsageLine(
       forceLabel: true,
       labelOptions,
       usageValueMode,
+      wallClockOpts,
     });
     return appendBalance(`${usageLabel} ${fiveHourPart} | ${sevenDayPart}${scopedSuffix}`, balanceLabel);
   }
@@ -201,9 +209,10 @@ function formatCompactWindowPart(
   timeFormat: TimeFormatMode,
   colors?: RenderContext["config"]["colors"],
   usageValueMode: UsageValueMode = 'percent',
+  wallClockOpts?: WallClockOptions,
 ): string {
   const usageDisplay = formatUsagePercent(percent, colors, usageValueMode);
-  const reset = formatWindowTime(resetAt, windowMs, timeFormat);
+  const reset = formatWindowTime(resetAt, windowMs, timeFormat, wallClockOpts);
   const styledLabel = label(`${windowLabel}:`, colors);
   return reset
     ? `${styledLabel} ${usageDisplay} ${label(`(${reset})`, colors)}`
@@ -237,6 +246,7 @@ function formatUsageWindowPart({
   forceLabel = false,
   labelOptions = {},
   usageValueMode = 'percent',
+  wallClockOpts,
 }: {
   label: string;
   labelKey?: MessageKey;
@@ -251,9 +261,10 @@ function formatUsageWindowPart({
   forceLabel?: boolean;
   labelOptions?: ProgressLabelInput;
   usageValueMode?: UsageValueMode;
+  wallClockOpts?: WallClockOptions;
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors, usageValueMode);
-  const reset = formatWindowTime(resetAt, windowMs, timeFormat);
+  const reset = formatWindowTime(resetAt, windowMs, timeFormat, wallClockOpts);
   const styledLabel = labelKey
     ? progressLabel(labelKey, colors, labelOptions)
     : label(windowLabel, colors);
@@ -307,6 +318,7 @@ function formatWindowTime(
   resetAt: Date | null,
   windowMs: number,
   timeFormat: TimeFormatMode,
+  wallClockOpts?: WallClockOptions,
 ): string {
   if (timeFormat === 'elapsed') {
     return formatElapsedWindow(resetAt, windowMs);
@@ -314,14 +326,14 @@ function formatWindowTime(
 
   if (timeFormat === 'elapsedAndAbsolute') {
     const elapsed = formatElapsedWindow(resetAt, windowMs);
-    const absolute = formatResetTime(resetAt, 'absolute');
+    const absolute = formatResetTime(resetAt, 'absolute', wallClockOpts);
     if (elapsed && absolute) {
       return `${elapsed}, ${absolute}`;
     }
     return elapsed || absolute;
   }
 
-  return formatResetTime(resetAt, timeFormat);
+  return formatResetTime(resetAt, timeFormat, wallClockOpts);
 }
 
 function formatElapsedWindow(resetAt: Date | null, windowMs: number): string {

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -10,7 +10,7 @@ import { renderSessionTimeLine } from './lines/session-time.js';
 import { renderAdvisorLine } from './lines/advisor.js';
 import { t } from '../i18n/index.js';
 import type { TimeFormatMode, UsageValueMode } from '../config.js';
-import { formatResetTime } from './format-reset-time.js';
+import { formatResetTime, type WallClockOptions } from './format-reset-time.js';
 import { formatTokens, formatContextValue } from '../utils/format.js';
 import { formatAuthSegment } from '../auth.js';
 import { createDebug } from '../debug.js';
@@ -54,6 +54,10 @@ export function renderSessionLine(ctx: RenderContext): string {
   const parts: FirstLinePart[] = [];
   const push = (text: string, key: FirstLineSegment | null = null) => parts.push({ key, text });
   const timeFormat: TimeFormatMode = display?.timeFormat ?? 'relative';
+  const wallClockOpts: WallClockOptions = {
+    hourCycle: display?.hourCycle ?? 'auto',
+    showSeconds: display?.showClockSeconds ?? false,
+  };
   const resetsKey = timeFormat === 'absolute' ? 'format.resets' : 'format.resetsIn';
   const contextValueMode = display?.contextValue ?? 'percent';
   const contextValue = formatContextValue(ctx, percent, contextValueMode);
@@ -188,6 +192,7 @@ export function renderSessionLine(ctx: RenderContext): string {
             timeFormat,
             colors,
             usageValueMode,
+            wallClockOpts,
           )
         : formatUsageWindowPart({
             label: window.label,
@@ -201,13 +206,14 @@ export function renderSessionLine(ctx: RenderContext): string {
             forceLabel: true,
             usageValueMode,
             windowDurationLabel: '7d',
+            wallClockOpts,
           }),
     );
 
     if (isLimitReached(ctx.usageData)) {
       const resetTime = ctx.usageData.fiveHour === 100
-        ? formatResetTime(ctx.usageData.fiveHourResetAt, timeFormat)
-        : formatResetTime(ctx.usageData.sevenDayResetAt, timeFormat);
+        ? formatResetTime(ctx.usageData.fiveHourResetAt, timeFormat, wallClockOpts)
+        : formatResetTime(ctx.usageData.sevenDayResetAt, timeFormat, wallClockOpts);
       if (usageCompact) {
         push(critical(`⚠ Limit${resetTime ? ` (${resetTime})` : ''}`, colors));
       } else {
@@ -233,11 +239,11 @@ export function renderSessionLine(ctx: RenderContext): string {
         const usageBarEnabled = display?.usageBarEnabled ?? true;
         if (usageCompact) {
           const fiveHourPart = fiveHour !== null
-            ? formatCompactWindowPart('5h', fiveHour, ctx.usageData.fiveHourResetAt, timeFormat, colors, usageValueMode)
+            ? formatCompactWindowPart('5h', fiveHour, ctx.usageData.fiveHourResetAt, timeFormat, colors, usageValueMode, wallClockOpts)
             : null;
           const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
           const sevenDayPart = (sevenDay !== null && (fiveHour === null || sevenDay >= sevenDayThreshold))
-            ? formatCompactWindowPart('7d', sevenDay, ctx.usageData.sevenDayResetAt, timeFormat, colors, usageValueMode)
+            ? formatCompactWindowPart('7d', sevenDay, ctx.usageData.sevenDayResetAt, timeFormat, colors, usageValueMode, wallClockOpts)
             : null;
 
           if (fiveHourPart && sevenDayPart) {
@@ -261,6 +267,7 @@ export function renderSessionLine(ctx: RenderContext): string {
             showResetLabel,
             forceLabel: true,
             usageValueMode,
+            wallClockOpts,
           });
           push(weeklyOnlyPart);
           scopedParts.forEach((part) => push(part));
@@ -275,6 +282,7 @@ export function renderSessionLine(ctx: RenderContext): string {
             timeFormat,
             showResetLabel,
             usageValueMode,
+            wallClockOpts,
           });
 
           const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
@@ -290,6 +298,7 @@ export function renderSessionLine(ctx: RenderContext): string {
               showResetLabel,
               forceLabel: true,
               usageValueMode,
+              wallClockOpts,
             });
             push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
             push(sevenDayPart);
@@ -401,9 +410,10 @@ function formatCompactWindowPart(
   timeFormat: TimeFormatMode,
   colors?: RenderContext['config']['colors'],
   usageValueMode: UsageValueMode = 'percent',
+  wallClockOpts?: WallClockOptions,
 ): string {
   const usageDisplay = formatUsagePercent(percent, colors, usageValueMode);
-  const reset = formatResetTime(resetAt, timeFormat);
+  const reset = formatResetTime(resetAt, timeFormat, wallClockOpts);
   const styledLabel = label(`${windowLabel}:`, colors);
   return reset
     ? `${styledLabel} ${usageDisplay} ${label(`(${reset})`, colors)}`
@@ -435,6 +445,7 @@ function formatUsageWindowPart({
   forceLabel = false,
   usageValueMode = 'percent',
   windowDurationLabel,
+  wallClockOpts,
 }: {
   label: string;
   percent: number | null;
@@ -447,9 +458,10 @@ function formatUsageWindowPart({
   forceLabel?: boolean;
   usageValueMode?: UsageValueMode;
   windowDurationLabel?: string;
+  wallClockOpts?: WallClockOptions;
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors, usageValueMode);
-  const reset = formatResetTime(resetAt, timeFormat);
+  const reset = formatResetTime(resetAt, timeFormat, wallClockOpts);
   const styledLabel = label(windowLabel, colors);
   // "resets in X" for relative/both; "resets X" for absolute (avoids "resets in at 14:30")
   const resetsKey = timeFormat === 'absolute' ? 'format.resets' : 'format.resetsIn';

--- a/tests/format-reset-time.test.js
+++ b/tests/format-reset-time.test.js
@@ -123,6 +123,46 @@ test('both: format is "<relative>, <absolute>"', () => {
 });
 
 // ---------------------------------------------------------------------------
+// hourCycle / showSeconds opts
+// ---------------------------------------------------------------------------
+
+test('opts: default (auto) matches the pre-existing locale-driven output', () => {
+  const resetAt = future(2 * HOUR);
+  const withoutOpts = formatResetTime(resetAt, 'absolute');
+  const withAutoOpts = formatResetTime(resetAt, 'absolute', { hourCycle: 'auto', showSeconds: false });
+  assert.equal(withoutOpts, withAutoOpts);
+});
+
+test('opts: h23 avoids AM/PM and uses 00-23 hours', () => {
+  const resetAt = future(2 * HOUR);
+  const result = formatResetTime(resetAt, 'absolute', { hourCycle: 'h23', showSeconds: false });
+  assert.doesNotMatch(result, /AM|PM/i);
+  assert.match(result, /^at \d{2}:\d{2}$/);
+});
+
+test('opts: showSeconds adds a seconds component', () => {
+  const resetAt = future(2 * HOUR);
+  const result = formatResetTime(resetAt, 'absolute', { hourCycle: 'h23', showSeconds: true });
+  assert.match(result, /^at \d{2}:\d{2}:\d{2}$/);
+});
+
+test('opts: midnight boundary — h23 shows 00, not 24', () => {
+  const resetAt = new Date();
+  resetAt.setDate(resetAt.getDate() + 1);
+  resetAt.setHours(0, 5, 0, 0);
+  const result = formatResetTime(resetAt, 'absolute', { hourCycle: 'h23', showSeconds: false });
+  assert.match(result, /00:05$/);
+});
+
+test('opts: midnight boundary — h24 shows 24, not 00', () => {
+  const resetAt = new Date();
+  resetAt.setDate(resetAt.getDate() + 1);
+  resetAt.setHours(0, 5, 0, 0);
+  const result = formatResetTime(resetAt, 'absolute', { hourCycle: 'h24', showSeconds: false });
+  assert.match(result, /24:05$/);
+});
+
+// ---------------------------------------------------------------------------
 // config integration — mergeConfig accepts and validates timeFormat
 // ---------------------------------------------------------------------------
 
@@ -148,4 +188,38 @@ test('mergeConfig rejects invalid timeFormat and falls back to "relative"', asyn
   const { mergeConfig } = await import('../dist/config.js');
   const config = mergeConfig({ display: { timeFormat: 'invalid-value' } });
   assert.equal(config.display.timeFormat, 'relative');
+});
+
+// ---------------------------------------------------------------------------
+// config integration — mergeConfig accepts and validates hourCycle / showClockSeconds
+// ---------------------------------------------------------------------------
+
+test('mergeConfig defaults hourCycle to "auto"', async () => {
+  const { mergeConfig } = await import('../dist/config.js');
+  const config = mergeConfig({});
+  assert.equal(config.display.hourCycle, 'auto');
+});
+
+test('mergeConfig accepts a valid hourCycle', async () => {
+  const { mergeConfig } = await import('../dist/config.js');
+  const config = mergeConfig({ display: { hourCycle: 'h23' } });
+  assert.equal(config.display.hourCycle, 'h23');
+});
+
+test('mergeConfig rejects invalid hourCycle and falls back to "auto"', async () => {
+  const { mergeConfig } = await import('../dist/config.js');
+  const config = mergeConfig({ display: { hourCycle: 'not-a-cycle' } });
+  assert.equal(config.display.hourCycle, 'auto');
+});
+
+test('mergeConfig defaults showClockSeconds to false', async () => {
+  const { mergeConfig } = await import('../dist/config.js');
+  const config = mergeConfig({});
+  assert.equal(config.display.showClockSeconds, false);
+});
+
+test('mergeConfig accepts showClockSeconds true', async () => {
+  const { mergeConfig } = await import('../dist/config.js');
+  const config = mergeConfig({ display: { showClockSeconds: true } });
+  assert.equal(config.display.showClockSeconds, true);
 });


### PR DESCRIPTION
## Summary

`formatResetTime`'s absolute/both/elapsedAndAbsolute display uses `toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })` — an empty locale array with no `hourCycle`, so 12- vs 24-hour formatting is entirely decided by the OS locale. Users have no way to override this short of setting `LC_ALL` for their whole shell, which affects every other tool too.

This is particularly awkward for zh-Hans/zh-Hant users: `display.language` already localizes the HUD's own labels, but reset times still follow the OS locale for AM/PM vs 24-hour formatting, producing a mixed "Chinese labels + 12-hour AM/PM" display for locales that default to 12-hour time.

- `LC_ALL=zh_TW.UTF-8` → `下午08:20`
- `LC_ALL=en_GB.UTF-8` → `20:20`
- unset → `08:20 PM`

## Changes

- `display.hourCycle`: `'auto' | 'h11' | 'h12' | 'h23' | 'h24'`, default `'auto'`. `'auto'` preserves the current locale-driven behavior exactly — this is the key point for backward compatibility. Setting it to e.g. `'h23'` forces 24-hour time regardless of locale.
- `display.showClockSeconds`: boolean, default `false`. Adds a seconds component to wall-clock reset times, e.g. `at 14:30:07`.
- `formatResetTime`/`formatAbsolute` in `src/render/format-reset-time.ts` take an optional `WallClockOptions` param (with a default that reproduces the old behavior), threaded through the call sites in `src/render/lines/usage.ts` and `src/render/session-line.ts`.
- Message keys aren't touched — no i18n changes needed since this doesn't add new visible labels.

## Test plan

- [x] `npm run build && npm test` — new tests in `tests/format-reset-time.test.js` (default/auto parity, `h23` avoids AM/PM, `showClockSeconds`, midnight boundary `h23` vs `h24`, `mergeConfig` validation) all pass
- [x] Verified pre-existing test failures in this environment are identical with and without this change (compared against a clean `main` worktree) — unrelated Windows/sandbox flakiness, not introduced by this PR
- [x] `dist/` excluded from the commit per CONTRIBUTING.md
- [x] `README.md` and `README.zh.md` Options tables and prose both updated