### PR TITLE
release: prepare v0.7.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hud",
   "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-11
+
 ### Fixed
-- Remove completed agents on the next HUD refresh after one minute, keep completed history from displacing running agents, and sanitize agent labels before terminal output (#704).
+- Remove completed agents on the next HUD refresh after one minute and keep completed history from displacing running agents (#704).
+
+### Security
+- Sanitize, validate, and bound agent labels before terminal output (#704).
 
 ## [0.7.0] - 2026-08-07
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hud",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hud",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hud",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Real-time statusline HUD for Claude Code",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- bump package and Claude plugin metadata to 0.7.1
- publish the completed-agent retention fix and agent-label terminal hardening from #706
- keep the release diff metadata-only with trusted dist already regenerated on main

## Validation

- `npm test` (1,039 passed, 6 platform skips)
- `npm pack --dry-run --cache /tmp/claude-hud-npm-cache-0.7.1`
- version consistency across package, lockfile, plugin manifest, and marketplace metadata
- explicit security, quality, packaging, readability, and maintainability review