### PR TITLE
fix: price the Claude 5 model family (Opus 5, Sonnet 5, Fable 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Claude HUD will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Add local cost pricing for the Claude 5 model family (Opus 5, Sonnet 5, Fable 5), so the estimated-cost fallback no longer silently disappears on current models (#PRNUM).
+- Add local cost pricing for the Claude 5 model family (Opus 5, Sonnet 5, Fable 5), so the estimated-cost fallback no longer silently disappears on current models (#694).
 
 ## [0.6.0] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Add local cost pricing for the Claude 5 model family (Opus 5, Sonnet 5, Fable 5), so the estimated-cost fallback no longer silently disappears on current models (#PRNUM).
+
 ## [0.6.0] - 2026-07-20
 
 ### Added

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -27,13 +27,16 @@ const CACHE_READ_MULTIPLIER = 0.1;
 // model lines (Haiku 4.x differs from Haiku 3.5) must come before any broader
 // fallback patterns to avoid silent under-pricing.
 const ANTHROPIC_MODEL_PRICING: Array<{ pattern: RegExp; pricing: ModelPricing }> = [
+  { pattern: /\bopus 5(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 5, outputUsdPerMillion: 25 } },
   { pattern: /\bopus 4 (?:[5-9]|\d{2,})\b/i, pricing: { inputUsdPerMillion: 5, outputUsdPerMillion: 25 } },
   { pattern: /\bopus 4(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 15, outputUsdPerMillion: 75 } },
+  { pattern: /\bsonnet 5(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 2, outputUsdPerMillion: 10 } },
   { pattern: /\bsonnet 4(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
   { pattern: /\bsonnet 3 7\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
   { pattern: /\bsonnet 3 5\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
   { pattern: /\bhaiku 4(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 1, outputUsdPerMillion: 5 } },
   { pattern: /\bhaiku 3 5\b/i, pricing: { inputUsdPerMillion: 0.8, outputUsdPerMillion: 4 } },
+  { pattern: /\bfable 5(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 10, outputUsdPerMillion: 50 } },
   // Enterprise plan aliases (e.g. opusplan, sonnetplan, haikuplan)
   { pattern: /\bopusplan\b/i, pricing: { inputUsdPerMillion: 15, outputUsdPerMillion: 75 } },
   { pattern: /\bsonnetplan\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },

--- a/tests/cost-coverage.test.js
+++ b/tests/cost-coverage.test.js
@@ -103,6 +103,52 @@ test('estimateSessionCost prices enterprise plan aliases', () => {
   assert.equal(haikuPlan.outputUsd, 4);
 });
 
+test('estimateSessionCost prices the Claude 5 family', () => {
+  const tokens = { inputTokens: 1000000, outputTokens: 1000000, cacheCreationTokens: 0, cacheReadTokens: 0 };
+
+  const opus5 = estimateSessionCost({ model: { display_name: 'Opus 5' } }, tokens);
+  assert.ok(opus5);
+  assert.equal(opus5.inputUsd, 5);
+  assert.equal(opus5.outputUsd, 25);
+
+  const sonnet5 = estimateSessionCost({ model: { display_name: 'Sonnet 5' } }, tokens);
+  assert.ok(sonnet5);
+  assert.equal(sonnet5.inputUsd, 2);
+  assert.equal(sonnet5.outputUsd, 10);
+
+  const fable5 = estimateSessionCost({ model: { display_name: 'Fable 5' } }, tokens);
+  assert.ok(fable5);
+  assert.equal(fable5.inputUsd, 10);
+  assert.equal(fable5.outputUsd, 50);
+});
+
+test('estimateSessionCost prices Claude 5 ids carrying a context-window suffix', () => {
+  const tokens = { inputTokens: 1000000, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 };
+
+  const fromDisplayName = estimateSessionCost(
+    { model: { display_name: 'Opus 5 (1M context)', id: 'claude-opus-5[1m]' } },
+    tokens,
+  );
+  assert.ok(fromDisplayName);
+  assert.equal(fromDisplayName.inputUsd, 5);
+
+  const fromId = estimateSessionCost({ model: { display_name: 'Unknown', id: 'claude-opus-5[1m]' } }, tokens);
+  assert.ok(fromId);
+  assert.equal(fromId.inputUsd, 5);
+});
+
+test('estimateSessionCost prices Claude 5 point releases like their base model', () => {
+  const tokens = { inputTokens: 1000000, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 };
+
+  const opus51 = estimateSessionCost({ model: { display_name: 'Opus 5.1' } }, tokens);
+  assert.ok(opus51);
+  assert.equal(opus51.inputUsd, 5);
+
+  const sonnet51 = estimateSessionCost({ model: { display_name: 'Sonnet 5.1' } }, tokens);
+  assert.ok(sonnet51);
+  assert.equal(sonnet51.inputUsd, 2);
+});
+
 test('estimateSessionCost prices Sonnet 3.7', () => {
   const tokens = { inputTokens: 1000000, outputTokens: 1000000, cacheCreationTokens: 0, cacheReadTokens: 0 };
   const result = estimateSessionCost({ model: { display_name: 'Claude Sonnet 3.7' } }, tokens);


### PR DESCRIPTION
## Summary

`ANTHROPIC_MODEL_PRICING` tops out at Opus 4.5, so **Opus 5, Sonnet 5 and Fable 5 match no entry**. `matchAnthropicPricing` returns `null`, `estimateSessionCost` bails out, and the cost line silently disappears whenever the native `cost.total_cost_usd` field is unavailable (older payloads, and the `showRoutedCost` fallback path for Bedrock/Vertex).

Same failure mode as #452 (Haiku 4.5 had no entry) and #622 / #625 (Opus 4.5/4.6 rates were stale).

Adds the three current model lines at their published rates:

| Model | Input $/M | Output $/M |
| --- | --- | --- |
| Opus 5 | 5 | 25 |
| Sonnet 5 | 2 | 10 |
| Fable 5 | 10 | 50 |

Two things worth flagging for review:

- **Sonnet 5 is cheaper than Sonnet 4.5** ($2/$10 vs $3/$15), not more expensive. So it needs its own entry ahead of the `sonnet 4` line — letting it fall through to a broader pattern would have *overestimated* it rather than hidden it.
- **Cache multipliers are untouched.** The published cache-write and cache-read rates for all three models are still 1.25x and 0.1x of the input rate, which matches the existing `CACHE_WRITE_MULTIPLIER` / `CACHE_READ_MULTIPLIER` constants.

No `dist/` changes — source only, per CONTRIBUTING.

## Testing

- [x] `npm test`
- [x] `npm run test:coverage`

`tests/cost-coverage.test.js`: **24 -> 27 passing**. `cost.ts` coverage is 100% statements / branches / functions / lines.

Full-suite numbers on my machine went **930 -> 933 passing**, with the **same 37 failures before and after** the change. Those 37 are pre-existing Windows-only environment failures (`countConfigs`, `runExtraCmd`, `getGitStatus`, CLI render snapshots, `isJjRepo` symlinks, `getOutputSpeed`, `getClaudeCodeVersion`) and are unrelated to this change — I measured the baseline on a clean checkout of `main` before touching anything. CI on Linux should be unaffected.

New tests cover:

- the three families priced from `display_name`
- model ids carrying a context-window suffix (`claude-opus-5[1m]`), which is what Claude Code actually sends
- point releases such as Opus 5.1, matching the existing `(?: \d+)?` convention

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed

README/README.zh describe the pricing table generically ("the Anthropic pricing table") and do not enumerate models, so no README change is needed. CHANGELOG updated under `[Unreleased]`.
