### PR TITLE
Add MiniMax model pricing and endpoint labels

### DIFF
--- a/src/cost.ts
+++ b/src/cost.ts
@@ -4,6 +4,10 @@ import { isBedrockModelId, isVertexModelId } from './stdin.js';
 type ModelPricing = {
   inputUsdPerMillion: number;
   outputUsdPerMillion: number;
+  // Undefined keeps the existing cache multipliers. Null means the
+  // model does not publish a separately priced cache write.
+  cacheReadUsdPerMillion?: number;
+  cacheWriteUsdPerMillion?: number | null;
 };
 
 export interface SessionCostEstimate {
@@ -26,7 +30,9 @@ const CACHE_READ_MULTIPLIER = 0.1;
 // Patterns are tried in order; the first match wins. Families with more specific
 // model lines (Haiku 4.x differs from Haiku 3.5) must come before any broader
 // fallback patterns to avoid silent under-pricing.
-const ANTHROPIC_MODEL_PRICING: Array<{ pattern: RegExp; pricing: ModelPricing }> = [
+const MODEL_PRICING: Array<{ pattern: RegExp; pricing: ModelPricing }> = [
+  { pattern: /^minimax m3(?:\[1m\])?$/i, pricing: { inputUsdPerMillion: 0.6, outputUsdPerMillion: 2.4, cacheReadUsdPerMillion: 0.12, cacheWriteUsdPerMillion: null } },
+  { pattern: /^minimax m2 7$/i, pricing: { inputUsdPerMillion: 0.3, outputUsdPerMillion: 1.2, cacheReadUsdPerMillion: 0.06, cacheWriteUsdPerMillion: 0.375 } },
   { pattern: /\bopus 4 (?:[5-9]|\d{2,})\b/i, pricing: { inputUsdPerMillion: 5, outputUsdPerMillion: 25 } },
   { pattern: /\bopus 4(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 15, outputUsdPerMillion: 75 } },
   { pattern: /\bsonnet 4(?: \d+)?\b/i, pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 } },
@@ -50,9 +56,9 @@ function normalizeModelName(modelName: string): string {
     .trim();
 }
 
-function matchAnthropicPricing(modelName: string): ModelPricing | null {
+function matchModelPricing(modelName: string): ModelPricing | null {
   const normalized = normalizeModelName(modelName);
-  for (const entry of ANTHROPIC_MODEL_PRICING) {
+  for (const entry of MODEL_PRICING) {
     if (entry.pattern.test(normalized)) {
       return entry.pricing;
     }
@@ -64,7 +70,7 @@ function calculateUsd(tokens: number, usdPerMillion: number): number {
   return (tokens * usdPerMillion) / TOKENS_PER_MILLION;
 }
 
-function getAnthropicPricing(stdin: StdinData): ModelPricing | null {
+function getModelPricing(stdin: StdinData): ModelPricing | null {
   const candidates = [
     stdin.model?.display_name?.trim(),
     stdin.model?.id?.trim(),
@@ -75,7 +81,7 @@ function getAnthropicPricing(stdin: StdinData): ModelPricing | null {
       continue;
     }
 
-    const pricing = matchAnthropicPricing(candidate);
+    const pricing = matchModelPricing(candidate);
     if (pricing) {
       return pricing;
     }
@@ -97,7 +103,7 @@ export function estimateSessionCost(
     return null;
   }
 
-  const pricing = getAnthropicPricing(stdin);
+  const pricing = getModelPricing(stdin);
   if (!pricing) {
     return null;
   }
@@ -111,8 +117,12 @@ export function estimateSessionCost(
   }
 
   const inputUsd = calculateUsd(sessionTokens.inputTokens, pricing.inputUsdPerMillion);
-  const cacheCreationUsd = calculateUsd(sessionTokens.cacheCreationTokens, pricing.inputUsdPerMillion * CACHE_WRITE_MULTIPLIER);
-  const cacheReadUsd = calculateUsd(sessionTokens.cacheReadTokens, pricing.inputUsdPerMillion * CACHE_READ_MULTIPLIER);
+  const cacheWriteUsdPerMillion = pricing.cacheWriteUsdPerMillion === undefined
+    ? pricing.inputUsdPerMillion * CACHE_WRITE_MULTIPLIER
+    : pricing.cacheWriteUsdPerMillion ?? 0;
+  const cacheReadUsdPerMillion = pricing.cacheReadUsdPerMillion ?? pricing.inputUsdPerMillion * CACHE_READ_MULTIPLIER;
+  const cacheCreationUsd = calculateUsd(sessionTokens.cacheCreationTokens, cacheWriteUsdPerMillion);
+  const cacheReadUsd = calculateUsd(sessionTokens.cacheReadTokens, cacheReadUsdPerMillion);
   const outputUsd = calculateUsd(sessionTokens.outputTokens, pricing.outputUsdPerMillion);
 
   return {

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -313,6 +313,26 @@ export function isVertexModelId(modelId?: string): boolean {
 
 const ENTERPRISE_MODEL_IDS = new Set(['opusplan', 'sonnetplan', 'haikuplan']);
 
+const MINIMAX_ANTHROPIC_ENDPOINTS = new Set([
+  'https://api.minimax.io/anthropic',
+  'https://api.minimaxi.com/anthropic',
+]);
+
+function isMiniMaxAnthropicEndpoint(env: NodeJS.ProcessEnv = process.env): boolean {
+  const baseUrl = env.ANTHROPIC_BASE_URL?.trim() || env.ANTHROPIC_API_BASE_URL?.trim();
+  if (!baseUrl) {
+    return false;
+  }
+
+  try {
+    const url = new URL(baseUrl);
+    const normalized = `${url.origin}${url.pathname.replace(/\/+$/, '')}`;
+    return MINIMAX_ANTHROPIC_ENDPOINTS.has(normalized);
+  } catch {
+    return false;
+  }
+}
+
 export function isEnterpriseModelId(modelId?: string): boolean {
   if (!modelId) {
     return false;
@@ -326,6 +346,9 @@ export function getProviderLabel(stdin: StdinData): string | null {
   }
   if (process.env.CLAUDE_CODE_USE_VERTEX === '1') {
     return 'Vertex';
+  }
+  if (isMiniMaxAnthropicEndpoint()) {
+    return 'MiniMax';
   }
   if (isEnterpriseModelId(stdin.model?.id)) {
     return 'Enterprise';

--- a/tests/cost-coverage.test.js
+++ b/tests/cost-coverage.test.js
@@ -76,6 +76,44 @@ test('estimateSessionCost calculates cache costs correctly', () => {
   assert.ok(Math.abs(result.totalUsd - 4.05) < 1e-10);
 });
 
+test('estimateSessionCost applies MiniMax-M3 pricing without a cache write charge', () => {
+  const result = estimateSessionCost(
+    { model: { display_name: 'MiniMax-M3' } },
+    {
+      inputTokens: 1_000_000,
+      cacheCreationTokens: 1_000_000,
+      cacheReadTokens: 1_000_000,
+      outputTokens: 1_000_000,
+    },
+  );
+
+  assert.ok(result);
+  assert.equal(result.inputUsd, 0.6);
+  assert.equal(result.cacheCreationUsd, 0);
+  assert.equal(result.cacheReadUsd, 0.12);
+  assert.equal(result.outputUsd, 2.4);
+  assert.equal(result.totalUsd, 3.12);
+});
+
+test('estimateSessionCost applies MiniMax-M2.7 cache pricing from the model parameters', () => {
+  const result = estimateSessionCost(
+    { model: { id: 'MiniMax-M2.7' } },
+    {
+      inputTokens: 1_000_000,
+      cacheCreationTokens: 1_000_000,
+      cacheReadTokens: 1_000_000,
+      outputTokens: 1_000_000,
+    },
+  );
+
+  assert.ok(result);
+  assert.equal(result.inputUsd, 0.3);
+  assert.equal(result.cacheCreationUsd, 0.375);
+  assert.equal(result.cacheReadUsd, 0.06);
+  assert.equal(result.outputUsd, 1.2);
+  assert.ok(Math.abs(result.totalUsd - 1.935) < 1e-12);
+});
+
 test('estimateSessionCost matches model from id when display_name fails', () => {
   const tokens = { inputTokens: 1000000, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 };
   const result = estimateSessionCost({ model: { display_name: 'Unknown', id: 'claude-sonnet-3.5-20241022' } }, tokens);

--- a/tests/stdin.test.js
+++ b/tests/stdin.test.js
@@ -203,3 +203,39 @@ test('getProviderLabel returns null when CLAUDE_CODE_USE_BEDROCK=0', () => {
     else process.env.CLAUDE_CODE_USE_BEDROCK = orig;
   }
 });
+
+test('getProviderLabel recognizes both MiniMax Anthropic endpoints', () => {
+  const originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
+  const originalApiBaseUrl = process.env.ANTHROPIC_API_BASE_URL;
+
+  try {
+    delete process.env.ANTHROPIC_API_BASE_URL;
+    process.env.ANTHROPIC_BASE_URL = 'https://api.minimax.io/anthropic';
+    assert.equal(getProviderLabel({ model: { id: 'MiniMax-M3' } }), 'MiniMax');
+
+    delete process.env.ANTHROPIC_BASE_URL;
+    process.env.ANTHROPIC_API_BASE_URL = 'https://api.minimaxi.com/anthropic/';
+    assert.equal(getProviderLabel({ model: { id: 'MiniMax-M3' } }), 'MiniMax');
+  } finally {
+    if (originalBaseUrl === undefined) delete process.env.ANTHROPIC_BASE_URL;
+    else process.env.ANTHROPIC_BASE_URL = originalBaseUrl;
+    if (originalApiBaseUrl === undefined) delete process.env.ANTHROPIC_API_BASE_URL;
+    else process.env.ANTHROPIC_API_BASE_URL = originalApiBaseUrl;
+  }
+});
+
+test('getProviderLabel rejects lookalike MiniMax endpoints', () => {
+  const originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
+  const originalApiBaseUrl = process.env.ANTHROPIC_API_BASE_URL;
+
+  try {
+    delete process.env.ANTHROPIC_API_BASE_URL;
+    process.env.ANTHROPIC_BASE_URL = 'https://proxy.api.minimax.io/anthropic';
+    assert.equal(getProviderLabel({ model: { id: 'MiniMax-M3' } }), null);
+  } finally {
+    if (originalBaseUrl === undefined) delete process.env.ANTHROPIC_BASE_URL;
+    else process.env.ANTHROPIC_BASE_URL = originalBaseUrl;
+    if (originalApiBaseUrl === undefined) delete process.env.ANTHROPIC_API_BASE_URL;
+    else process.env.ANTHROPIC_API_BASE_URL = originalApiBaseUrl;
+  }
+});


### PR DESCRIPTION
Reason: MiniMax cost estimates and provider labels need current model pricing and regional endpoint support.

## Changes

- Add MiniMax-M3 and MiniMax-M2.7 input, output, and cache pricing.
- Handle the MiniMax-M3 absent cache-write price without applying the default multiplier.
- Recognize the global and China Anthropic-compatible endpoints for provider labeling.
- Add focused regression tests for pricing, cache handling, regional endpoints, and lookalike URLs.

## Checks

- `npm run build`
- `node --test tests/cost-coverage.test.js tests/stdin.test.js`
- `npm test`
