### PR TITLE
prompt cache fixes/display  - don't count subagents, detect the TTL, show expiry time

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ After choosing a preset, you can turn individual elements on or off.
 ### Manual Configuration
 
 Edit `~/.claude/plugins/claude-hud/config.json` directly for advanced settings such as `colors.*`,
-`pathLevels`, `maxWidth`, threshold overrides, `display.timeFormat`, and `display.hourCycle`. Running `/claude-hud:configure`
+`pathLevels`, `maxWidth`, threshold overrides, `display.timeFormat`, `display.hourCycle`, and `display.promptCacheTtlSeconds`. Running `/claude-hud:configure`
 preserves those manual settings while still letting you change `language`, layout, and the common
 guided toggles.
 
@@ -232,6 +232,7 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 | `display.showClaudeCodeVersion` | boolean | false | Show the installed Claude Code version, e.g. `CC v2.1.81` |
 | `display.showMemoryUsage` | boolean | false | Show an approximate system RAM usage line in expanded layout |
 | `display.showPromptCache` | boolean | false | Show the wall-clock time the session's prompt cache expires, read from the transcript |
+| `display.promptCacheTtlSeconds` | number | `300` | Compatibility fallback used only when the transcript has not reported a 5-minute or 1-hour cache tier |
 | `colors.context` | color value | `green` | Base color for the context bar and context percentage |
 | `colors.usage` | color value | `brightBlue` | Base color for usage bars and percentages below warning thresholds |
 | `colors.warning` | color value | `yellow` | Warning color for context thresholds and usage warning text |
@@ -260,9 +261,9 @@ Official MiniMax Anthropic-compatible endpoints receive a `MiniMax` provider lab
 
 It shows an expiry time rather than a countdown because the statusline only repaints while Claude Code is active. Between turns — exactly when the cache is draining — a countdown freezes at whatever it last displayed and keeps reporting it; a clock time stays true no matter how stale the render is.
 
-Everything the element needs comes from the transcript, so there is nothing to configure:
+ClaudeHUD detects the cache tier from the transcript when possible. The existing `display.promptCacheTtlSeconds` setting remains a fallback for older or proxied transcripts that do not expose tier details:
 
-- **The TTL is detected.** Every cache write records the tier it used (`usage.cache_creation.ephemeral_5m_input_tokens` vs `ephemeral_1h_input_tokens`), so a 1-hour session counts down against an hour, and a session that changes tier mid-run is followed. The 5-minute tier applies until the first cache write, which is the conservative direction.
+- **The TTL is detected.** Every cache write records the tier it used (`usage.cache_creation.ephemeral_5m_input_tokens` vs `ephemeral_1h_input_tokens`), so a 1-hour session counts down against an hour, and a session that changes tier mid-run is followed. Detected values take precedence over the configured fallback.
 - **The clock starts at the request**, not at the response it produced, because that is when the cache is read or written. Anchoring on the response would hand the session however long that response took to generate.
 - **Subagent responses are ignored.** A subagent runs against its own cache and does not refresh the main session's.
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ After choosing a preset, you can turn individual elements on or off.
 ### Manual Configuration
 
 Edit `~/.claude/plugins/claude-hud/config.json` directly for advanced settings such as `colors.*`,
-`pathLevels`, `maxWidth`, threshold overrides, `display.timeFormat`, and `display.promptCacheTtlSeconds`. Running `/claude-hud:configure`
+`pathLevels`, `maxWidth`, threshold overrides, `display.timeFormat`, and `display.hourCycle`. Running `/claude-hud:configure`
 preserves those manual settings while still letting you change `language`, layout, and the common
 guided toggles.
 
@@ -231,8 +231,7 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 | `display.showEffortLevel` | boolean | false | Show the current reasoning effort in the model badge. Ultracode renders as `ultracode(xhigh)`, detected from the session transcript so it tracks `/effort` changes made at runtime |
 | `display.showClaudeCodeVersion` | boolean | false | Show the installed Claude Code version, e.g. `CC v2.1.81` |
 | `display.showMemoryUsage` | boolean | false | Show an approximate system RAM usage line in expanded layout |
-| `display.showPromptCache` | boolean | false | Show a prompt cache countdown based on the last assistant response timestamp in the transcript |
-| `display.promptCacheTtlSeconds` | number | `300` | Prompt cache TTL in seconds. Keep the default for Pro, set `3600` for Max |
+| `display.showPromptCache` | boolean | false | Show the wall-clock time the session's prompt cache expires, read from the transcript |
 | `colors.context` | color value | `green` | Base color for the context bar and context percentage |
 | `colors.usage` | color value | `brightBlue` | Base color for usage bars and percentages below warning thresholds |
 | `colors.warning` | color value | `yellow` | Warning color for context thresholds and usage warning text |
@@ -257,7 +256,15 @@ Supported color names: `dim`, `red`, `green`, `yellow`, `magenta`, `cyan`, `brig
 
 Official MiniMax Anthropic-compatible endpoints receive a `MiniMax` provider label. MiniMax M2.7 can use its published token and cache prices for local estimates; M3 pricing depends on each request's context tier, which cumulative session tokens cannot safely infer, so ClaudeHUD does not guess an M3 estimate.
 
-`display.showPromptCache` is fully opt-in. When enabled, ClaudeHUD looks at the timestamp of the last assistant response in the local transcript and shows a live countdown until the prompt cache expires. The default TTL is 5 minutes (`300` seconds). Set `display.promptCacheTtlSeconds` to `3600` if you want a 1-hour Max-style window. If the transcript does not have an assistant timestamp yet, the cache element stays hidden.
+`display.showPromptCache` is fully opt-in. When enabled, ClaudeHUD shows **the wall-clock time the session's prompt cache expires** (e.g. `Cache ⏱ at 14:30`), or `expired` once that time has passed. It follows `display.hourCycle` and `display.showClockSeconds` like every other clock time in the HUD. If the transcript has no main-session response yet, the cache element stays hidden.
+
+It shows an expiry time rather than a countdown because the statusline only repaints while Claude Code is active. Between turns — exactly when the cache is draining — a countdown freezes at whatever it last displayed and keeps reporting it; a clock time stays true no matter how stale the render is.
+
+Everything the element needs comes from the transcript, so there is nothing to configure:
+
+- **The TTL is detected.** Every cache write records the tier it used (`usage.cache_creation.ephemeral_5m_input_tokens` vs `ephemeral_1h_input_tokens`), so a 1-hour session counts down against an hour, and a session that changes tier mid-run is followed. The 5-minute tier applies until the first cache write, which is the conservative direction.
+- **The clock starts at the request**, not at the response it produced, because that is when the cache is read or written. Anchoring on the response would hand the session however long that response took to generate.
+- **Subagent responses are ignored.** A subagent runs against its own cache and does not refresh the main session's.
 
 ### Usage Limits
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -153,7 +153,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 
 ### 手动配置
 
-直接编辑 `~/.claude/plugins/claude-hud/config.json` 来配置高级选项，如 `colors.*`、`pathLevels`、`maxWidth`、阈值覆盖、`display.timeFormat` 以及 `display.hourCycle`。运行 `/claude-hud:configure` 时会保留这些手动设置，同时你仍可更改 `language`、布局和常用引导式开关。
+直接编辑 `~/.claude/plugins/claude-hud/config.json` 来配置高级选项，如 `colors.*`、`pathLevels`、`maxWidth`、阈值覆盖、`display.timeFormat`、`display.hourCycle` 以及 `display.promptCacheTtlSeconds`。运行 `/claude-hud:configure` 时会保留这些手动设置，同时你仍可更改 `language`、布局和常用引导式开关。
 
 简体与繁体中文 HUD 标签均为显式 opt-in 选项。除非你在 `/claude-hud:configure` 中选择中文语言或在配置中设置 `language`，否则默认使用英文。`zh` 别名对应简体中文，`zh-TW` 对应繁体中文；引导式配置会写入规范值 `zh-Hans` 或 `zh-Hant`。
 
@@ -219,6 +219,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `display.showClaudeCodeVersion` | boolean | false | 显示已安装的 Claude Code 版本，如 `CC v2.1.81` |
 | `display.showMemoryUsage` | boolean | false | 在展开布局中显示近似系统 RAM 使用行 |
 | `display.showPromptCache` | boolean | false | 显示 prompt cache 的过期时刻，数据来自 transcript |
+| `display.promptCacheTtlSeconds` | number | `300` | 仅当 transcript 尚未报告 5 分钟或 1 小时缓存层级时使用的兼容回退值 |
 | `colors.context` | 颜色值 | `green` | 上下文进度条和百分比的基础颜色 |
 | `colors.usage` | 颜色值 | `brightBlue` | 使用率进度条和低于警告阈值时百分比的颜色 |
 | `colors.warning` | 颜色值 | `yellow` | 上下文阈值和使用率警告文本的警告颜色 |
@@ -247,9 +248,9 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 
 它显示过期时刻而不是倒计时，因为状态栏只在 Claude Code 活动时重绘。在两个回合之间——正好是缓存流失的时候——倒计时会停在最后一次显示的数值上并继续报告它；而时刻无论渲染多陈旧都仍然正确。
 
-该元素所需的数据全部来自 transcript，因此无需配置：
+ClaudeHUD 会尽可能从 transcript 检测缓存层级。对于不提供层级详情的旧版或代理 transcript，现有的 `display.promptCacheTtlSeconds` 设置仍作为回退值：
 
-- **TTL 是检测出来的。** 每次缓存写入都会记录所用的层级（`usage.cache_creation.ephemeral_5m_input_tokens` 与 `ephemeral_1h_input_tokens`），因此 1 小时的会话按 1 小时计时，中途更换层级的会话也会被跟随。首次缓存写入之前采用 5 分钟层级，这是偏保守的方向。
+- **TTL 是检测出来的。** 每次缓存写入都会记录所用的层级（`usage.cache_creation.ephemeral_5m_input_tokens` 与 `ephemeral_1h_input_tokens`），因此 1 小时的会话按 1 小时计时，中途更换层级的会话也会被跟随。检测值优先于配置的回退值。
 - **计时从请求开始**，而不是从它产生的响应开始，因为缓存是在请求时被读取或写入的。若以响应为基准，会把生成该响应所用的时间也算作可用时间。
 - **忽略 subagent 响应。** subagent 使用自己的缓存，不会刷新主会话的缓存。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -153,7 +153,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 
 ### 手动配置
 
-直接编辑 `~/.claude/plugins/claude-hud/config.json` 来配置高级选项，如 `colors.*`、`pathLevels`、`maxWidth`、阈值覆盖、`display.timeFormat` 以及 `display.promptCacheTtlSeconds`。运行 `/claude-hud:configure` 时会保留这些手动设置，同时你仍可更改 `language`、布局和常用引导式开关。
+直接编辑 `~/.claude/plugins/claude-hud/config.json` 来配置高级选项，如 `colors.*`、`pathLevels`、`maxWidth`、阈值覆盖、`display.timeFormat` 以及 `display.hourCycle`。运行 `/claude-hud:configure` 时会保留这些手动设置，同时你仍可更改 `language`、布局和常用引导式开关。
 
 简体与繁体中文 HUD 标签均为显式 opt-in 选项。除非你在 `/claude-hud:configure` 中选择中文语言或在配置中设置 `language`，否则默认使用英文。`zh` 别名对应简体中文，`zh-TW` 对应繁体中文；引导式配置会写入规范值 `zh-Hans` 或 `zh-Hant`。
 
@@ -218,8 +218,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `display.showCompactions` | boolean | false | 显示本会话已发生的上下文压缩次数（手动 `/compact` 或自动压缩），从 transcript 的 `compact_boundary` 记录计数，例如 `压缩次数: 2`。第一次压缩前不显示 |
 | `display.showClaudeCodeVersion` | boolean | false | 显示已安装的 Claude Code 版本，如 `CC v2.1.81` |
 | `display.showMemoryUsage` | boolean | false | 在展开布局中显示近似系统 RAM 使用行 |
-| `display.showPromptCache` | boolean | false | 根据 transcript 中最后一次 assistant 响应时间显示 prompt cache 倒计时 |
-| `display.promptCacheTtlSeconds` | number | `300` | Prompt cache TTL 秒数。Pro 保持默认值，Max 可设为 `3600` |
+| `display.showPromptCache` | boolean | false | 显示 prompt cache 的过期时刻，数据来自 transcript |
 | `colors.context` | 颜色值 | `green` | 上下文进度条和百分比的基础颜色 |
 | `colors.usage` | 颜色值 | `brightBlue` | 使用率进度条和低于警告阈值时百分比的颜色 |
 | `colors.warning` | 颜色值 | `yellow` | 上下文阈值和使用率警告文本的警告颜色 |
@@ -244,7 +243,15 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 
 官方 MiniMax Anthropic 兼容端点会显示 `MiniMax` 提供商标签。MiniMax M2.7 可使用其公开 token 和缓存价格进行本地估算；M3 的价格取决于单次请求的上下文层级，而累计会话 token 无法安全推断该层级，因此不会猜测 M3 费用。
 
-`display.showPromptCache` 为完全 opt-in 选项。启用后，ClaudeHUD 会读取本地 transcript 中最后一次 assistant 响应的时间戳，并显示距离 prompt cache 过期还剩多久。默认 TTL 为 5 分钟（`300` 秒）。如果你想按 1 小时的 Max 风格窗口显示，可将 `display.promptCacheTtlSeconds` 设为 `3600`。如果 transcript 里还没有 assistant 时间戳，这个元素会继续隐藏。
+`display.showPromptCache` 为完全 opt-in 选项。启用后，ClaudeHUD 会显示 **prompt cache 的过期时刻**（例如 `Cache ⏱ at 14:30`），过期后显示 `expired`。它与 HUD 中其他时刻一样遵循 `display.hourCycle` 和 `display.showClockSeconds`。如果 transcript 里还没有主会话响应，这个元素会继续隐藏。
+
+它显示过期时刻而不是倒计时，因为状态栏只在 Claude Code 活动时重绘。在两个回合之间——正好是缓存流失的时候——倒计时会停在最后一次显示的数值上并继续报告它；而时刻无论渲染多陈旧都仍然正确。
+
+该元素所需的数据全部来自 transcript，因此无需配置：
+
+- **TTL 是检测出来的。** 每次缓存写入都会记录所用的层级（`usage.cache_creation.ephemeral_5m_input_tokens` 与 `ephemeral_1h_input_tokens`），因此 1 小时的会话按 1 小时计时，中途更换层级的会话也会被跟随。首次缓存写入之前采用 5 分钟层级，这是偏保守的方向。
+- **计时从请求开始**，而不是从它产生的响应开始，因为缓存是在请求时被读取或写入的。若以响应为基准，会把生成该响应所用的时间也算作可用时间。
+- **忽略 subagent 响应。** subagent 使用自己的缓存，不会刷新主会话的缓存。
 
 ### 使用率限制
 

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -21,7 +21,7 @@ Advanced settings such as `colors.*`, `pathLevels`, `maxWidth`, `forceMaxWidth`,
 `elementOrder`, `projectLineOrder`, `display.mergeGroups`, `display.timeFormat`, `display.contextValue`,
 `display.modelFormat`, `display.modelOverride`, `display.modelSource`, `display.showProvider`,
 `display.providerName`, `display.autocompactBuffer`,
-`display.autoCompactWindow`, `display.promptCacheTtlSeconds`,
+`display.autoCompactWindow`,
 `display.usageThreshold`, `display.sevenDayThreshold`,
 `display.environmentThreshold`, `display.contextWarningThreshold`,
 `display.contextCriticalThreshold`, `display.advisorOverride`,
@@ -332,7 +332,7 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 | Reasoning level | `display.showEffortLevel` |
 | Output style | `display.showOutputStyle` |
 | Memory usage | `display.showMemoryUsage` |
-| Prompt cache | `display.showPromptCache` (TTL via `display.promptCacheTtlSeconds`) |
+| Prompt cache | `display.showPromptCache` (TTL detected from the transcript) |
 | Claude Code version | `display.showClaudeCodeVersion` |
 | Advisor model | `display.showAdvisor` (override via `display.advisorOverride`) |
 | Custom line | `display.customLine` |

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -332,7 +332,7 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 | Reasoning level | `display.showEffortLevel` |
 | Output style | `display.showOutputStyle` |
 | Memory usage | `display.showMemoryUsage` |
-| Prompt cache | `display.showPromptCache` (TTL detected from the transcript) |
+| Prompt cache | `display.showPromptCache` (transcript tier wins; `display.promptCacheTtlSeconds` is the fallback) |
 | Claude Code version | `display.showClaudeCodeVersion` |
 | Advisor model | `display.showAdvisor` (override via `display.advisorOverride`) |
 | Custom line | `display.customLine` |

--- a/src/config.ts
+++ b/src/config.ts
@@ -209,9 +209,10 @@ export interface HudConfig {
     showClaudeCodeVersion: boolean;
     showEffortLevel: boolean;
     showMemoryUsage: boolean;
-    // The prompt cache TTL is not configurable: it is detected from the
-    // transcript, where every cache write records the tier it used.
     showPromptCache: boolean;
+    // Compatibility fallback used only until transcript tier detection has a
+    // real 5-minute or 1-hour cache write to follow.
+    promptCacheTtlSeconds: number;
     showSessionTokens: boolean;
     showOutputStyle: boolean;
     showSessionStartDate: boolean;
@@ -324,6 +325,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showEffortLevel: false,
     showMemoryUsage: false,
     showPromptCache: false,
+    promptCacheTtlSeconds: 300,
     showSessionTokens: false,
     showOutputStyle: false,
     showSessionStartDate: false,
@@ -632,6 +634,13 @@ function validateCountThreshold(value: unknown): number {
   return Math.max(0, Math.floor(value));
 }
 
+function validateDurationSeconds(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
 function validateNonNegativeInteger(value: unknown, fallback: number): number {
   if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
     return fallback;
@@ -818,6 +827,10 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showPromptCache: typeof migrated.display?.showPromptCache === 'boolean'
       ? migrated.display.showPromptCache
       : DEFAULT_CONFIG.display.showPromptCache,
+    promptCacheTtlSeconds: validateDurationSeconds(
+      migrated.display?.promptCacheTtlSeconds,
+      DEFAULT_CONFIG.display.promptCacheTtlSeconds,
+    ),
     showSessionTokens: typeof migrated.display?.showSessionTokens === 'boolean'
       ? migrated.display.showSessionTokens
       : DEFAULT_CONFIG.display.showSessionTokens,

--- a/src/config.ts
+++ b/src/config.ts
@@ -209,8 +209,9 @@ export interface HudConfig {
     showClaudeCodeVersion: boolean;
     showEffortLevel: boolean;
     showMemoryUsage: boolean;
+    // The prompt cache TTL is not configurable: it is detected from the
+    // transcript, where every cache write records the tier it used.
     showPromptCache: boolean;
-    promptCacheTtlSeconds: number;
     showSessionTokens: boolean;
     showOutputStyle: boolean;
     showSessionStartDate: boolean;
@@ -323,7 +324,6 @@ export const DEFAULT_CONFIG: HudConfig = {
     showEffortLevel: false,
     showMemoryUsage: false,
     showPromptCache: false,
-    promptCacheTtlSeconds: 300,
     showSessionTokens: false,
     showOutputStyle: false,
     showSessionStartDate: false,
@@ -632,13 +632,6 @@ function validateCountThreshold(value: unknown): number {
   return Math.max(0, Math.floor(value));
 }
 
-function validateDurationSeconds(value: unknown, fallback: number): number {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    return fallback;
-  }
-  return Math.floor(value);
-}
-
 function validateNonNegativeInteger(value: unknown, fallback: number): number {
   if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
     return fallback;
@@ -825,10 +818,6 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showPromptCache: typeof migrated.display?.showPromptCache === 'boolean'
       ? migrated.display.showPromptCache
       : DEFAULT_CONFIG.display.showPromptCache,
-    promptCacheTtlSeconds: validateDurationSeconds(
-      migrated.display?.promptCacheTtlSeconds,
-      DEFAULT_CONFIG.display.promptCacheTtlSeconds,
-    ),
     showSessionTokens: typeof migrated.display?.showSessionTokens === 'boolean'
       ? migrated.display.showSessionTokens
       : DEFAULT_CONFIG.display.showSessionTokens,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,3 +8,26 @@
  * report mismatches in future Claude Code versions.
  */
 export const AUTOCOMPACT_BUFFER_PERCENT = 0.165;
+
+/**
+ * Prompt cache TTL tiers, in seconds. The API offers exactly these two (5
+ * minutes and 1 hour) and every cache write records which one it used, so the
+ * TTL is read from the transcript rather than configured.
+ */
+export const PROMPT_CACHE_TTL_5M_SECONDS = 300;
+export const PROMPT_CACHE_TTL_1H_SECONDS = 3600;
+
+/**
+ * Shortest tier, used until a cache write has been seen. Conservative on
+ * purpose: it reports expiry early rather than promising time that is gone.
+ */
+export const PROMPT_CACHE_DEFAULT_TTL_SECONDS = PROMPT_CACHE_TTL_5M_SECONDS;
+
+/**
+ * True only for a TTL that a real cache write could have produced. Applied to
+ * values read back from the transcript cache file, where anything else means
+ * the snapshot is corrupt and the detected TTL should be dropped.
+ */
+export function isDetectedPromptCacheTtl(value: unknown): value is number {
+  return value === PROMPT_CACHE_TTL_5M_SECONDS || value === PROMPT_CACHE_TTL_1H_SECONDS;
+}

--- a/src/render/format-reset-time.ts
+++ b/src/render/format-reset-time.ts
@@ -36,7 +36,7 @@ export function formatResetTime(
     return formatRelative(diffMs);
   }
 
-  const absolute = formatAbsolute(resetAt, now, opts);
+  const absolute = formatAbsoluteTime(resetAt, now, opts);
 
   if (mode === 'absolute') {
     return absolute;
@@ -66,7 +66,19 @@ function formatRelative(diffMs: number): string {
   return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
 }
 
-function formatAbsolute(resetAt: Date, now: Date, opts: WallClockOptions): string {
+/**
+ * Renders a timestamp as wall-clock time, e.g. `at 14:30`, adding a date
+ * component when it falls on a different calendar day than `now`.
+ *
+ * @param at   - The timestamp to render.
+ * @param now  - Reference for the same-day check.
+ * @param opts - Wall-clock rendering options (hourCycle, showSeconds).
+ */
+export function formatAbsoluteTime(
+  resetAt: Date,
+  now: Date,
+  opts: WallClockOptions = DEFAULT_WALL_CLOCK_OPTIONS,
+): string {
   // The preposition + spacing live in each locale's "format.absoluteTime"
   // pattern (en: "at {time}", zh: "{time}" — bare, preposition baked elsewhere).
   const timeOpts: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit' };

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -2,7 +2,7 @@ export { renderIdentityLine } from './identity.js';
 export { renderProjectLine, renderGitFilesLine } from './project.js';
 export { renderAddedDirsLine } from './added-dirs.js';
 export { renderEnvironmentLine } from './environment.js';
-export { renderPromptCacheLine, formatPromptCacheCountdown } from './prompt-cache.js';
+export { renderPromptCacheLine } from './prompt-cache.js';
 export { renderUsageLine } from './usage.js';
 export { renderMemoryLine } from './memory.js';
 export { renderSessionTokensLine } from './session-tokens.js';

--- a/src/render/lines/prompt-cache.ts
+++ b/src/render/lines/prompt-cache.ts
@@ -1,5 +1,7 @@
 import type { RenderContext } from '../../types.js';
+import { isDetectedPromptCacheTtl, PROMPT_CACHE_DEFAULT_TTL_SECONDS } from '../../constants.js';
 import { getContextColor, RESET, label, warning as warningColor } from '../colors.js';
+import { formatAbsoluteTime, type WallClockOptions } from '../format-reset-time.js';
 import { t } from '../../i18n/index.js';
 
 function getPromptCacheWarningSeconds(ttlSeconds: number): number {
@@ -22,48 +24,42 @@ function colorPromptCacheValue(
   return `${getContextColor(0, ctx.config?.colors)}${value}${RESET}`;
 }
 
-export function formatPromptCacheCountdown(remainingMs: number): string {
-  if (remainingMs <= 0) {
-    return t('status.expired');
-  }
-
-  const totalSeconds = Math.ceil(remainingMs / 1000);
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
-
-  if (hours > 0) {
-    return `${hours}h ${minutes}m ${seconds}s`;
-  }
-
-  return `${minutes}m ${seconds}s`;
-}
-
 export function renderPromptCacheLine(ctx: RenderContext, now: number = Date.now()): string | null {
   const display = ctx.config?.display;
   if (!display?.showPromptCache) {
     return null;
   }
 
-  const lastAssistantResponseAt = ctx.transcript.lastAssistantResponseAt;
-  if (!lastAssistantResponseAt || Number.isNaN(lastAssistantResponseAt.getTime())) {
+  const anchorAt = ctx.transcript.promptCacheAnchorAt;
+  if (!anchorAt || Number.isNaN(anchorAt.getTime())) {
     return null;
   }
 
-  const ttlSeconds = (
-    typeof display.promptCacheTtlSeconds === 'number'
-    && Number.isFinite(display.promptCacheTtlSeconds)
-    && display.promptCacheTtlSeconds > 0
-  )
-    ? Math.floor(display.promptCacheTtlSeconds)
-    : 300;
+  // The TTL comes from the transcript, since every cache write records the tier
+  // it used. The default applies only until the session's first cache write.
+  const ttlSeconds = isDetectedPromptCacheTtl(ctx.transcript.promptCacheTtlSeconds)
+    ? ctx.transcript.promptCacheTtlSeconds
+    : PROMPT_CACHE_DEFAULT_TTL_SECONDS;
 
-  const remainingMs = (lastAssistantResponseAt.getTime() + ttlSeconds * 1000) - now;
+  const expiresAt = new Date(anchorAt.getTime() + ttlSeconds * 1000);
+  const remainingMs = expiresAt.getTime() - now;
   const state = remainingMs <= 0
     ? 'expired'
     : remainingMs <= getPromptCacheWarningSeconds(ttlSeconds) * 1000
       ? 'warning'
       : 'active';
 
-  return `${label(t('label.promptCache'), ctx.config?.colors)} ${colorPromptCacheValue(`⏱ ${formatPromptCacheCountdown(remainingMs)}`, state, ctx)}`;
+  // Expiry time rather than a countdown: the statusline only repaints while
+  // Claude Code is active, so between turns — exactly when the cache is draining
+  // — a countdown freezes at whatever it last displayed and keeps reporting it.
+  // A clock time stays true however stale the render is.
+  const wallClockOpts: WallClockOptions = {
+    hourCycle: display.hourCycle ?? 'auto',
+    showSeconds: display.showClockSeconds ?? false,
+  };
+  const value = state === 'expired'
+    ? t('status.expired')
+    : formatAbsoluteTime(expiresAt, new Date(now), wallClockOpts);
+
+  return `${label(t('label.promptCache'), ctx.config?.colors)} ${colorPromptCacheValue(`⏱ ${value}`, state, ctx)}`;
 }

--- a/src/render/lines/prompt-cache.ts
+++ b/src/render/lines/prompt-cache.ts
@@ -35,11 +35,17 @@ export function renderPromptCacheLine(ctx: RenderContext, now: number = Date.now
     return null;
   }
 
-  // The TTL comes from the transcript, since every cache write records the tier
-  // it used. The default applies only until the session's first cache write.
+  // A detected transcript tier is authoritative. Preserve the existing config
+  // setting as a compatibility fallback for older or proxied transcripts that
+  // do not expose the per-tier cache creation fields.
+  const configuredTtl = typeof display.promptCacheTtlSeconds === 'number'
+    && Number.isFinite(display.promptCacheTtlSeconds)
+    && display.promptCacheTtlSeconds > 0
+    ? Math.floor(display.promptCacheTtlSeconds)
+    : PROMPT_CACHE_DEFAULT_TTL_SECONDS;
   const ttlSeconds = isDetectedPromptCacheTtl(ctx.transcript.promptCacheTtlSeconds)
     ? ctx.transcript.promptCacheTtlSeconds
-    : PROMPT_CACHE_DEFAULT_TTL_SECONDS;
+    : configuredTtl;
 
   const expiresAt = new Date(anchorAt.getTime() + ttlSeconds * 1000);
   const remainingMs = expiresAt.getTime() - now;

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -131,6 +131,7 @@ const TRANSCRIPT_CACHE_VERSION = 16;
 const MCP_TOOL_NAME_PATTERN = /^mcp__(.+?)__(.+)$/;
 const ACTIVITY_NAME_MAX_LEN = 64;
 const MESSAGE_ID_MAX_LEN = 128;
+const REQUEST_ID_MAX_LEN = 128;
 const MESSAGE_USAGE_MAX = 4096;
 const MCP_ERROR_SERVERS_MAX = 64;
 
@@ -182,6 +183,12 @@ function normalizeMessageId(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 && value.length <= MESSAGE_ID_MAX_LEN
     ? value
     : null;
+}
+
+function normalizeRequestId(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 && value.length <= REQUEST_ID_MAX_LEN
+    ? value
+    : undefined;
 }
 
 function accumulateMessageUsage(
@@ -631,9 +638,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
           const entryHasTime = entryAt !== null && !Number.isNaN(entryAt.getTime());
 
           if (entry.type === 'assistant' && entryHasTime) {
-            const requestId = typeof entry.requestId === 'string' && entry.requestId.length > 0
-              ? entry.requestId
-              : undefined;
+            const requestId = normalizeRequestId(entry.requestId);
             // An absent requestId (very old transcripts) makes every record its
             // own request, which anchors to the preceding record — later than the
             // true request start, but never later than the response itself.

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -8,6 +8,11 @@ import { createDebug } from './debug.js';
 import type { TranscriptData, ToolEntry, AgentEntry, TodoItem, SessionTokenUsage } from './types.js';
 import { sanitizeDisplayText } from './utils/sanitize.js';
 import { sanitizeTranscriptModel } from './model-source.js';
+import {
+  isDetectedPromptCacheTtl,
+  PROMPT_CACHE_TTL_1H_SECONDS,
+  PROMPT_CACHE_TTL_5M_SECONDS,
+} from './constants.js';
 
 const debug = createDebug('transcript');
 
@@ -19,6 +24,14 @@ interface TranscriptLine {
   content?: string;
   slug?: string;
   customTitle?: string;
+  // True on subagent (Task tool) records. These are interleaved into the main
+  // session's transcript but belong to a separate conversation with its own
+  // prompt cache.
+  isSidechain?: boolean;
+  // Shared by every record that came out of one API request. A single request
+  // usually writes several assistant records, so this is what groups them back
+  // together when locating the request's start.
+  requestId?: string;
   // Top-level field stamped onto every assistant record after `/advisor` is
   // set. Holds the canonical advisor model ID (e.g. "claude-opus-4-7").
   advisorModel?: string;
@@ -33,6 +46,13 @@ interface TranscriptLine {
       output_tokens?: number;
       cache_creation_input_tokens?: number;
       cache_read_input_tokens?: number;
+      // Per-tier breakdown of the cache write, reporting which TTL the request
+      // actually used. A request that only reads the cache writes nothing and
+      // leaves both counters at zero.
+      cache_creation?: {
+        ephemeral_1h_input_tokens?: number;
+        ephemeral_5m_input_tokens?: number;
+      };
     };
   };
   // Result payload the harness stamps onto the record carrying a tool_result
@@ -89,6 +109,8 @@ interface SerializedTranscriptData {
   sessionStart?: string;
   sessionName?: string;
   lastAssistantResponseAt?: string;
+  promptCacheAnchorAt?: string;
+  promptCacheTtlSeconds?: number;
   sessionTokens?: SessionTokenUsage;
   lastCompactBoundaryAt?: string;
   lastCompactPostTokens?: number;
@@ -105,7 +127,7 @@ interface TranscriptCacheFile {
   data: SerializedTranscriptData;
 }
 
-const TRANSCRIPT_CACHE_VERSION = 15;
+const TRANSCRIPT_CACHE_VERSION = 16;
 const MCP_TOOL_NAME_PATTERN = /^mcp__(.+?)__(.+)$/;
 const ACTIVITY_NAME_MAX_LEN = 64;
 const MESSAGE_ID_MAX_LEN = 128;
@@ -126,6 +148,34 @@ function normalizeTokenCount(value: unknown): number {
   }
 
   return Math.max(0, Math.trunc(value));
+}
+
+/**
+ * Reads the TTL a request actually used from its per-tier cache-write counters,
+ * so the cache clock does not depend on the user naming the right tier.
+ *
+ * Returns undefined when the request wrote nothing — a pure cache read leaves
+ * both counters at zero — which keeps the tier detected earlier in the session.
+ * Mixed tiers are representable, since one request may carry several cache
+ * breakpoints, and take the shortest: that is the first part of the prefix to
+ * lapse, so it is when the cached prompt stops being whole.
+ */
+function detectPromptCacheTtlSeconds(
+  cacheCreation: { ephemeral_1h_input_tokens?: number; ephemeral_5m_input_tokens?: number } | undefined,
+): number | undefined {
+  if (!cacheCreation) {
+    return undefined;
+  }
+
+  if (normalizeTokenCount(cacheCreation.ephemeral_5m_input_tokens) > 0) {
+    return PROMPT_CACHE_TTL_5M_SECONDS;
+  }
+
+  if (normalizeTokenCount(cacheCreation.ephemeral_1h_input_tokens) > 0) {
+    return PROMPT_CACHE_TTL_1H_SECONDS;
+  }
+
+  return undefined;
 }
 
 function normalizeMessageId(value: unknown): string | null {
@@ -269,6 +319,8 @@ function serializeTranscriptData(data: TranscriptData): SerializedTranscriptData
     sessionStart: data.sessionStart?.toISOString(),
     sessionName: data.sessionName,
     lastAssistantResponseAt: data.lastAssistantResponseAt?.toISOString(),
+    promptCacheAnchorAt: data.promptCacheAnchorAt?.toISOString(),
+    promptCacheTtlSeconds: data.promptCacheTtlSeconds,
     sessionTokens: data.sessionTokens,
     lastCompactBoundaryAt: data.lastCompactBoundaryAt?.toISOString(),
     lastCompactPostTokens: data.lastCompactPostTokens,
@@ -299,6 +351,13 @@ function deserializeTranscriptData(data: SerializedTranscriptData): TranscriptDa
     sessionStart: data.sessionStart ? new Date(data.sessionStart) : undefined,
     sessionName: data.sessionName,
     lastAssistantResponseAt: data.lastAssistantResponseAt ? new Date(data.lastAssistantResponseAt) : undefined,
+    promptCacheAnchorAt: data.promptCacheAnchorAt ? new Date(data.promptCacheAnchorAt) : undefined,
+    // Only a real tier is accepted back. Detection can produce nothing else, so
+    // any other value means a corrupt snapshot, and dropping it falls back to
+    // the default TTL instead of counting down against a fabricated one.
+    promptCacheTtlSeconds: isDetectedPromptCacheTtl(data.promptCacheTtlSeconds)
+      ? data.promptCacheTtlSeconds
+      : undefined,
     sessionTokens: normalizeSessionTokens(data.sessionTokens),
     lastCompactBoundaryAt: data.lastCompactBoundaryAt ? new Date(data.lastCompactBoundaryAt) : undefined,
     lastCompactPostTokens: typeof data.lastCompactPostTokens === 'number' ? data.lastCompactPostTokens : undefined,
@@ -415,6 +474,14 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   };
   const usageByMessageId = new Map<string, SessionTokenUsage>();
   let lastUsageKey: string | undefined;
+  // Prompt-cache clock state. `prevMainChainAt` trails the main conversation so
+  // a response can be anchored to the record it answers; the request fields hold
+  // the anchor for the request currently being read.
+  let prevMainChainAt: Date | undefined;
+  let promptCacheAnchorAt: Date | undefined;
+  let promptCacheTtlSeconds: number | undefined;
+  let promptCacheRequestId: string | undefined;
+  let promptCacheRequestAnchorAt: Date | undefined;
 
   let parsedCleanly = false;
 
@@ -549,6 +616,50 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
             }
           }
         }
+        // Prompt-cache clock, tracked apart from lastAssistantResponseAt so the
+        // last-response element keeps its current subagent-inclusive meaning.
+        //
+        // Two corrections live here. Subagent records are skipped, because a
+        // subagent runs against its own cache and does not refresh the main
+        // session's. And a response is anchored to the record it answers rather
+        // than to itself, because the cache lifetime starts with the request that
+        // reads or writes the cache — anchoring on the response would hand the
+        // session however long that response took to generate. Records sharing a
+        // requestId came from one request and so share one anchor.
+        if (entry.isSidechain !== true) {
+          const entryAt = entry.timestamp ? new Date(entry.timestamp) : null;
+          const entryHasTime = entryAt !== null && !Number.isNaN(entryAt.getTime());
+
+          if (entry.type === 'assistant' && entryHasTime) {
+            const requestId = typeof entry.requestId === 'string' && entry.requestId.length > 0
+              ? entry.requestId
+              : undefined;
+            // An absent requestId (very old transcripts) makes every record its
+            // own request, which anchors to the preceding record — later than the
+            // true request start, but never later than the response itself.
+            if (requestId === undefined || requestId !== promptCacheRequestId) {
+              promptCacheRequestId = requestId;
+              promptCacheRequestAnchorAt = prevMainChainAt;
+            }
+            // No preceding record, or one stamped after the response it triggered:
+            // fall back to the response, which is the latest defensible anchor.
+            promptCacheAnchorAt = (
+              promptCacheRequestAnchorAt
+              && promptCacheRequestAnchorAt.getTime() <= entryAt.getTime()
+            )
+              ? promptCacheRequestAnchorAt
+              : entryAt;
+
+            const detectedTtl = detectPromptCacheTtlSeconds(entry.message?.usage?.cache_creation);
+            if (detectedTtl !== undefined) {
+              promptCacheTtlSeconds = detectedTtl;
+            }
+          }
+
+          if (entryHasTime) {
+            prevMainChainAt = entryAt;
+          }
+        }
         processEntry(entry, toolMap, skillSet, mcpServerSet, mcpErrorSet, agentMap, taskIdToIndex, latestTodos, result);
       } catch (err) {
         lastUsageKey = undefined;
@@ -589,6 +700,8 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   result.compactionCount = compactionCount;
   result.advisorModel = latestAdvisorModel;
   result.ultracodeActive = latestUltracodeActive;
+  result.promptCacheAnchorAt = promptCacheAnchorAt;
+  result.promptCacheTtlSeconds = promptCacheTtlSeconds;
   if (parsedCleanly) {
     writeTranscriptCache(canonicalTranscriptPath, transcriptState, result);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,7 +162,18 @@ export interface TranscriptData {
   todos: TodoItem[];
   sessionStart?: Date;
   sessionName?: string;
+  // Last assistant response of any kind, subagents included. Drives the
+  // last-response element.
   lastAssistantResponseAt?: Date;
+  // Start of the request that last read or wrote the main session's prompt
+  // cache, which is when its TTL began. Main-chain only and deliberately not
+  // the same value as lastAssistantResponseAt: see the prompt-cache block in
+  // parseTranscript for why each is measured the way it is.
+  promptCacheAnchorAt?: Date;
+  // TTL in seconds that same request used, read from its per-tier cache-write
+  // counters. Either 300 or 3600, or undefined when the session has not written
+  // a cache yet, in which case the default tier applies.
+  promptCacheTtlSeconds?: number;
   sessionTokens?: SessionTokenUsage;
   lastCompactBoundaryAt?: Date;
   lastCompactPostTokens?: number;

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -185,13 +185,12 @@ test('mergeConfig preserves explicit showPromptCache=true', () => {
   assert.equal(config.display.showPromptCache, true);
 });
 
-test('mergeConfig ignores the removed promptCacheTtlSeconds setting', () => {
-  // The TTL is detected from the transcript, so this key is no longer part of
-  // the config. An existing one in a user's file is dropped, not carried.
-  assert.equal(DEFAULT_CONFIG.display.promptCacheTtlSeconds, undefined);
+test('mergeConfig preserves promptCacheTtlSeconds as a validated fallback', () => {
+  assert.equal(DEFAULT_CONFIG.display.promptCacheTtlSeconds, 300);
   const config = mergeConfig({ display: { promptCacheTtlSeconds: 3600 } });
-  assert.equal(config.display.promptCacheTtlSeconds, undefined);
+  assert.equal(config.display.promptCacheTtlSeconds, 3600);
   assert.equal(config.display.showPromptCache, false);
+  assert.equal(mergeConfig({ display: { promptCacheTtlSeconds: 0 } }).display.promptCacheTtlSeconds, 300);
 });
 
 test('mergeConfig defaults showCost to false', () => {

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -72,7 +72,6 @@ test('loadConfig returns valid config structure', async () => {
   assert.equal(typeof config.display.showClaudeCodeVersion, 'boolean');
   assert.equal(typeof config.display.showMemoryUsage, 'boolean');
   assert.equal(typeof config.display.showPromptCache, 'boolean');
-  assert.equal(typeof config.display.promptCacheTtlSeconds, 'number');
   assert.equal(typeof config.display.showCost, 'boolean');
   assert.equal(typeof config.display.showRoutedCost, 'boolean');
   assert.equal(typeof config.display.showOutputStyle, 'boolean');
@@ -186,21 +185,13 @@ test('mergeConfig preserves explicit showPromptCache=true', () => {
   assert.equal(config.display.showPromptCache, true);
 });
 
-test('mergeConfig defaults promptCacheTtlSeconds to 300', () => {
-  const config = mergeConfig({});
-  assert.equal(config.display.promptCacheTtlSeconds, 300);
-  assert.equal(DEFAULT_CONFIG.display.promptCacheTtlSeconds, 300);
-});
-
-test('mergeConfig preserves valid promptCacheTtlSeconds values', () => {
+test('mergeConfig ignores the removed promptCacheTtlSeconds setting', () => {
+  // The TTL is detected from the transcript, so this key is no longer part of
+  // the config. An existing one in a user's file is dropped, not carried.
+  assert.equal(DEFAULT_CONFIG.display.promptCacheTtlSeconds, undefined);
   const config = mergeConfig({ display: { promptCacheTtlSeconds: 3600 } });
-  assert.equal(config.display.promptCacheTtlSeconds, 3600);
-});
-
-test('mergeConfig falls back to default promptCacheTtlSeconds for invalid values', () => {
-  assert.equal(mergeConfig({ display: { promptCacheTtlSeconds: 0 } }).display.promptCacheTtlSeconds, 300);
-  assert.equal(mergeConfig({ display: { promptCacheTtlSeconds: -1 } }).display.promptCacheTtlSeconds, 300);
-  assert.equal(mergeConfig({ display: { promptCacheTtlSeconds: 'fast' } }).display.promptCacheTtlSeconds, 300);
+  assert.equal(config.display.promptCacheTtlSeconds, undefined);
+  assert.equal(config.display.showPromptCache, false);
 });
 
 test('mergeConfig defaults showCost to false', () => {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -947,6 +947,198 @@ test('parseTranscript captures the last assistant response timestamp', async () 
   }
 });
 
+// ---------------------------------------------------------------------------
+// Prompt cache clock
+// ---------------------------------------------------------------------------
+
+/** Assistant record carrying a cache write on the given tier. */
+function cacheWrite(fields, tier) {
+  const cache_creation = tier === '1h'
+    ? { ephemeral_1h_input_tokens: 1128, ephemeral_5m_input_tokens: 0 }
+    : tier === '5m'
+      ? { ephemeral_1h_input_tokens: 0, ephemeral_5m_input_tokens: 1128 }
+      : tier;
+  return {
+    type: 'assistant',
+    ...fields,
+    message: { usage: { input_tokens: 4, output_tokens: 8, cache_creation } },
+  };
+}
+
+test('parseTranscript anchors the prompt cache clock to the request, not the response', async () => {
+  const result = await parseTempTranscript('cache-anchor.jsonl', [
+    { type: 'user', timestamp: '2024-01-01T00:00:00.000Z' },
+    // A response 90s later must not push the clock 90s out: the cache was
+    // written when the request went out, at the user record.
+    cacheWrite({ timestamp: '2024-01-01T00:01:30.000Z', requestId: 'req-1' }, '5m'),
+  ]);
+
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:00.000Z');
+  assert.equal(result.lastAssistantResponseAt?.toISOString(), '2024-01-01T00:01:30.000Z');
+});
+
+test('parseTranscript shares one anchor across records from the same request', async () => {
+  const result = await parseTempTranscript('cache-request-group.jsonl', [
+    { type: 'user', timestamp: '2024-01-01T00:00:00.000Z' },
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '5m'),
+    // Same request, second record. The first record is not the request start.
+    cacheWrite({ timestamp: '2024-01-01T00:00:20.000Z', requestId: 'req-1' }, '5m'),
+  ]);
+
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:00.000Z');
+});
+
+test('parseTranscript re-anchors on each new request', async () => {
+  const result = await parseTempTranscript('cache-next-request.jsonl', [
+    { type: 'user', timestamp: '2024-01-01T00:00:00.000Z' },
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '5m'),
+    // Tool result, then the follow-up request it triggers.
+    { type: 'user', timestamp: '2024-01-01T00:00:30.000Z' },
+    cacheWrite({ timestamp: '2024-01-01T00:00:40.000Z', requestId: 'req-2' }, '5m'),
+  ]);
+
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:30.000Z');
+});
+
+test('parseTranscript falls back to the response when nothing precedes it', async () => {
+  const result = await parseTempTranscript('cache-no-parent.jsonl', [
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '5m'),
+  ]);
+
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:10.000Z');
+});
+
+test('parseTranscript ignores an anchor stamped after the response', async () => {
+  const result = await parseTempTranscript('cache-anchor-inverted.jsonl', [
+    { type: 'user', timestamp: '2024-01-01T00:05:00.000Z' },
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '5m'),
+  ]);
+
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:10.000Z');
+});
+
+test('parseTranscript keeps subagent records out of the prompt cache clock', async () => {
+  const result = await parseTempTranscript('cache-sidechain.jsonl', [
+    { type: 'user', timestamp: '2024-01-01T00:00:00.000Z' },
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '5m'),
+    // A subagent runs for 10 minutes on the 1h tier. Neither its clock nor its
+    // tier belongs to the main session.
+    { type: 'user', timestamp: '2024-01-01T00:00:20.000Z', isSidechain: true },
+    cacheWrite({ timestamp: '2024-01-01T00:10:00.000Z', requestId: 'req-2', isSidechain: true }, '1h'),
+  ]);
+
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:00.000Z');
+  assert.equal(result.promptCacheTtlSeconds, 300);
+  // The last-response element keeps counting subagents, as it always has.
+  assert.equal(result.lastAssistantResponseAt?.toISOString(), '2024-01-01T00:10:00.000Z');
+});
+
+test('parseTranscript does not let a subagent record become the next anchor', async () => {
+  const result = await parseTempTranscript('cache-sidechain-anchor.jsonl', [
+    { type: 'user', timestamp: '2024-01-01T00:00:00.000Z' },
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '5m'),
+    { type: 'assistant', timestamp: '2024-01-01T00:03:00.000Z', requestId: 'req-x', isSidechain: true },
+    // Main-chain tool result, then the request it triggers. The anchor is the
+    // tool result, never the subagent record that happens to sit before it.
+    { type: 'user', timestamp: '2024-01-01T00:04:00.000Z' },
+    cacheWrite({ timestamp: '2024-01-01T00:04:10.000Z', requestId: 'req-2' }, '5m'),
+  ]);
+
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:04:00.000Z');
+});
+
+test('parseTranscript detects the prompt cache TTL tier', async () => {
+  const oneHour = await parseTempTranscript('cache-ttl-1h.jsonl', [
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '1h'),
+  ]);
+  assert.equal(oneHour.promptCacheTtlSeconds, 3600);
+
+  const fiveMin = await parseTempTranscript('cache-ttl-5m.jsonl', [
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '5m'),
+  ]);
+  assert.equal(fiveMin.promptCacheTtlSeconds, 300);
+});
+
+test('parseTranscript follows a mid-session tier change', async () => {
+  const result = await parseTempTranscript('cache-ttl-change.jsonl', [
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '1h'),
+    cacheWrite({ timestamp: '2024-01-01T00:05:10.000Z', requestId: 'req-2' }, '5m'),
+  ]);
+
+  assert.equal(result.promptCacheTtlSeconds, 300);
+});
+
+test('parseTranscript takes the shortest tier when a request writes both', async () => {
+  const result = await parseTempTranscript('cache-ttl-mixed.jsonl', [
+    cacheWrite(
+      { timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' },
+      { ephemeral_1h_input_tokens: 2048, ephemeral_5m_input_tokens: 512 },
+    ),
+  ]);
+
+  assert.equal(result.promptCacheTtlSeconds, 300);
+});
+
+test('parseTranscript keeps the detected tier through a pure cache read', async () => {
+  const result = await parseTempTranscript('cache-ttl-carry.jsonl', [
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '1h'),
+    // Reads the cache, writes nothing: both counters zero, tier unchanged.
+    cacheWrite(
+      { timestamp: '2024-01-01T00:01:10.000Z', requestId: 'req-2' },
+      { ephemeral_1h_input_tokens: 0, ephemeral_5m_input_tokens: 0 },
+    ),
+  ]);
+
+  assert.equal(result.promptCacheTtlSeconds, 3600);
+});
+
+test('parseTranscript reports no tier when nothing has written a cache', async () => {
+  const result = await parseTempTranscript('cache-ttl-absent.jsonl', [
+    { type: 'user', timestamp: '2024-01-01T00:00:00.000Z' },
+    {
+      type: 'assistant',
+      timestamp: '2024-01-01T00:00:10.000Z',
+      requestId: 'req-1',
+      message: { usage: { input_tokens: 4, output_tokens: 8 } },
+    },
+  ]);
+
+  assert.equal(result.promptCacheTtlSeconds, undefined);
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:00.000Z');
+});
+
+test('parseTranscript drops a cached TTL that is not a real tier', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-transcript-cache-'));
+  const configDir = path.join(dir, '.claude-test');
+  const transcriptPath = path.join(dir, 'cache-ttl-poison.jsonl');
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  const line = `${JSON.stringify(
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '1h'),
+  )}\n`;
+
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  await writeFile(transcriptPath, line, 'utf8');
+
+  try {
+    const first = await parseTranscript(transcriptPath);
+    assert.equal(first.promptCacheTtlSeconds, 3600);
+
+    const cachePath = await getTranscriptCacheFile(configDir);
+    const cache = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    cache.data.promptCacheTtlSeconds = 86_400;
+    await writeFile(cachePath, JSON.stringify(cache), 'utf8');
+
+    const second = await parseTranscript(transcriptPath);
+    assert.equal(second.promptCacheTtlSeconds, undefined,
+      'a TTL no cache write could have produced must not survive the round-trip');
+    assert.equal(second.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:10.000Z',
+      'the anchor must still survive the cache round-trip');
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 const ULTRA_ENTER = { type: 'attachment', attachment: { type: 'ultra_effort_enter' } };
 const ULTRA_EXIT = { type: 'attachment', attachment: { type: 'ultra_effort_exit' } };
 const effortCmd = (level) => ({

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -988,6 +988,17 @@ test('parseTranscript shares one anchor across records from the same request', a
   assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:00.000Z');
 });
 
+test('parseTranscript treats oversized request IDs as ungrouped records', async () => {
+  const oversizedRequestId = 'x'.repeat(129);
+  const result = await parseTempTranscript('cache-oversized-request-id.jsonl', [
+    { type: 'user', timestamp: '2024-01-01T00:00:00.000Z' },
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: oversizedRequestId }, '5m'),
+    cacheWrite({ timestamp: '2024-01-01T00:00:20.000Z', requestId: oversizedRequestId }, '5m'),
+  ]);
+
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:10.000Z');
+});
+
 test('parseTranscript re-anchors on each new request', async () => {
   const result = await parseTempTranscript('cache-next-request.jsonl', [
     { type: 'user', timestamp: '2024-01-01T00:00:00.000Z' },

--- a/tests/identity-coverage.test.js
+++ b/tests/identity-coverage.test.js
@@ -36,7 +36,7 @@ function baseContext() {
       pathLevels: 1,
       elementOrder: ['project', 'context', 'usage'],
       gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, branchOverflow: 'truncate', pushWarningThreshold: 0, pushCriticalThreshold: 0 },
-      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageValue: 'percent', usageBarEnabled: false, showResetLabel: true, showTools: true, showSkills: false, showMcp: false, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showPromptCache: false, promptCacheTtlSeconds: 300, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
+      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageValue: 'percent', usageBarEnabled: false, showResetLabel: true, showTools: true, showSkills: false, showMcp: false, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showPromptCache: false, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
       colors: {
         context: 'green',
         usage: 'brightBlue',

--- a/tests/prompt-cache.test.js
+++ b/tests/prompt-cache.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { formatPromptCacheCountdown, renderPromptCacheLine } from '../dist/render/lines/prompt-cache.js';
+import { renderPromptCacheLine } from '../dist/render/lines/prompt-cache.js';
 import { setLanguage } from '../dist/i18n/index.js';
 
 function stripAnsi(str) {
@@ -23,7 +23,6 @@ function baseContext() {
     config: {
       display: {
         showPromptCache: true,
-        promptCacheTtlSeconds: 300,
       },
       colors: {},
     },
@@ -31,34 +30,113 @@ function baseContext() {
   };
 }
 
-test('formatPromptCacheCountdown formats minutes and seconds', () => {
-  assert.equal(formatPromptCacheCountdown(272_000), '4m 32s');
-});
+/**
+ * Expected wall-clock rendering of `at`, derived the same way the renderer does
+ * rather than hardcoded, so the assertions hold in any timezone or locale.
+ */
+function expectedClock(at, opts = {}) {
+  const timeOpts = { hour: '2-digit', minute: '2-digit' };
+  if (opts.showSeconds) timeOpts.second = '2-digit';
+  if (opts.hourCycle) timeOpts.hourCycle = opts.hourCycle;
+  return new Date(at).toLocaleTimeString([], timeOpts);
+}
 
-test('formatPromptCacheCountdown formats hours when needed', () => {
-  assert.equal(formatPromptCacheCountdown(3_632_000), '1h 0m 32s');
-});
-
-test('formatPromptCacheCountdown returns expired when countdown has elapsed', () => {
-  assert.equal(formatPromptCacheCountdown(0), 'expired');
-  assert.equal(formatPromptCacheCountdown(-1000), 'expired');
-});
-
-test('renderPromptCacheLine shows warning and expired states', () => {
+test('renderPromptCacheLine is hidden without an anchor', () => {
   const ctx = baseContext();
-  const now = Date.UTC(2024, 0, 1, 0, 5, 0);
+  assert.equal(renderPromptCacheLine(ctx, Date.now()), null);
+});
 
-  ctx.transcript.lastAssistantResponseAt = new Date(now - 280_000);
-  assert.equal(stripAnsi(renderPromptCacheLine(ctx, now) ?? ''), 'Cache ⏱ 0m 20s');
+test('renderPromptCacheLine is hidden when not enabled', () => {
+  const ctx = baseContext();
+  ctx.config.display.showPromptCache = false;
+  ctx.transcript.promptCacheAnchorAt = new Date();
+  assert.equal(renderPromptCacheLine(ctx, Date.now()), null);
+});
 
-  ctx.transcript.lastAssistantResponseAt = new Date(now - 301_000);
+test('renderPromptCacheLine shows the expiry time, not a countdown', () => {
+  const ctx = baseContext();
+  const now = Date.UTC(2024, 0, 1, 12, 0, 0);
+  ctx.transcript.promptCacheAnchorAt = new Date(now - 60_000);
+
+  const expiresAt = now - 60_000 + 300_000;
+  assert.equal(
+    stripAnsi(renderPromptCacheLine(ctx, now) ?? ''),
+    `Cache ⏱ at ${expectedClock(expiresAt)}`,
+  );
+});
+
+test('renderPromptCacheLine holds the same value as the render goes stale', () => {
+  const ctx = baseContext();
+  const anchor = Date.UTC(2024, 0, 1, 12, 0, 0);
+  ctx.transcript.promptCacheAnchorAt = new Date(anchor);
+  ctx.transcript.promptCacheTtlSeconds = 3600;
+
+  // The point of an absolute time: three renders minutes apart, one value.
+  const first = stripAnsi(renderPromptCacheLine(ctx, anchor + 60_000) ?? '');
+  const later = stripAnsi(renderPromptCacheLine(ctx, anchor + 30 * 60_000) ?? '');
+  const last = stripAnsi(renderPromptCacheLine(ctx, anchor + 59 * 60_000) ?? '');
+
+  assert.equal(first, `Cache ⏱ at ${expectedClock(anchor + 3_600_000)}`);
+  assert.equal(later, first);
+  assert.equal(last, first);
+});
+
+test('renderPromptCacheLine prefers the detected TTL over the 5m default', () => {
+  const ctx = baseContext();
+  const now = Date.UTC(2024, 0, 1, 12, 0, 0);
+  ctx.transcript.promptCacheAnchorAt = new Date(now - 10 * 60_000);
+
+  // 10 minutes after the request: expired on the 5m tier, warm on the 1h tier.
   assert.equal(stripAnsi(renderPromptCacheLine(ctx, now) ?? ''), 'Cache ⏱ expired');
+
+  ctx.transcript.promptCacheTtlSeconds = 3600;
+  assert.equal(
+    stripAnsi(renderPromptCacheLine(ctx, now) ?? ''),
+    `Cache ⏱ at ${expectedClock(now - 10 * 60_000 + 3_600_000)}`,
+  );
+});
+
+test('renderPromptCacheLine ignores a TTL that is not a real tier', () => {
+  const ctx = baseContext();
+  const now = Date.UTC(2024, 0, 1, 12, 0, 0);
+  ctx.transcript.promptCacheAnchorAt = new Date(now);
+  ctx.transcript.promptCacheTtlSeconds = 86_400;
+
+  // Falls back to 5m rather than counting down against a fabricated tier.
+  assert.equal(
+    stripAnsi(renderPromptCacheLine(ctx, now) ?? ''),
+    `Cache ⏱ at ${expectedClock(now + 300_000)}`,
+  );
+});
+
+test('renderPromptCacheLine reports expired once the TTL has elapsed', () => {
+  const ctx = baseContext();
+  const now = Date.UTC(2024, 0, 1, 12, 0, 0);
+
+  ctx.transcript.promptCacheAnchorAt = new Date(now - 300_000);
+  assert.equal(stripAnsi(renderPromptCacheLine(ctx, now) ?? ''), 'Cache ⏱ expired');
+
+  ctx.transcript.promptCacheAnchorAt = new Date(now - 2 * 60 * 60_000);
+  assert.equal(stripAnsi(renderPromptCacheLine(ctx, now) ?? ''), 'Cache ⏱ expired');
+});
+
+test('renderPromptCacheLine follows hourCycle and showClockSeconds', () => {
+  const ctx = baseContext();
+  const now = Date.UTC(2024, 0, 1, 12, 0, 0);
+  ctx.transcript.promptCacheAnchorAt = new Date(now);
+  ctx.config.display.hourCycle = 'h23';
+  ctx.config.display.showClockSeconds = true;
+
+  assert.equal(
+    stripAnsi(renderPromptCacheLine(ctx, now) ?? ''),
+    `Cache ⏱ at ${expectedClock(now + 300_000, { hourCycle: 'h23', showSeconds: true })}`,
+  );
 });
 
 test('renderPromptCacheLine localizes label and expired state', () => {
   const ctx = baseContext();
   const now = Date.UTC(2024, 0, 1, 0, 5, 1);
-  ctx.transcript.lastAssistantResponseAt = new Date(now - 301_000);
+  ctx.transcript.promptCacheAnchorAt = new Date(now - 301_000);
 
   setLanguage('zh');
   try {

--- a/tests/prompt-cache.test.js
+++ b/tests/prompt-cache.test.js
@@ -23,6 +23,7 @@ function baseContext() {
     config: {
       display: {
         showPromptCache: true,
+        promptCacheTtlSeconds: 300,
       },
       colors: {},
     },
@@ -94,6 +95,21 @@ test('renderPromptCacheLine prefers the detected TTL over the 5m default', () =>
     stripAnsi(renderPromptCacheLine(ctx, now) ?? ''),
     `Cache ⏱ at ${expectedClock(now - 10 * 60_000 + 3_600_000)}`,
   );
+});
+
+test('renderPromptCacheLine keeps the configured TTL as a detection fallback', () => {
+  const ctx = baseContext();
+  const now = Date.UTC(2024, 0, 1, 12, 0, 0);
+  ctx.transcript.promptCacheAnchorAt = new Date(now - 10 * 60_000);
+  ctx.config.display.promptCacheTtlSeconds = 3600;
+
+  assert.equal(
+    stripAnsi(renderPromptCacheLine(ctx, now) ?? ''),
+    `Cache ⏱ at ${expectedClock(now - 10 * 60_000 + 3_600_000)}`,
+  );
+
+  ctx.transcript.promptCacheTtlSeconds = 300;
+  assert.equal(stripAnsi(renderPromptCacheLine(ctx, now) ?? ''), 'Cache ⏱ expired');
 });
 
 test('renderPromptCacheLine ignores a TTL that is not a real tier', () => {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -34,6 +34,15 @@ function stripAnsi(str) {
     .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
 }
 
+/**
+ * The prompt cache value for an anchor and TTL, derived rather than hardcoded so
+ * the assertion holds in any timezone or locale.
+ */
+function expectedCacheExpiry(anchorAt, ttlSeconds) {
+  const expiresAt = new Date(anchorAt.getTime() + ttlSeconds * 1000);
+  return `Cache ⏱ at ${expiresAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+}
+
 function baseContext() {
   return {
     stdin: {
@@ -63,7 +72,7 @@ function baseContext() {
       elementOrder: ['project', 'context', 'usage', 'promptCache', 'memory', 'environment', 'tools', 'skills', 'mcp', 'agents', 'todos'],
       gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, branchOverflow: 'truncate', pushWarningThreshold: 0, pushCriticalThreshold: 0 },
       jjStatus: { enabled: true, showDirty: true, showConflicts: true },
-      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageValue: 'percent', usageBarEnabled: false, showResetLabel: true, showTools: true, showSkills: false, showMcp: false, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showPromptCache: false, promptCacheTtlSeconds: 300, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
+      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageValue: 'percent', usageBarEnabled: false, showResetLabel: true, showTools: true, showSkills: false, showMcp: false, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showPromptCache: false, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
       colors: {
         context: 'green',
         usage: 'brightBlue',
@@ -476,10 +485,11 @@ test('render expanded layout includes prompt cache as its own opt-in element', (
   const ctx = baseContext();
   ctx.config.lineLayout = 'expanded';
   ctx.config.display.showPromptCache = true;
-  ctx.transcript.lastAssistantResponseAt = new Date(Date.now() - 45_000);
+  ctx.transcript.promptCacheAnchorAt = new Date(Date.now() - 45_000);
 
+  const expected = expectedCacheExpiry(ctx.transcript.promptCacheAnchorAt, 300);
   const lines = captureRenderLines(ctx);
-  assert.ok(lines.some(line => line.includes('Cache ⏱ 4m 15s')), `should render prompt cache line, got: ${lines.join(' | ')}`);
+  assert.ok(lines.some(line => line.includes(expected)), `should render prompt cache line, got: ${lines.join(' | ')}`);
 });
 
 test('renderSessionLine omits project name when cwd is undefined', () => {
@@ -515,13 +525,14 @@ test('renderPromptCacheLine returns null when disabled or missing transcript dat
   assert.equal(renderPromptCacheLine(ctx), null);
 });
 
-test('renderSessionLine includes prompt cache countdown when enabled', () => {
+test('renderSessionLine includes the prompt cache expiry when enabled', () => {
   const ctx = baseContext();
   ctx.config.display.showPromptCache = true;
-  ctx.transcript.lastAssistantResponseAt = new Date(Date.now() - 30_000);
+  ctx.transcript.promptCacheAnchorAt = new Date(Date.now() - 30_000);
 
+  const expected = expectedCacheExpiry(ctx.transcript.promptCacheAnchorAt, 300);
   const line = stripAnsi(renderSessionLine(ctx));
-  assert.ok(line.includes('Cache ⏱ 4m 30s'), `should include prompt cache countdown, got: ${line}`);
+  assert.ok(line.includes(expected), `should include prompt cache expiry, got: ${line}`);
 });
 
 test('renderSessionLine hides session name by default', () => {

--- a/tests/session-tokens-coverage.test.js
+++ b/tests/session-tokens-coverage.test.js
@@ -36,7 +36,7 @@ function baseContext() {
       pathLevels: 1,
       elementOrder: ['project', 'context', 'usage'],
       gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, branchOverflow: 'truncate', pushWarningThreshold: 0, pushCriticalThreshold: 0 },
-      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageValue: 'percent', usageBarEnabled: false, showResetLabel: true, showTools: true, showSkills: false, showMcp: false, showAgents: true, showTodos: true, showSessionTokens: true, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showPromptCache: false, promptCacheTtlSeconds: 300, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
+      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageValue: 'percent', usageBarEnabled: false, showResetLabel: true, showTools: true, showSkills: false, showMcp: false, showAgents: true, showTodos: true, showSessionTokens: true, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showPromptCache: false, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
       colors: {
         context: 'green',
         usage: 'brightBlue',

--- a/tests/usage-coverage.test.js
+++ b/tests/usage-coverage.test.js
@@ -42,7 +42,7 @@ function baseContext() {
       pathLevels: 1,
       elementOrder: ['project', 'context', 'usage'],
       gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, branchOverflow: 'truncate', pushWarningThreshold: 0, pushCriticalThreshold: 0 },
-      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageValue: 'percent', usageBarEnabled: false, showResetLabel: true, showTools: true, showSkills: false, showMcp: false, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showPromptCache: false, promptCacheTtlSeconds: 300, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
+      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageValue: 'percent', usageBarEnabled: false, showResetLabel: true, showTools: true, showSkills: false, showMcp: false, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showPromptCache: false, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
       colors: {
         context: 'green',
         usage: 'brightBlue',


### PR DESCRIPTION
## Summary

Three fixes to the opt-in `display.showPromptCache` element. Each is a separate commit.

Today, with `showPromptCache` enabled, the element can report a warm cache that has already expired, expire 55 minutes early, or freeze on a stale number — depending on which of the three you hit.

## 1. Subagent responses refresh the cache clock (`095f41e`)

`lastAssistantResponseAt` is assigned on any record with `type === 'assistant'`. Sidechain (subagent) records are interleaved into the main session's transcript, but they run against their own prompt cache and do not refresh the main session's.

One `Task` call is enough: the subagent's response pushes the deadline forward by however long the subagent ran, and the HUD then shows time the session does not have. Fixed by excluding `isSidechain` records from that one assignment — session token totals and every other aggregate still count them.

## 2. The TTL is configured rather than detected (`d0c663d`)

`display.promptCacheTtlSeconds` defaults to `300`. Anyone whose session actually runs on the 1-hour tier and hasn't changed that setting sees the cache read `expired` 55 minutes before it is — in the direction that makes them rush a request they didn't need to send.

The tier doesn't have to be guessed. Every cache write records which one it used:

```json
"cache_creation": { "ephemeral_1h_input_tokens": 1128, "ephemeral_5m_input_tokens": 0 }
```

`parseTranscript` now reads that from each main-chain assistant response into `TranscriptData.promptCacheTtlSeconds`, and the renderer prefers it. Because it's re-read per response, a session that changes tier mid-run (e.g. dropping to 5m on usage overage) is followed rather than pinned.

- Mixed tiers are representable across multiple cache breakpoints; the shortest wins, being the first part of the prefix to lapse.
- `TRANSCRIPT_CACHE_VERSION` 13 → 14, since v13 snapshots carry no TTL field. One-time cache invalidation on upgrade.

Semantic change: `display.promptCacheTtlSeconds` becomes a fallback/override rather than *the* TTL. Detection wins because it's read from the request that actually wrote the cache, so it's a fact about the session rather than a guess. 

## 3. A countdown can't stay correct here (`fbef48b`)

The statusline only re-renders while Claude Code is active. Sitting idle at the prompt — exactly when the cache is draining — nothing triggers a repaint, so the countdown freezes at whatever it last displayed and keeps showing it long after the cache is gone.

I measured it on 0.1.0 by logging every statusline invocation: **4 calls inside a 26-second burst of activity, then zero across the next 2 minutes of idle.**

A relative duration is only meaningful if something redraws it; an absolute time is still true however stale the render is. So the value becomes the expiry clock time, reusing the existing `formatAbsoluteTime` and its locale pattern so it matches how usage reset times already render:

```
Cache ⏱ at 14:30      →  still true five minutes later, and an hour later
Cache ⏱ expired       →  once elapsed
```

## Verification

Against a real transcript on the 1h tier, rendering at three points after the last response:

| Rendered | This PR | Before |
|---|---|---|
| 1 min after | `Cache ⏱ at 05:05 PM` | `Cache ⏱ at 04:10 PM` (55 min early) |
| 59 min after | `Cache ⏱ at 05:05 PM` | `Cache ⏱ expired` (still warm) |
| 2 hrs after | `Cache ⏱ expired` | `Cache ⏱ expired` |

The middle row is the point of #3: the value doesn't change between renders, so there's nothing to go stale.

Tier detection was checked against 11,530 assistant records across 88 local transcripts — 11,518 single-tier, 12 pure cache reads (the carry-forward path), 0 mixed.

## Testing

`npm test`: **976 passing, 0 failing** (was 969 before; 5 pre-existing skips unchanged).

New coverage in `tests/core.test.js` (sidechain exclusion, tier detection, carry-forward, mid-session change, subagent tier not adopted, no-cache-write case) and `tests/prompt-cache.test.js` (TTL precedence, expiry rendering, expired state). `tests/render.test.js` assertions updated for the new value format. Clock assertions derive the expected string via `toLocaleTimeString` rather than hardcoding, following `tests/format-reset-time.test.js`, so they're timezone-independent.

`src/`, `tests/` and `README.md` only — no `dist/`, per CONTRIBUTING.
