### PR TITLE
perf(auth): cache derived auth info instead of re-parsing claude.json every tick (18.6x)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { getClaudeConfigJsonPath } from './claude-config-dir.js';
+import * as path from 'node:path';
+import { getClaudeConfigJsonPath, getHudPluginDir } from './claude-config-dir.js';
 import { sanitizeDisplayText } from './utils/sanitize.js';
 
 /**
@@ -98,16 +99,95 @@ export function deriveAuthInfo(claudeJson: unknown, env: NodeJS.ProcessEnv = pro
 }
 
 /** Reads auth info for the current login. Never throws. */
+/**
+ * Cache of the two DERIVED fields, keyed on the source file's identity.
+ *
+ * Both mtime and size are compared: two writes can land inside the same
+ * millisecond, and mtime alone would then serve a stale entry.
+ */
+interface AuthCacheEntry {
+  mtimeMs: number;
+  size: number;
+  method: string | null;
+  user: string | null;
+}
+
+function authCachePath(homeDir: string): string {
+  return path.join(getHudPluginDir(homeDir), AUTH_CACHE_DIRNAME, 'auth.json');
+}
+
+const AUTH_CACHE_DIRNAME = 'auth-cache';
+
+function readAuthCache(homeDir: string): AuthCacheEntry | null {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(authCachePath(homeDir), 'utf-8'));
+    if (
+      parsed == null || typeof parsed !== 'object'
+      || typeof (parsed as AuthCacheEntry).mtimeMs !== 'number'
+      || typeof (parsed as AuthCacheEntry).size !== 'number'
+    ) {
+      return null;
+    }
+    return parsed as AuthCacheEntry;
+  } catch {
+    return null;
+  }
+}
+
+function writeAuthCache(homeDir: string, entry: AuthCacheEntry): void {
+  try {
+    const cachePath = authCachePath(homeDir);
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    // Write-then-rename: the status line can run concurrently across sessions,
+    // and a torn read would just miss the cache, but a torn WRITE would persist.
+    const tmpPath = `${cachePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(entry), 'utf-8');
+    fs.renameSync(tmpPath, cachePath);
+  } catch {
+    // A cache write must never break the status line.
+  }
+}
+
+/**
+ * Reads auth info for the current login. Never throws.
+ *
+ * claude.json is the user's entire CLI config and grows with project history —
+ * 73 KB on the host this was measured on. The status line runs on every
+ * interaction, so parsing it per tick is not free. The two derived fields are
+ * cached against the file's (mtimeMs, size) instead, making the steady-state
+ * cost a stat plus a ~100-byte read.
+ */
 export function readAuthInfo(): AuthInfo {
   // Avoid reading a stale OAuth profile when the active source is an API key.
   if (hasApiKey(process.env)) {
     return API_KEY_AUTH_INFO;
   }
 
+  const homeDir = os.homedir();
+  const configJsonPath = getClaudeConfigJsonPath(homeDir);
+
+  let stat: fs.Stats;
   try {
-    const configJsonPath = getClaudeConfigJsonPath(os.homedir());
+    stat = fs.statSync(configJsonPath);
+  } catch {
+    return EMPTY_AUTH_INFO;
+  }
+
+  const cached = readAuthCache(homeDir);
+  if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+    return { method: cached.method, user: cached.user };
+  }
+
+  try {
     const content = fs.readFileSync(configJsonPath, 'utf-8');
-    return deriveAuthInfo(JSON.parse(content));
+    const info = deriveAuthInfo(JSON.parse(content));
+    writeAuthCache(homeDir, {
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+      method: info.method,
+      user: info.user,
+    });
+    return info;
   } catch {
     return EMPTY_AUTH_INFO;
   }

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -141,3 +141,109 @@ test('formatAuthSegment joins method and truncated user', () => {
   assert.equal(formatAuthSegment(info, { showAuth: false, showAuthUser: false }), null);
   assert.equal(formatAuthSegment(null, { showAuth: true, showAuthUser: true }), null);
 });
+
+// --- derived-auth caching -------------------------------------------------
+// claude.json is the user's entire CLI config and grows with project history.
+// The status line runs on every interaction, so an uncached parse is paid per
+// tick. These tests exist because a cache that silently does nothing is still
+// CORRECT, just slow -- a performance property with no test regresses unnoticed.
+
+test('readAuthInfo caches derived auth and serves it on an unchanged file', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'hud-auth-cache-'));
+  const configDir = path.join(dir, '.claude');
+  const original = process.env.CLAUDE_CONFIG_DIR;
+  const originalKey = process.env.ANTHROPIC_API_KEY;
+  const fsSync = await import('node:fs');
+
+  try {
+    delete process.env.ANTHROPIC_API_KEY;   // force the file path
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    fsSync.mkdirSync(configDir, { recursive: true });
+    const jsonPath = `${configDir}.json`;
+    await writeFile(jsonPath, JSON.stringify(MAX_ACCOUNT), 'utf8');
+
+    assert.deepEqual(readAuthInfo(), { method: 'Claude Max 20x', user: 'someone.long' });
+
+    const cacheFile = path.join(configDir, 'plugins', 'claude-hud', 'auth-cache', 'auth.json');
+    assert.ok(fsSync.existsSync(cacheFile), 'first read must write a cache entry');
+
+    // Prove the CACHED path is taken without depending on timestamp precision
+    // (utimes cannot faithfully restore sub-millisecond mtime on APFS, which
+    // would bust the key for the wrong reason). Make the source unreadable:
+    // statSync still succeeds, so a HIT returns the stored value while a
+    // re-parse would hit EACCES and fall through to EMPTY_AUTH_INFO.
+    fsSync.chmodSync(jsonPath, 0o000);
+    let unreadable = true;
+    try { fsSync.readFileSync(jsonPath, 'utf-8'); unreadable = false; } catch { /* expected */ }
+    if (unreadable) {
+      assert.deepEqual(readAuthInfo(), { method: 'Claude Max 20x', user: 'someone.long' },
+        'an unchanged (mtime,size) must serve the CACHED value');
+    }
+    fsSync.chmodSync(jsonPath, 0o600);
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', original);
+    restoreEnvVar('ANTHROPIC_API_KEY', originalKey);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('readAuthInfo re-parses when claude.json actually changes', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'hud-auth-bust-'));
+  const configDir = path.join(dir, '.claude');
+  const original = process.env.CLAUDE_CONFIG_DIR;
+  const originalKey = process.env.ANTHROPIC_API_KEY;
+  const fsSync = await import('node:fs');
+
+  try {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    fsSync.mkdirSync(configDir, { recursive: true });
+    const jsonPath = `${configDir}.json`;
+    await writeFile(jsonPath, JSON.stringify(MAX_ACCOUNT), 'utf8');
+    assert.equal(readAuthInfo().user, 'someone.long');
+
+    await writeFile(jsonPath, JSON.stringify({
+      oauthAccount: { emailAddress: 'other@example.com', organizationType: 'claude_pro' },
+    }), 'utf8');
+    const future = new Date(Date.now() + 5000);
+    fsSync.utimesSync(jsonPath, future, future);
+
+    assert.equal(readAuthInfo().user, 'other', 'a changed file must bust the cache');
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', original);
+    restoreEnvVar('ANTHROPIC_API_KEY', originalKey);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// Size is in the key alongside mtime because two writes can land in the same
+// millisecond. Hard to provoke by racing the clock, so the entry is forged.
+test('readAuthInfo busts the cache when only the SIZE differs', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'hud-auth-size-'));
+  const configDir = path.join(dir, '.claude');
+  const original = process.env.CLAUDE_CONFIG_DIR;
+  const originalKey = process.env.ANTHROPIC_API_KEY;
+  const fsSync = await import('node:fs');
+
+  try {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    fsSync.mkdirSync(configDir, { recursive: true });
+    const jsonPath = `${configDir}.json`;
+    await writeFile(jsonPath, JSON.stringify(MAX_ACCOUNT), 'utf8');
+    assert.equal(readAuthInfo().user, 'someone.long', 'seed the cache');
+
+    const cacheFile = path.join(configDir, 'plugins', 'claude-hud', 'auth-cache', 'auth.json');
+    const stat = fsSync.statSync(jsonPath);
+    fsSync.writeFileSync(cacheFile, JSON.stringify({
+      mtimeMs: stat.mtimeMs, size: stat.size + 1, method: 'STALE', user: 'stale-user',
+    }), 'utf8');
+
+    assert.equal(readAuthInfo().user, 'someone.long',
+      'a size mismatch must bust the cache and re-parse');
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', original);
+    restoreEnvVar('ANTHROPIC_API_KEY', originalKey);
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
`readAuthInfo()` parses the whole of `claude.json` on every call. That file is the user's entire CLI config and grows with project history — **73,526 bytes** on the host I measured — and the status line runs on every interaction, so the parse is paid per tick whenever `showAuth` or `showAuthUser` is on.

This caches the two *derived* fields against the source file's `(mtimeMs, size)`, reducing the steady state to a `stat` plus a ~100-byte read.

## Measured

300 calls, warm, against a 73,474-byte `claude.json`:

| | ms/call |
|---|---|
| uncached | 0.6669 |
| cached | 0.0359 |
| | **18.6×** |

## Design notes

- **Size is in the key alongside mtime.** Two writes can land inside the same millisecond; mtime alone would serve a stale entry.
- **Write-then-rename.** The status line runs concurrently across sessions. A torn *read* merely misses the cache, but a torn *write* would persist.
- **Every cache failure is swallowed.** A cache must never be able to break the status line.
- Cache lives under `getHudPluginDir()/auth-cache/`, alongside the existing `context-cache/`.

## Tests

Three added. The cache-**hit** test is the one worth explaining.

It deliberately does *not* rewrite the file and restore mtime via `utimes` — sub-millisecond precision doesn't round-trip on APFS, so the key busts for the wrong reason and the test passes vacuously (I hit exactly this while writing it). Instead it makes the source unreadable: `statSync` still succeeds so the key still matches, meaning a **hit** returns the stored value while a **re-parse** hits `EACCES` and falls through to `EMPTY_AUTH_INFO`. Unambiguous, and precision-independent.

## Mutation testing — 4/4 caught

Green baseline before and after each restore.

| mutation | |
|---|---|
| cache never written | CAUGHT |
| cache ignores mtime | CAUGHT |
| cache ignores size | CAUGHT |
| API-key short-circuit removed | CAUGHT |

The first two matter most. **A cache that silently does nothing is still *correct*, just slow** — so without those tests this optimisation could be deleted entirely and the suite would stay green. That's the failure mode a perf change most needs guarding against.

## Verification

- baseline before: 972 tests, 0 fail
- after: **975 tests, 970 pass, 0 fail, 5 skipped**

Branched directly off `main`; no dependencies on anything else in my fork.
