### PR TITLE
fix(agents): expire stale completed entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Remove completed agents on the next HUD refresh after one minute, keep completed history from displacing running agents, and sanitize agent labels before terminal output (#704).
+
 ## [0.7.0] - 2026-08-07
 
 ### Added

--- a/src/render/agents-line.ts
+++ b/src/render/agents-line.ts
@@ -1,28 +1,58 @@
 import type { RenderContext, AgentEntry } from '../types.js';
 import { yellow, green, magenta, label } from './colors.js';
 import { truncateString } from '../utils/truncate.js';
-import { sanitize as sanitizeDisplayText } from './lines/added-dirs.js';
+import { sanitizeDisplayText } from '../utils/sanitize.js';
 
 const MAX_RECENT_COMPLETED = 2;
 const MAX_AGENTS_SHOWN = 3;
+const COMPLETED_RETENTION_MS = 60_000;
+const AGENT_TYPE_MAX_LEN = 24;
+const AGENT_DESCRIPTION_MAX_LEN = 40;
+
+function takeLast<T>(entries: readonly T[], count: number): T[] {
+  return count > 0 ? entries.slice(-count) : [];
+}
 
 export function renderAgentsLine(ctx: RenderContext): string | null {
   const { agents } = ctx.transcript;
   const colors = ctx.config?.colors;
-
-  const runningAgents = agents.filter((a) => a.status === 'running');
-  const recentCompleted = agents
-    .filter((a) => a.status === 'completed')
-    .slice(-MAX_RECENT_COMPLETED);
+  const now = Date.now();
 
   const seen = new Set<string>();
-  const toShow = [...runningAgents, ...recentCompleted]
-    .filter((a) => {
-      if (seen.has(a.id)) return false;
-      seen.add(a.id);
-      return true;
-    })
-    .slice(-MAX_AGENTS_SHOWN);
+  const unique = (agent: AgentEntry): boolean => {
+    if (seen.has(agent.id)) return false;
+    seen.add(agent.id);
+    return true;
+  };
+
+  // Running work is the primary signal. Fill the fixed three-agent budget with
+  // running agents first so completed history can never evict active work.
+  const runningAgents = takeLast(
+    agents
+      .filter((agent) => agent.status === 'running')
+      .filter(unique),
+    MAX_AGENTS_SHOWN,
+  );
+
+  const completedSlots = Math.min(
+    MAX_RECENT_COMPLETED,
+    MAX_AGENTS_SHOWN - runningAgents.length,
+  );
+  const recentCompleted = takeLast(
+    agents
+      .filter((agent) => agent.status === 'completed')
+      .filter((agent) => {
+        const completedAt = agent.endTime?.getTime();
+        return completedAt !== undefined
+          && Number.isFinite(completedAt)
+          && completedAt <= now
+          && now - completedAt <= COMPLETED_RETENTION_MS;
+      })
+      .filter(unique),
+    completedSlots,
+  );
+
+  const toShow = [...runningAgents, ...recentCompleted];
 
   if (toShow.length === 0) {
     return null;
@@ -30,7 +60,7 @@ export function renderAgentsLine(ctx: RenderContext): string | null {
 
   const lines: string[] = [];
   for (const agent of toShow) {
-    lines.push(formatAgent(agent, colors));
+    lines.push(formatAgent(agent, colors, now));
   }
   return lines.join('\n');
 }
@@ -90,22 +120,27 @@ function getStatusIcon(
 
 function formatAgent(
   agent: AgentEntry,
-  colors?: RenderContext['config']['colors']
+  colors: RenderContext['config']['colors'] | undefined,
+  now: number,
 ): string {
   const statusIcon = getStatusIcon(agent.status);
-  const type = magenta(agent.type);
+  const typeLabel = sanitizeAgentText(agent.type, AGENT_TYPE_MAX_LEN) || 'agent';
+  const type = magenta(typeLabel);
   const modelLabel = formatAgentModel(agent.model);
   const model = modelLabel ? label(`[${modelLabel}]`, colors) : '';
-  const desc = agent.description
-    ? label(`: ${truncateString(agent.description, 40)}`, colors)
-    : '';
-  const elapsed = formatElapsed(agent);
+  const description = sanitizeAgentText(agent.description, AGENT_DESCRIPTION_MAX_LEN);
+  const desc = description ? label(`: ${description}`, colors) : '';
+  const elapsed = formatElapsed(agent, now);
 
   return `${statusIcon} ${type}${model ? ` ${model}` : ''}${desc} ${label(`(${elapsed})`, colors)}`;
 }
 
-function formatElapsed(agent: AgentEntry): string {
-  const now = Date.now();
+function sanitizeAgentText(value: unknown, maxLen: number): string {
+  if (typeof value !== 'string') return '';
+  return truncateString(sanitizeDisplayText(value).trim(), maxLen);
+}
+
+function formatElapsed(agent: AgentEntry, now: number): string {
   const start = agent.startTime.getTime();
   const end = agent.endTime?.getTime() ?? now;
   const ms = Math.max(0, end - start);

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -124,6 +124,7 @@ function countContaining(lines, needle) {
 
 test('render wraps long lines to terminal width and keeps all activity lines visible', () => {
   const ctx = baseContext();
+  const completedAt = Date.now() - 3_000;
   ctx.stdin.model = { display_name: 'Sonnet 4.6' };
   ctx.stdin.cwd = '/tmp/very-long-project-name-for-terminal-wrap-checking';
   ctx.gitStatus = {
@@ -149,8 +150,8 @@ test('render wraps long lines to terminal width and keeps all activity lines vis
   ];
   ctx.transcript.agents = [
     { id: 'agent-1', type: 'plan-a', status: 'running', startTime: new Date(0) },
-    { id: 'agent-2', type: 'plan-b', status: 'completed', startTime: new Date(0), endTime: new Date(3000) },
-    { id: 'agent-3', type: 'plan-c', status: 'completed', startTime: new Date(0), endTime: new Date(3500) },
+    { id: 'agent-2', type: 'plan-b', status: 'completed', startTime: new Date(completedAt - 3_000), endTime: new Date(completedAt) },
+    { id: 'agent-3', type: 'plan-c', status: 'completed', startTime: new Date(completedAt - 3_500), endTime: new Date(completedAt) },
   ];
   ctx.transcript.todos = [
     { content: 'todo-marker', status: 'in_progress' },

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -81,6 +81,16 @@ function baseContext() {
   };
 }
 
+function withNow(now, fn) {
+  const originalNow = Date.now;
+  Date.now = () => now;
+  try {
+    return fn();
+  } finally {
+    Date.now = originalNow;
+  }
+}
+
 function captureRenderLines(ctx) {
   const logs = [];
   const originalLog = console.log;
@@ -1842,9 +1852,111 @@ test('renderAgentsLine renders completed agents', () => {
     },
   ];
 
-  const line = renderAgentsLine(ctx);
+  const line = withNow(30_000, () => renderAgentsLine(ctx));
   assert.ok(line?.includes('explore'));
   assert.ok(line?.includes('haiku'));
+});
+
+test('renderAgentsLine expires completed agents on the next render after one minute', () => {
+  const ctx = baseContext();
+  ctx.transcript.agents = [
+    {
+      id: 'agent-recent',
+      type: 'recent',
+      status: 'completed',
+      startTime: new Date(50_000),
+      endTime: new Date(60_000),
+    },
+  ];
+
+  assert.ok(withNow(120_000, () => renderAgentsLine(ctx))?.includes('recent'));
+  assert.equal(withNow(120_001, () => renderAgentsLine(ctx)), null);
+});
+
+test('renderAgentsLine hides completed agents without a trustworthy completion time', () => {
+  const ctx = baseContext();
+  ctx.transcript.agents = [
+    {
+      id: 'agent-missing-end',
+      type: 'missing-end',
+      status: 'completed',
+      startTime: new Date(0),
+    },
+    {
+      id: 'agent-invalid-end',
+      type: 'invalid-end',
+      status: 'completed',
+      startTime: new Date(0),
+      endTime: new Date(Number.NaN),
+    },
+    {
+      id: 'agent-future-end',
+      type: 'future-end',
+      status: 'completed',
+      startTime: new Date(0),
+      endTime: new Date(120_001),
+    },
+  ];
+
+  assert.equal(withNow(120_000, () => renderAgentsLine(ctx)), null);
+});
+
+test('renderAgentsLine gives all visible slots to running agents before completed history', () => {
+  const ctx = baseContext();
+  ctx.transcript.agents = [
+    {
+      id: 'completed-1',
+      type: 'completed-one',
+      status: 'completed',
+      startTime: new Date(0),
+      endTime: new Date(119_000),
+    },
+    {
+      id: 'completed-2',
+      type: 'completed-two',
+      status: 'completed',
+      startTime: new Date(0),
+      endTime: new Date(119_000),
+    },
+    ...['running-one', 'running-two', 'running-three', 'running-four'].map((type, index) => ({
+      id: `running-${index + 1}`,
+      type,
+      status: 'running',
+      startTime: new Date(119_000),
+    })),
+  ];
+
+  const line = withNow(120_000, () => renderAgentsLine(ctx));
+  assert.doesNotMatch(line ?? '', /completed-/);
+  assert.doesNotMatch(line ?? '', /running-one/);
+  assert.match(line ?? '', /running-two/);
+  assert.match(line ?? '', /running-three/);
+  assert.match(line ?? '', /running-four/);
+});
+
+test('renderAgentsLine fills remaining slots with the latest completed agents', () => {
+  const ctx = baseContext();
+  ctx.transcript.agents = [
+    ...['completed-one', 'completed-two', 'completed-three'].map((type, index) => ({
+      id: `completed-${index + 1}`,
+      type,
+      status: 'completed',
+      startTime: new Date(100_000),
+      endTime: new Date(119_000 + index),
+    })),
+    {
+      id: 'running-1',
+      type: 'running-one',
+      status: 'running',
+      startTime: new Date(119_000),
+    },
+  ];
+
+  const line = withNow(120_000, () => renderAgentsLine(ctx));
+  assert.doesNotMatch(line ?? '', /completed-one/);
+  assert.match(line ?? '', /completed-two/);
+  assert.match(line ?? '', /completed-three/);
+  assert.match(line ?? '', /running-one/);
 });
 
 test('renderAgentsLine truncates long descriptions and formats elapsed time', () => {
@@ -1856,8 +1968,8 @@ test('renderAgentsLine truncates long descriptions and formats elapsed time', ()
       model: 'haiku',
       description: 'A very long description that should be truncated in the HUD output',
       status: 'completed',
-      startTime: new Date(0),
-      endTime: new Date(1500),
+      startTime: new Date(63_500),
+      endTime: new Date(65_000),
     },
     {
       id: 'agent-2',
@@ -1868,7 +1980,7 @@ test('renderAgentsLine truncates long descriptions and formats elapsed time', ()
     },
   ];
 
-  const line = renderAgentsLine(ctx);
+  const line = withNow(65_000, () => renderAgentsLine(ctx));
   assert.ok(line?.includes('...'));
   assert.ok(line?.includes('2s'));
   assert.ok(line?.includes('1m'));
@@ -1909,7 +2021,10 @@ test('renderAgentsLine formats elapsed time in hours for long-running agents', (
     },
   ];
 
-  const line = renderAgentsLine(ctx);
+  const line = withNow(
+    (2 * 60 * 60 + 5 * 60) * 1000,
+    () => renderAgentsLine(ctx),
+  );
   assert.ok(line?.includes('2h 5m'));
 });
 
@@ -1925,8 +2040,59 @@ test('renderAgentsLine clamps negative elapsed time to under one second', () => 
     },
   ];
 
-  const line = renderAgentsLine(ctx);
+  const line = withNow(1000, () => renderAgentsLine(ctx));
   assert.ok(line?.includes('<1s'));
+});
+
+test('renderAgentsLine sanitizes untrusted agent labels before terminal output', () => {
+  const ctx = baseContext();
+  ctx.transcript.agents = [
+    {
+      id: 'agent-hostile',
+      type: '\x1b]8;;https://evil.example\x07explore\x1b]8;;\x07\n\u202e',
+      description: 'safe\x1b[2J\n\u202evisible',
+      status: 'running',
+      startTime: new Date(0),
+    },
+  ];
+
+  const line = withNow(1_000, () => renderAgentsLine(ctx));
+  assert.match(line ?? '', /explore/);
+  assert.match(line ?? '', /safevisible/);
+  assert.doesNotMatch(line ?? '', /evil\.example|\x1b\]8|\x1b\[2J|\n|\u202e/);
+});
+
+test('renderAgentsLine safely handles non-string cached agent labels', () => {
+  const ctx = baseContext();
+  ctx.transcript.agents = [
+    {
+      id: 'agent-invalid-labels',
+      type: { unexpected: true },
+      description: { unexpected: true },
+      status: 'running',
+      startTime: new Date(0),
+    },
+  ];
+
+  const line = withNow(1_000, () => renderAgentsLine(ctx));
+  assert.match(line ?? '', /agent/);
+  assert.doesNotMatch(line ?? '', /unexpected|\[object Object\]/);
+});
+
+test('renderAgentsLine bounds untrusted agent types', () => {
+  const ctx = baseContext();
+  ctx.transcript.agents = [
+    {
+      id: 'agent-long-type',
+      type: 'x'.repeat(100),
+      status: 'running',
+      startTime: new Date(0),
+    },
+  ];
+
+  const line = withNow(1_000, () => renderAgentsLine(ctx));
+  assert.match(line ?? '', new RegExp(`${'x'.repeat(21)}\\.\\.\\.`));
+  assert.doesNotMatch(line ?? '', new RegExp('x'.repeat(22)));
 });
 
 test('renderTodosLine handles in-progress and completed-only cases', () => {


### PR DESCRIPTION
## Summary

- expire completed agents on the next HUD refresh after 60 seconds
- reserve the three visible slots for running agents before completed history
- sanitize and bound untrusted agent labels at the terminal boundary
- preserve the existing default configuration and renderer API

Closes #704.

## Validation

- `npm run build`
- `npm test` (1,039 passed, 6 platform skips)
- `npm run test:coverage`
- explicit security, quality, regression, readability, and maintainability review

Generated `dist/` artifacts are intentionally excluded.