### PR TITLE
fix(version): resolve Windows cmd.exe from SystemRoot

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -40,12 +40,13 @@ type ClaudeVersionInvocation = {
 };
 
 const CACHE_FILENAME = '.claude-code-version-cache.json';
+const DEFAULT_WINDOWS_CMD = 'C:\\Windows\\System32\\cmd.exe';
 const defaultExecFile: ExecFileImpl = promisify(execFile) as ExecFileImpl;
 
 let execFileImpl: ExecFileImpl = defaultExecFile;
 let resolveClaudeBinaryImpl: () => ClaudeBinaryInfo | null = resolveClaudeBinaryFromPath;
 let platformImpl: () => NodeJS.Platform = () => process.platform;
-let windowsCmdImpl: () => string = () => 'C:\\Windows\\System32\\cmd.exe';
+let windowsCmdImpl: () => string = () => resolveWindowsCmdPath();
 let cachedBinaryKey: string | undefined;
 let cachedVersion: string | undefined;
 let hasResolved = false;
@@ -56,6 +57,20 @@ function getVersionCachePath(homeDir: string): string {
 
 function getBinaryCacheKey(binaryInfo: ClaudeBinaryInfo): string {
   return `${binaryInfo.path}:${binaryInfo.mtimeMs}`;
+}
+
+function resolveWindowsCmdPath(environment: NodeJS.ProcessEnv = process.env): string {
+  const rawSystemRoot = environment.SystemRoot ?? environment.SYSTEMROOT;
+  if (!rawSystemRoot || rawSystemRoot.includes('\0')) {
+    return DEFAULT_WINDOWS_CMD;
+  }
+
+  const systemRoot = rawSystemRoot.trim().replace(/^"(.*)"$/, '$1');
+  if (!/^[A-Za-z]:[\\/]/.test(systemRoot) || !path.win32.isAbsolute(systemRoot)) {
+    return DEFAULT_WINDOWS_CMD;
+  }
+
+  return path.win32.join(path.win32.normalize(systemRoot), 'System32', 'cmd.exe');
 }
 
 function quoteForCmd(arg: string): string {
@@ -319,5 +334,5 @@ export function _setVersionInvocationEnvForTests(
   windowsCmdGetter: (() => string) | null
 ): void {
   platformImpl = platformGetter ?? (() => process.platform);
-  windowsCmdImpl = windowsCmdGetter ?? (() => 'C:\\Windows\\System32\\cmd.exe');
+  windowsCmdImpl = windowsCmdGetter ?? (() => resolveWindowsCmdPath());
 }

--- a/tests/version-system-root.test.js
+++ b/tests/version-system-root.test.js
@@ -1,0 +1,49 @@
+import { afterEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  _getClaudeVersionInvocation,
+  _setVersionInvocationEnvForTests,
+} from '../dist/version.js';
+
+const originalSystemRoot = process.env.SystemRoot;
+const originalSystemRootUpper = process.env.SYSTEMROOT;
+
+function restoreEnvVar(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+afterEach(() => {
+  restoreEnvVar('SystemRoot', originalSystemRoot);
+  restoreEnvVar('SYSTEMROOT', originalSystemRootUpper);
+  _setVersionInvocationEnvForTests(null, null);
+});
+
+test('_getClaudeVersionInvocation resolves cmd.exe from SystemRoot', () => {
+  process.env.SystemRoot = 'D:\\Windows';
+  delete process.env.SYSTEMROOT;
+  _setVersionInvocationEnvForTests(null, null);
+
+  const invocation = _getClaudeVersionInvocation(
+    'C:\\Program Files\\Claude\\claude.cmd',
+    'win32',
+  );
+
+  assert.equal(invocation.file, 'D:\\Windows\\System32\\cmd.exe');
+});
+
+test('_getClaudeVersionInvocation rejects non-absolute SystemRoot values', () => {
+  process.env.SystemRoot = 'relative\\Windows';
+  delete process.env.SYSTEMROOT;
+  _setVersionInvocationEnvForTests(null, null);
+
+  const invocation = _getClaudeVersionInvocation(
+    'C:\\Program Files\\Claude\\claude.cmd',
+    'win32',
+  );
+
+  assert.equal(invocation.file, 'C:\\Windows\\System32\\cmd.exe');
+});


### PR DESCRIPTION
## Summary

Fix Windows Claude Code version detection when Windows is installed on a drive other than `C:`.

`src/version.ts` previously hard-coded:

`C:\Windows\System32\cmd.exe`

for launching `.cmd` / `.bat` Claude binaries. On systems where Windows is installed under another drive, such as `D:\Windows`, the version probe can fail even though Claude Code itself is installed and working.

This change:

- resolves `cmd.exe` from `SystemRoot` / `SYSTEMROOT`
- accepts only drive-absolute Windows paths
- rejects malformed, relative, or null-byte-containing values
- preserves `C:\Windows\System32\cmd.exe` as the safe fallback
- does not trust `COMSPEC` or PATH for the shell location

Example:

```text
SystemRoot=D:\Windows
→ D:\Windows\System32\cmd.exe
```

The existing behavior for normal `C:\Windows` installations is unchanged.

## Testing

- [x] Added regression coverage for Windows installed under `D:\Windows`
- [x] Added coverage ensuring relative `SystemRoot` values fall back safely
- [x] Verified the branch contains exactly one commit relative to upstream `main`
- [ ] `npm test` — CI
- [ ] `npm run test:coverage` — CI

## Checklist

- [x] Tests updated
- [x] No documentation change needed; this is an internal platform compatibility fix
- [x] No `dist/` changes
