### PR TITLE
feat(mcp): flag MCP servers that returned errors on the environment line

### DIFF
--- a/src/render/lines/environment.ts
+++ b/src/render/lines/environment.ts
@@ -1,6 +1,9 @@
 import type { RenderContext } from "../../types.js";
-import { label } from "../colors.js";
+import { label, red } from "../colors.js";
 import { t } from "../../i18n/index.js";
+
+/** How many failing server names to spell out before collapsing to a count. */
+const MAX_NAMED_MCP_ERRORS = 3;
 
 export function renderEnvironmentLine(ctx: RenderContext): string | null {
   const display = ctx.config?.display;
@@ -9,7 +12,9 @@ export function renderEnvironmentLine(ctx: RenderContext): string | null {
   const threshold = display?.environmentThreshold ?? 0;
   const showCounts = display?.showConfigCounts === true;
   const showOutputStyle = display?.showOutputStyle === true;
+  const mcpErrors = ctx.transcript?.mcpErrors ?? [];
   const parts: string[] = [];
+  let renderedMcpCount = false;
 
   if (showCounts && totalCounts >= threshold && totalCounts > 0) {
     if (ctx.claudeMdCount > 0) {
@@ -21,7 +26,10 @@ export function renderEnvironmentLine(ctx: RenderContext): string | null {
     }
 
     if (ctx.mcpCount > 0) {
-      parts.push(`${ctx.mcpCount} MCPs`);
+      parts.push(mcpErrors.length > 0
+        ? `${ctx.mcpCount} MCPs ${formatMcpErrors(mcpErrors)}`
+        : `${ctx.mcpCount} MCPs`);
+      renderedMcpCount = true;
     }
 
     if (ctx.hooksCount > 0) {
@@ -33,9 +41,25 @@ export function renderEnvironmentLine(ctx: RenderContext): string | null {
     parts.push(`style: ${ctx.outputStyle}`);
   }
 
+  // A failing MCP server bypasses the config-count gate. The counts are
+  // ambient detail you switch off once you have read them; an erroring server
+  // is a live fault, and hiding it behind an unrelated display toggle is how
+  // a broken tool goes unnoticed for a whole session.
+  if (mcpErrors.length > 0 && !renderedMcpCount) {
+    parts.push(formatMcpErrors(mcpErrors));
+  }
+
   if (parts.length === 0) {
     return null;
   }
 
   return label(parts.join(" | "), ctx.config?.colors);
+}
+
+/** `⚠ github, tenable +2` — names first, then an overflow count. */
+function formatMcpErrors(mcpErrors: string[]): string {
+  const named = mcpErrors.slice(0, MAX_NAMED_MCP_ERRORS).join(", ");
+  const overflow = mcpErrors.length - MAX_NAMED_MCP_ERRORS;
+  const suffix = overflow > 0 ? ` +${overflow}` : "";
+  return red(`⚠ ${named}${suffix}`);
 }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -83,6 +83,7 @@ interface SerializedTranscriptData {
   tools: SerializedToolEntry[];
   skills: string[];
   mcpServers: string[];
+  mcpErrors: string[];
   agents: SerializedAgentEntry[];
   todos: TodoItem[];
   sessionStart?: string;
@@ -233,6 +234,7 @@ function serializeTranscriptData(data: TranscriptData): SerializedTranscriptData
     })),
     skills: [...data.skills],
     mcpServers: [...data.mcpServers],
+    mcpErrors: [...data.mcpErrors],
     agents: data.agents.map((agent) => ({
       ...agent,
       startTime: agent.startTime.toISOString(),
@@ -261,6 +263,7 @@ function deserializeTranscriptData(data: SerializedTranscriptData): TranscriptDa
     })),
     skills: normalizeNameList(data.skills),
     mcpServers: normalizeNameList(data.mcpServers),
+    mcpErrors: normalizeNameList(data.mcpErrors),
     agents: data.agents.map((agent) => ({
       ...agent,
       model: sanitizeTranscriptModel(agent.model),
@@ -340,6 +343,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
     tools: [],
     skills: [],
     mcpServers: [],
+    mcpErrors: [],
     agents: [],
     todos: [],
   };
@@ -366,6 +370,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   const toolMap = new Map<string, ToolEntry>();
   const skillSet = new Set<string>();
   const mcpServerSet = new Set<string>();
+  const mcpErrorSet = new Set<string>();
   const agentMap = new Map<string, AgentEntry>();
   let latestTodos: TodoItem[] = [];
   const taskIdToIndex = new Map<string, number>();
@@ -518,7 +523,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
             }
           }
         }
-        processEntry(entry, toolMap, skillSet, mcpServerSet, agentMap, taskIdToIndex, latestTodos, result);
+        processEntry(entry, toolMap, skillSet, mcpServerSet, mcpErrorSet, agentMap, taskIdToIndex, latestTodos, result);
       } catch (err) {
         lastUsageKey = undefined;
         debug('Skipping malformed transcript line:', err instanceof Error ? err.message : err);
@@ -548,6 +553,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   result.tools = Array.from(toolMap.values()).slice(-20);
   result.skills = Array.from(skillSet.values());
   result.mcpServers = Array.from(mcpServerSet.values());
+  result.mcpErrors = Array.from(mcpErrorSet.values());
   result.agents = Array.from(agentMap.values()).slice(-10);
   result.todos = latestTodos;
   result.sessionName = customTitle ?? latestSlug;
@@ -573,6 +579,7 @@ function processEntry(
   toolMap: Map<string, ToolEntry>,
   skillSet: Set<string>,
   mcpServerSet: Set<string>,
+  mcpErrorSet: Set<string>,
   agentMap: Map<string, AgentEntry>,
   taskIdToIndex: Map<string, number>,
   latestTodos: TodoItem[],
@@ -706,6 +713,15 @@ function processEntry(
       if (tool) {
         tool.status = block.is_error ? 'error' : 'completed';
         tool.endTime = timestamp;
+
+        // Attribute a failing MCP tool back to its server so the environment
+        // line can flag it. Names are `mcp__<server>__<tool>`.
+        if (block.is_error && tool.name.startsWith('mcp__')) {
+          const parts = tool.name.split('__');
+          if (parts.length >= 3 && parts[1]) {
+            mcpErrorSet.add(parts[1]);
+          }
+        }
       }
 
       const agent = agentMap.get(block.tool_use_id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,6 +142,13 @@ export interface TranscriptData {
   tools: ToolEntry[];
   skills: string[];
   mcpServers: string[];
+  /**
+   * MCP servers that returned at least one tool error this session, derived
+   * from `mcp__<server>__<tool>` results carrying is_error. Distinct from
+   * mcpServers, which is a plain activity list — a failing server is worth
+   * surfacing even when the config-count display is otherwise quiet.
+   */
+  mcpErrors: string[];
   agents: AgentEntry[];
   todos: TodoItem[];
   sessionStart?: Date;

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1339,6 +1339,58 @@ test('parseTranscript truncates long bash commands in targets', async () => {
   }
 });
 
+test('parseTranscript attributes MCP tool errors back to their server', async () => {
+  const result = await parseTempTranscript('mcp-errors.jsonl', [
+    {
+      message: {
+        content: [
+          { type: 'tool_use', id: 'm1', name: 'mcp__github__create_pr', input: {} },
+          { type: 'tool_use', id: 'm2', name: 'mcp__tenable__search_tools', input: {} },
+          { type: 'tool_use', id: 'm3', name: 'mcp__github__list_prs', input: {} },
+          { type: 'tool_result', tool_use_id: 'm1', is_error: true },
+          { type: 'tool_result', tool_use_id: 'm2', is_error: true },
+          { type: 'tool_result', tool_use_id: 'm3', is_error: false },
+        ],
+      },
+    },
+  ]);
+
+  assert.deepEqual([...result.mcpErrors].sort(), ['github', 'tenable']);
+});
+
+test('parseTranscript records no MCP errors when every MCP call succeeds', async () => {
+  const result = await parseTempTranscript('mcp-clean.jsonl', [
+    {
+      message: {
+        content: [
+          { type: 'tool_use', id: 'm1', name: 'mcp__linear__list_issues', input: {} },
+          { type: 'tool_result', tool_use_id: 'm1', is_error: false },
+        ],
+      },
+    },
+  ]);
+
+  assert.deepEqual(result.mcpErrors, []);
+});
+
+// A failing non-MCP tool must not be attributed to a server — the name has no
+// mcp__<server>__<tool> shape to parse, and mislabelling one would point an
+// investigation at the wrong subsystem.
+test('parseTranscript ignores non-MCP tool errors for MCP attribution', async () => {
+  const result = await parseTempTranscript('non-mcp-error.jsonl', [
+    {
+      message: {
+        content: [
+          { type: 'tool_use', id: 't1', name: 'Read', input: { path: '/nope' } },
+          { type: 'tool_result', tool_use_id: 't1', is_error: true },
+        ],
+      },
+    },
+  ]);
+
+  assert.deepEqual(result.mcpErrors, []);
+});
+
 test('parseTranscript handles edge-case lines and error statuses', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-'));
   const filePath = path.join(dir, 'edge-cases.jsonl');
@@ -1638,6 +1690,50 @@ test('parseTranscript reuses cached data when transcript state is unchanged', as
     assert.equal(second.tools.length, 1);
     assert.equal(second.tools[0].target, '/tmp/original.txt');
     assert.equal(second.compactionCount, 1);
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// mcpErrors must survive the transcript cache round-trip. The status line is
+// invoked continuously and almost every invocation is a CACHE HIT, so a field
+// that serializes but does not deserialize (or vice versa) is populated on the
+// very first tick and silently empty for the rest of the session. The file is
+// corrupted here while mtime+size are held constant, so a cache MISS would
+// re-parse garbage and yield nothing — the assertion can only pass if the
+// value genuinely round-tripped through the cache.
+test('parseTranscript round-trips mcpErrors through the transcript cache', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-mcperr-cache-'));
+  const configDir = path.join(dir, '.claude-test');
+  const transcriptPath = path.join(dir, 'mcp-cache.jsonl');
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  const line = `${JSON.stringify({
+    timestamp: '2024-01-01T00:00:00.000Z',
+    message: {
+      content: [
+        { type: 'tool_use', id: 'm1', name: 'mcp__airlock__block_hash', input: {} },
+        { type: 'tool_result', tool_use_id: 'm1', is_error: true },
+      ],
+    },
+  })}\n`;
+
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  await writeFile(transcriptPath, line, 'utf8');
+  fs.utimesSync(transcriptPath, 1710000000, 1710000000);
+
+  try {
+    const first = await parseTranscript(transcriptPath);
+    assert.deepEqual(first.mcpErrors, ['airlock'], 'first parse should attribute the error');
+
+    // Same mtime and size, different bytes: only a cache hit can still answer.
+    const stat = fs.statSync(transcriptPath);
+    await writeFile(transcriptPath, '#'.repeat(stat.size), 'utf8');
+    fs.utimesSync(transcriptPath, 1710000000, 1710000000);
+
+    const second = await parseTranscript(transcriptPath);
+    assert.deepEqual(second.mcpErrors, ['airlock'],
+      'mcpErrors must survive the cache round-trip, not just the first parse');
   } finally {
     restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
     await rm(dir, { recursive: true, force: true });

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1132,6 +1132,51 @@ test('renderEnvironmentLine appends output style after config counts', () => {
   assert.ok(line?.includes('style: learning'));
 });
 
+test('renderEnvironmentLine flags MCP servers that returned errors', () => {
+  const ctx = baseContext();
+  ctx.config.display.showConfigCounts = true;
+  ctx.mcpCount = 5;
+  ctx.transcript.mcpErrors = ['github', 'tenable'];
+
+  const line = renderEnvironmentLine(ctx);
+  assert.ok(line?.includes('5 MCPs'), 'count should still render');
+  assert.ok(line?.includes('github, tenable'), 'failing servers should be named');
+  assert.ok(line?.includes('\x1b[31m'), 'error segment should be red');
+});
+
+test('renderEnvironmentLine collapses more than three failing MCPs to a count', () => {
+  const ctx = baseContext();
+  ctx.config.display.showConfigCounts = true;
+  ctx.mcpCount = 9;
+  ctx.transcript.mcpErrors = ['a', 'b', 'c', 'd', 'e'];
+
+  const line = renderEnvironmentLine(ctx);
+  assert.ok(line?.includes('a, b, c +2'), `expected overflow count, got: ${line}`);
+});
+
+// A live fault must not be hidden behind an unrelated display toggle: the
+// config counts are ambient detail people switch off, an erroring server is not.
+test('renderEnvironmentLine surfaces MCP errors even when config counts are off', () => {
+  const ctx = baseContext();
+  ctx.config.display.showConfigCounts = false;
+  ctx.mcpCount = 5;
+  ctx.transcript.mcpErrors = ['airlock'];
+
+  const line = renderEnvironmentLine(ctx);
+  assert.ok(line, 'a failing MCP must render a line even with counts disabled');
+  assert.ok(line.includes('airlock'), `expected the failing server, got: ${line}`);
+  assert.ok(!line.includes('5 MCPs'), 'counts stay suppressed; only the fault shows');
+});
+
+test('renderEnvironmentLine stays null when nothing is enabled and no MCP errors', () => {
+  const ctx = baseContext();
+  ctx.config.display.showConfigCounts = false;
+  ctx.mcpCount = 5;
+  ctx.transcript.mcpErrors = [];
+
+  assert.equal(renderEnvironmentLine(ctx), null);
+});
+
 test('renderEnvironmentLine treats missing showConfigCounts as disabled in expanded layout', () => {
   const ctx = baseContext();
   ctx.config.lineLayout = 'expanded';


### PR DESCRIPTION
`showMcp` renders a plain activity list of server names, which can't distinguish a server that's working from one failing every call. This adds error attribution: any `mcp__<server>__<tool>` result carrying `is_error` is attributed back to its server and flagged.

```
5 MCPs ⚠ github, tenable
```

Names are collapsed to `+N` past three. The segment is red.

## Why it bypasses `showConfigCounts`

A failing server renders even when config counts are off. The counts are ambient detail people switch off once they've read them; an erroring server is a live fault, and gating it behind an unrelated display toggle is how a broken tool goes unnoticed for a whole session.

This caught a real one for me within minutes of enabling it — an MCP server had been silently failing calls all session and nothing else surfaced it.

## Implementation notes

- `mcpErrors` is `string[]`, mirroring `mcpServers` exactly — **not** a `Set`. `TranscriptData` is serialized into the transcript cache and a `Set` doesn't survive the JSON round-trip.
- Plumbed through all five points `mcpServers` touches: the `TranscriptData` type, `SerializedTranscriptData`, serialize, deserialize, and finalize — plus the `processEntry` signature and its call site.
- Attribution happens at the existing `is_error` site in `processEntry`, so there's no second pass over the transcript.
- Non-MCP tool errors are ignored: without an `mcp__<server>__<tool>` shape there's no server to attribute to, and guessing would point an investigation at the wrong subsystem.

## Tests

Six added, covering all three seams — parser attribution, the cache round-trip, and rendering.

The cache round-trip one is worth calling out. I mutation-tested this change and **both cache mutations were initially MISSED** — serialize and deserialize could each be broken with the whole suite still green. That's the dangerous shape here: the status line is invoked continuously and nearly every invocation is a cache **hit**, so a field that serializes but doesn't deserialize is populated on the very first tick and silently empty for the rest of the session.

The test closes it by corrupting the transcript while holding `mtime` and `size` constant, so a cache *miss* would re-parse garbage — the assertion can only pass if the value genuinely survived the cache.

After adding it, 7/7 mutations caught (parser attribution ×2, cache ×2, render ×3).

## Verification

- `v0.6.0` baseline before the change: 972 tests, 0 fail
- after: **980 tests, 975 pass, 0 fail, 5 skipped**

Branched directly off `main` — no dependencies on anything else in my fork.
