### PR TITLE
feat: add plancost segment for third-party coding-plan usage/balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `plancost` first-line segment showing third-party coding-plan usage or
+  account balance (Kimi / DeepSeek / Zhipu GLM), fetched directly from the
+  provider APIs with a 5-minute per-provider disk cache and stale-cache
+  fallback. Configured via the top-level `plancost` block; `displayMode`
+  `auto` matches the provider to the actually served model, `all` shows every
+  configured provider (#PR).
+- `/claude-hud:setup` and `/claude-hud:configure` wizard questions now support
+  Simplified Chinese alongside English, driven by the HUD `language` config.
+  The setup wizard detects an Anthropic official OAuth login and asks whether
+  third-party plancost should still be enabled (#PR).
+
 ## [0.7.1] - 2026-08-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -308,6 +308,89 @@ Set `display.showResetLabel` to `false` if you want shorter usage countdowns suc
 
 Set `display.usageCompact` to `true` if you want the shorter usage-only form, for example `5h: 25% (1h 30m)`. Compact usage takes precedence over `display.usageBarEnabled`.
 
+### Plancost (third-party model providers)
+
+A `plancost` first-line segment shows **coding-plan usage or account balance
+for third-party domestic model providers**, queried directly from the provider
+APIs (Kimi For Coding, DeepSeek, Zhipu GLM). It is **disabled by default** —
+you must opt in and fill in API keys. This complements the official
+`rate_limits` display (which requires an Anthropic subscriber login and is
+unavailable to API-key / proxy users) and the external usage snapshot path:
+plancost fetches provider data itself instead of reading a sidecar file.
+
+```
+🟡 Kimi 5h 15% (03:44) · week 69% (08/13)      ← Kimi coding plan (5h + weekly)
+💰 DS ¥40.96                                   ← DeepSeek account balance
+```
+
+Health markers: 🟢 < 60% / 🟡 60–84% / 🔴 ≥ 85% (worst window wins).
+DeepSeek shows balance only. The HUD strips ANSI from external data, so the
+emoji carry the color signal.
+
+#### Configuration
+
+```jsonc
+// ~/.claude/plugins/claude-hud/config.json
+{
+  "plancost": {
+    "enabled": true,
+    "displayMode": "auto",        // "auto" | "all"
+    "providers": {
+      "kimi":     { "apiKey": "sk-kimi-...", "models": ["k3", "kimi"] },
+      "deepseek": { "apiKey": "sk-...",      "models": ["deepseek"] },
+      "glm":      { "apiKey": "id.secret",   "models": ["glm", "chatglm"],
+                    "endpoint": "https://open.bigmodel.cn" }   // optional override
+    }
+  }
+}
+```
+
+- **`enabled`**: master switch. `false` means zero network calls.
+- **`displayMode`**:
+  - `auto` (default): show only the provider whose `models` prefix matches
+    the **actual served model** (transcript `message.model`, stdin model as
+    fallback before the first assistant message). Subagent turns never
+    override the main-session model.
+  - `all`: show every provider that has a non-empty `apiKey`, in config
+    key order.
+- **`providers`**: keys are fixed (`kimi` / `deepseek` / `glm`); unknown keys
+  are dropped. `models` are case-insensitive name prefixes (e.g. `k3` matches
+  `k3[1M]` and `k3-256`). `endpoint` is only needed for the GLM international
+  site (`https://api.z.ai`).
+
+Where each key comes from:
+- **Kimi For Coding**: `sk-kimi-...`, create at https://www.kimi.com/code/console
+- **DeepSeek**: `sk-...`, create at https://platform.deepseek.com/api_keys
+- **Zhipu GLM**: `{id}.{secret}` (no `sk-` prefix), create at
+  https://open.bigmodel.cn
+
+#### Position on the line
+
+The segment renders after the cost segment by default. Reorder it with
+`projectLineOrder`, e.g. right after the model badge:
+
+```jsonc
+{ "projectLineOrder": ["model", "plancost"] }
+```
+
+#### How it works
+
+- Queries: Kimi `GET api.kimi.com/coding/v1/usages` (Bearer); DeepSeek
+  `GET api.deepseek.com/user/balance` (Bearer); GLM
+  `GET {endpoint}/api/monitor/usage/quota/limit` (**bare key, no Bearer** —
+  a Bearer prefix fails GLM auth).
+- Caching: one file per provider under
+  `~/.claude/plugins/claude-hud/plancost-cache/`, 5-minute TTL, keyed by a
+  hash of the apiKey — swapping keys invalidates old data immediately.
+- Degradation: fresh cache → request (2s timeout) → stale cache for the same
+  key → segment hidden. Failures never break the HUD.
+- The `/claude-hud:setup` Step 4 and `/claude-hud:configure` Q7 wizards guide
+  through enabling providers, entering keys, display mode, and placement.
+  When an Anthropic official OAuth login is detected, the wizard asks whether
+  you still want third-party plancost (the official `rate_limits` usage is
+  already shown). Keys are written to `config.json` as plain text — do not
+  share that file.
+
 ### Security Notes
 
 ClaudeHUD is local-only by design. It does not make network requests, scrape credentials, or call undocumented Claude APIs. It reads the statusline JSON from stdin, the current session transcript path supplied by Claude Code, selected Claude configuration files under `~/.claude`, and git metadata for the current workspace.

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -9,6 +9,11 @@ allowed-tools: Read, Write, AskUserQuestion
 
 Store current values and note whether config exists (determines which flow to use).
 
+**LANGUAGE**: Every question below has an EN (English) and ZH (简体中文) variant.
+Set `LANG_HUD` from the loaded config: `language` is `en` (or missing) → use EN;
+`zh-Hans` / `zh-Hant` / `zh` / `zh-TW` → use ZH. Show the variant matching
+`LANG_HUD` for each AskUserQuestion below; technical prose stays English.
+
 ## Core Features (on by default)
 
 These default to ON and are what most users keep. They ARE configurable
@@ -45,37 +50,37 @@ Questions: **Turn Off → Turn On → Git Style → Layout/Reset → Language �
 ## Flow A: New User (6 Questions)
 
 ### Q1: Layout
-- header: "Layout"
-- question: "Choose your HUD layout:"
+- header: "Layout" / "布局"
+- question: EN: "Choose your HUD layout:" | ZH: "选择 HUD 布局："
 - multiSelect: false
 - options:
-  - "Expanded (Recommended)" - Split into semantic lines (identity, project, environment, usage)
-  - "Compact" - Everything on one line
-  - "Compact + Separators" - One line with separator before activity
+  - EN: "Expanded (Recommended)" - Split into semantic lines (identity, project, environment, usage) | ZH: "Expanded（推荐）—— 语义分行的多行布局"
+  - EN: "Compact" - Everything on one line | ZH: "Compact —— 单行紧凑布局"
+  - EN: "Compact + Separators" - One line with separator before activity | ZH: "Compact + 分隔符 —— 活动区前带分隔线的单行布局"
 
 ### Q2: Preset
-- header: "Preset"
-- question: "Choose a starting configuration:"
+- header: "Preset" / "预设"
+- question: EN: "Choose a starting configuration:" | ZH: "选择起始配置："
 - multiSelect: false
 - options:
-  - "Full" - Everything enabled (Recommended)
-  - "Essential" - Activity + git, minimal info
-  - "Minimal" - Core only (model, context bar)
+  - EN: "Full" - Everything enabled (Recommended) | ZH: "Full —— 全部开启（推荐）"
+  - EN: "Essential" - Activity + git, minimal info | ZH: "Essential —— 活动 + git，信息精简"
+  - EN: "Minimal" - Core only (model, context bar) | ZH: "Minimal —— 仅核心（模型、上下文条）"
 
 ### Q3: Language
-- header: "Language"
-- question: "Choose your HUD label language:"
+- header: "Language" / "语言"
+- question: EN: "Choose your HUD label language:" | ZH: "选择 HUD 标签语言："
 - multiSelect: false
 - options:
-  - "English (Recommended)" - Default, simplest onboarding path
-  - "简体中文" - Show HUD labels and status text in Simplified Chinese
-  - "繁體中文" - Show HUD labels and status text in Traditional Chinese
+  - EN: "English (Recommended)" - Default, simplest onboarding path | ZH: "English（推荐）—— 默认，最简上手路径"
+  - "简体中文" - EN: Show HUD labels and status text in Simplified Chinese | ZH: 显示简体中文标签
+  - "繁體中文" - EN: Show HUD labels and status text in Traditional Chinese | ZH: 显示繁體中文标签
 
 Save as `language: "en"`, `language: "zh-Hans"`, or `language: "zh-Hant"`.
 
 ### Q4: Turn Off (based on chosen preset)
-- header: "Turn Off"
-- question: "Disable any of these? (enabled by your preset)"
+- header: "Turn Off" / "关闭"
+- question: EN: "Disable any of these? (enabled by your preset)" | ZH: "要关闭哪些？（当前由预设开启）"
 - multiSelect: true
 - options: **ONLY items that are ON in the chosen preset** (max 4)
   - "Tools activity" - ◐ Edit: file.ts | ✓ Read ×3
@@ -105,10 +110,11 @@ Save as `language: "en"`, `language: "zh-Hans"`, or `language: "zh-Hant"`.
   - "Claude Code version" - the running CC version
   - "Compaction count" - Compactions: 2 after /compact or auto-compaction
   - "Advisor model" - Advisor: Opus 4.7 (when /advisor is configured)
+  - "Plancost 额度显示" - EN: Third-party plan usage/balance (Kimi/DeepSeek/GLM), needs API keys | ZH: 第三方套餐额度/余额显示（Kimi/DeepSeek/GLM），需填 key
 
 ### Q5: Turn On (based on chosen preset)
-- header: "Turn On"
-- question: "Enable any of these? (disabled by your preset)"
+- header: "Turn On" / "开启"
+- question: EN: "Enable any of these? (disabled by your preset)" | ZH: "要开启哪些？（当前由预设关闭）"
 - multiSelect: true
 - options: **ONLY items that are OFF in the chosen preset** (max 4)
   - (same list as above, filtered to OFF items)
@@ -117,22 +123,32 @@ Save as `language: "en"`, `language: "zh-Hans"`, or `language: "zh-Hant"`.
 If preset has all items OFF (Minimal), Q4 shows "Nothing to disable - Minimal preset is already minimal!"
 
 ### Q6: Custom Line (optional)
-- header: "Custom Line"
-- question: "Add a custom phrase to display in the HUD? (e.g. a motto, max 80 chars)"
+- header: "Custom Line" / "自定义短语"
+- question: EN: "Add a custom phrase to display in the HUD? (e.g. a motto, max 80 chars)" | ZH: "要在 HUD 中显示自定义短语吗？（如座右铭，最多 80 字符）"
 - multiSelect: false
 - options:
-  - "Skip" - No custom line
-  - "Enter custom text" - Ask user for their phrase via AskUserQuestion (free text input)
+  - EN: "Skip" - No custom line | ZH: "跳过 —— 不设置"
+  - EN: "Enter custom text" - Ask user for their phrase via AskUserQuestion (free text input) | ZH: "输入自定义文本 —— 通过 AskUserQuestion 输入"
 
 If user chooses "Enter custom text", use AskUserQuestion to get their text. Save as `display.customLine` in config.
+
+### Q7: Plancost 额度显示
+- header: "Plancost" / "套餐额度"
+- question: EN: "Configure the plancost segment (Kimi/DeepSeek/GLM usage or balance)?" | ZH: "配置 plancost 额度段（Kimi/DeepSeek/GLM 套餐或余额）？"
+- multiSelect: false
+- options:
+  - EN: "Skip" - Leave plancost disabled (do not write plancost keys) | ZH: "跳过 —— 不启用 plancost"
+  - EN: "Enable and configure" - Run the plancost wizard (below) | ZH: "启用并配置 —— 运行 plancost 向导"
+
+**If user chose "Enable and configure"**: run the wizard below; write `plancost.enabled: true` and the collected settings into `~/.claude/plugins/claude-hud/config.json`.
 
 ---
 
 ## Flow B: Update Config (6 Questions)
 
 ### Q1: Turn Off
-- header: "Turn Off"
-- question: "What do you want to DISABLE? (currently enabled)"
+- header: "Turn Off" / "关闭"
+- question: EN: "What do you want to DISABLE? (currently enabled)" | ZH: "要关闭哪些？（当前已开启的）"
 - multiSelect: true
 - options: **ONLY items currently ON** (max 4, prioritize Activity first)
   - "Tools activity" - ◐ Edit: file.ts | ✓ Read ×3
@@ -158,13 +174,14 @@ If user chooses "Enter custom text", use AskUserQuestion to get their text. Save
   - "Usage bar style" - ██░░ 25% visual bar (only if usageBarEnabled is true)
   - "Usage reset label" - show or hide the `resets in` prefix
   - "Compact usage" - 5h: 25% (1h 30m) shorter format (only if usageCompact is false)
+  - "Plancost 额度显示" - EN: Turn off third-party plan usage/balance display (`plancost.enabled: false`) | ZH: 关闭第三方套餐额度/余额显示
 
 If more than 4 items ON, show Activity items (Tools, Agents, Todos, Project, Git) first.
 Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset to Minimal" in Q4.
 
 ### Q2: Turn On
-- header: "Turn On"
-- question: "What do you want to ENABLE? (currently disabled)"
+- header: "Turn On" / "开启"
+- question: EN: "What do you want to ENABLE? (currently disabled)" | ZH: "要开启哪些？（当前已关闭的）"
 - multiSelect: true
 - options: **ONLY items currently OFF** (max 4)
   - "Config counts" - 2 CLAUDE.md | 4 rules
@@ -190,39 +207,40 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
   - "Claude Code version" - the running CC version
   - "Compaction count" - Compactions: 2 after /compact or auto-compaction
   - "Advisor model" - Advisor: Opus 4.7 (when /advisor is configured)
+  - "Plancost 额度显示" - EN: Third-party plan usage/balance (Kimi/DeepSeek/GLM), needs API keys (see Q7) | ZH: 第三方套餐额度/余额显示（Kimi/DeepSeek/GLM），需填 key（见 Q7）
 
 ### Q3: Git Style (only if Git is currently enabled)
-- header: "Git Style"
-- question: "How much git info to show?"
+- header: "Git Style" / "Git 样式"
+- question: EN: "How much git info to show?" | ZH: "要显示多少 Git 信息？"
 - multiSelect: false
 - options:
-  - "Branch only" - git:(main)
-  - "Branch + dirty" - git:(main*) shows uncommitted changes
-  - "Full details" - git:(main* ↑2 ↓1) includes ahead/behind
-  - "File stats" - git:(main* !2 +1 ?3) Starship-compatible format
+  - EN: "Branch only" - git:(main) | ZH: "仅分支"
+  - EN: "Branch + dirty" - git:(main*) shows uncommitted changes | ZH: "分支 + 未提交标记"
+  - EN: "Full details" - git:(main* ↑2 ↓1) includes ahead/behind | ZH: "完整详情（含 ahead/behind）"
+  - EN: "File stats" - git:(main* !2 +1 ?3) Starship-compatible format | ZH: "文件统计（Starship 格式）"
 
 **Skip Q3 if Git is OFF** - proceed to Q4.
 
 ### Q4: Layout/Reset
-- header: "Layout/Reset"
-- question: "Change layout or reset to preset?"
+- header: "Layout/Reset" / "布局/重置"
+- question: EN: "Change layout or reset to preset?" | ZH: "更改布局或重置为预设？"
 - multiSelect: false
 - options:
-  - "Keep current" - No layout/preset changes (current: Expanded/Compact/Compact + Separators)
-  - "Switch to Expanded" - Split into semantic lines (if not current)
-  - "Switch to Compact" - Everything on one line (if not current)
-  - "Reset to Full" - Enable everything
-  - "Reset to Essential" - Activity + git only
+  - EN: "Keep current" - No layout/preset changes (current: Expanded/Compact/Compact + Separators) | ZH: "保持当前 —— 不改变布局/预设"
+  - EN: "Switch to Expanded" - Split into semantic lines (if not current) | ZH: "切换到 Expanded —— 语义分行"
+  - EN: "Switch to Compact" - Everything on one line (if not current) | ZH: "切换到 Compact —— 单行"
+  - EN: "Reset to Full" - Enable everything | ZH: "重置为 Full —— 全部开启"
+  - EN: "Reset to Essential" - Activity + git only | ZH: "重置为 Essential —— 仅活动 + git"
 
 ### Q5: Language
-- header: "Language"
-- question: "Update HUD label language? (current: '{English, 简体中文, or 繁體中文}')"
+- header: "Language" / "语言"
+- question: EN: "Update HUD label language? (current: '{English, 简体中文, or 繁體中文}')" | ZH: "更新 HUD 标签语言？（当前：'{English, 简体中文, or 繁體中文}'）"
 - multiSelect: false
 - options:
-  - "Keep current" - No change
-  - "English (Recommended)" - Use English HUD labels
-  - "简体中文" - Use Simplified Chinese HUD labels
-  - "繁體中文" - Use Traditional Chinese HUD labels
+  - EN: "Keep current" - No change | ZH: "保持当前"
+  - EN: "English (Recommended)" - Use English HUD labels | ZH: "English（推荐）—— 英文标签"
+  - EN: "简体中文" - Use Simplified Chinese HUD labels | ZH: "简体中文标签"
+  - EN: "繁體中文" - Use Traditional Chinese HUD labels | ZH: "繁體中文标签"
 
 If user chooses "Keep current", leave `language` unchanged.
 If user chooses "English (Recommended)", save `language: "en"`.
@@ -230,16 +248,49 @@ If user chooses "简体中文", save `language: "zh-Hans"`.
 If user chooses "繁體中文", save `language: "zh-Hant"`.
 
 ### Q6: Custom Line (optional)
-- header: "Custom Line"
-- question: "Update your custom phrase? (currently: '{current customLine or none}')"
+- header: "Custom Line" / "自定义短语"
+- question: EN: "Update your custom phrase? (currently: '{current customLine or none}')" | ZH: "更新自定义短语？（当前：'{current customLine or none}'）"
 - multiSelect: false
 - options:
-  - "Keep current" - No change (skip if no customLine set)
-  - "Enter custom text" - Set or update custom phrase (max 80 chars)
-  - "Remove" - Clear the custom line (only show if customLine is currently set)
+  - EN: "Keep current" - No change (skip if no customLine set) | ZH: "保持当前"
+  - EN: "Enter custom text" - Set or update custom phrase (max 80 chars) | ZH: "输入自定义文本（最多 80 字符）"
+  - EN: "Remove" - Clear the custom line (only show if customLine is currently set) | ZH: "移除 —— 清除自定义短语"
 
 If user chooses "Enter custom text", use AskUserQuestion to get their text. Save as `display.customLine` in config.
 If user chooses "Remove", set `display.customLine` to `""` in config.
+
+### Q7: Plancost 额度显示
+- header: "Plancost" / "套餐额度"
+- question: EN: "Update plancost settings? (currently: {enabled ? 'enabled (' + displayMode + ')' : 'disabled'})" | ZH: "更新 plancost 设置？（当前：{enabled ? '已启用（' + displayMode + '）' : '未启用'}）"
+- multiSelect: false
+- options:
+  - EN: "Keep current" - No change | ZH: "保持当前"
+  - EN: "Edit providers" - Add/update/remove provider keys and model prefixes (run the wizard below) | ZH: "编辑供应商 —— 增改删 key 和模型前缀"
+  - EN: "Switch display mode" - Toggle between auto (按模型) and all (全部显示) — ask which with AskUserQuestion | ZH: "切换显示模式 —— auto/all 二选一"
+  - EN: "Change position" - Re-run the position question (see wizard step 4 below) | ZH: "改位置 —— 重新选择段位置"
+  - EN: "Disable plancost" - Set `plancost.enabled: false` (only when currently enabled) | ZH: "停用 plancost —— 设为 enabled: false"
+  - EN: "Enable and configure" - Enable and run the wizard (only when currently disabled) | ZH: "启用并配置 —— 启用并运行向导"
+
+---
+
+## Plancost 设置向导（Q7 共用）
+
+**安全红线（全程遵守）**：API key 只能通过文件写入 API（Write/Edit 工具 + JSON 序列化）写入 `~/.claude/plugins/claude-hud/config.json`。**严禁**把 key 放进 shell 命令行参数、echo 输出、settings.json 或任何命令字符串（防进程列表泄露）。写入后提醒用户 key 为明文存储。
+
+**官方登录检测（启用场景）**：当从"未启用"切换到"启用"时，先按 setup.md Step 4.6.0 的判定逻辑检测 Anthropic 官方 OAuth（读 `~/.claude/settings.json` env + `~/.claude.json` oauthAccount）；若判定为 OFFICIAL_OAUTH，AskUserQuestion（双语）提示："已检测到官方 coding plan（usage 段已显示官方额度），是否还要启用第三方 plancost？" → 仍启用 / 跳过。中转/API key/Bedrock 等场景不提示。
+
+1. **逐家询问**（Kimi → DeepSeek → 智谱 GLM，AskUserQuestion 双语，每家独立）：
+   - EN: "Enable {provider} plancost display?" | ZH: "启用 {provider} 的 plancost 额度显示？"
+   - EN: "Enter key and enable" | ZH: "填写 key 并启用"（选 Other 输入 key）；EN: "Skip" | ZH: "跳过"（保留现有 key 时用 "Keep current" 选项）
+   - key 格式：Kimi `sk-kimi-...`；DeepSeek `sk-...`；GLM `{id}.{secret}` 不含 `sk-` 前缀
+2. **模型前缀**：默认建议 Kimi `["k3","kimi"]`、DeepSeek `["deepseek"]`、GLM `["glm","chatglm"]`，用户可 Other 输入自定义（逗号分隔）
+3. **显示模式**：EN: "auto（按模型）" | ZH: "auto（推荐）按当前主对话模型自动切换" / EN: "all" | ZH: "all 同时显示全部"
+4. **排布位置**：EN: "After cost (default)" | ZH: "费用之后（默认，不写 projectLineOrder）" / EN: "After model" | ZH: "模型名之后（`["model","plancost"]`）" / EN: "First" | ZH: "行首（`["plancost"]`）" / EN: "Last" | ZH: "行尾（完整 11 项顺序）"
+5. **写入 config.json**：`plancost` 块与现有键合并写入（只写用户选中的键），格式：
+   ```json
+   { "plancost": { "enabled": true, "displayMode": "auto",
+     "providers": { "kimi": { "apiKey": "...", "models": ["k3","kimi"] } } } }
+   ```
 
 ---
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -3,6 +3,38 @@ description: Configure claude-hud as your statusline
 allowed-tools: Bash, Read, Edit, AskUserQuestion
 ---
 
+## Step -1: Detect Language (Run First)
+
+**IMPORTANT**: Every question and user-facing message below is provided in both
+English (EN) and Simplified Chinese (ZH). Read the HUD config and pick the
+language BEFORE asking anything:
+
+```bash
+# macOS/Linux
+if [ -f "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/claude-hud/config.json" ]; then
+  LANG_HUD=$(node -e "try { const c = JSON.parse(require('fs').readFileSync(process.env.HOME + '/.claude/plugins/claude-hud/config.json', 'utf8')); process.stdout.write(c.language || 'en'); } catch { process.stdout.write('en'); }" 2>/dev/null || echo en)
+else
+  LANG_HUD=en
+fi
+```
+
+**Windows (PowerShell)**:
+```powershell
+$langHud = "en"
+$cfgPath = Join-Path (if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }) "plugins\claude-hud\config.json"
+if (Test-Path $cfgPath) {
+  try { $langHud = (Get-Content $cfgPath -Raw | ConvertFrom-Json).language } catch {}
+}
+```
+
+- `LANG_HUD` = `en` → use the **EN** variant of every question below
+- `LANG_HUD` = `zh-Hans` / `zh-Hant` / `zh` / `zh-TW` → use the **ZH (简体中文)** variant
+
+For any user-facing AskUserQuestion, if the EN and ZH variants differ, show
+the one matching `LANG_HUD` (EN questions stay fully functional in English
+for everyone; ZH adds Simplified Chinese). Technical shell snippets stay in
+English in both cases.
+
 **Note**: Placeholders like `{RUNTIME_PATH}`, `{SOURCE}`, and `{GENERATED_COMMAND}` should be substituted with actual detected values.
 
 ## Step 0: Detect Ghost Installation (Run First)
@@ -523,13 +555,13 @@ if (Test-Path $settingsPath) {
 
 **If the statusline belongs to a known project or is a custom script**: Use AskUserQuestion to ask the user what to do.
 
-Use AskUserQuestion:
-- header: "Existing statusline detected"
-- question: "Found an existing statusLine in settings.json:\n\n  command preview: {REDACTED_COMMAND_PREVIEW}\n  source: {SOURCE_LABEL}\n\nWhat would you like to do?"
+Use AskUserQuestion (按 `LANG_HUD` 选择语言):
+- header: "Existing statusline detected" / "检测到已有状态栏"
+- question: EN: "Found an existing statusLine in settings.json:\n\n  command preview: {REDACTED_COMMAND_PREVIEW}\n  source: {SOURCE_LABEL}\n\nWhat would you like to do?" | ZH: "在 settings.json 中发现了已有的 statusLine 配置：\n\n  命令预览：{REDACTED_COMMAND_PREVIEW}\n  来源：{SOURCE_LABEL}\n\n你想怎么处理？"
 - options:
-  - "Replace it with claude-hud (your current setup will be backed up)"
-  - "Keep my current statusline and exit setup (settings stay unchanged)"
-  - "Cancel setup without changing settings"
+  - EN: "Replace it with claude-hud (your current setup will be backed up)" | ZH: "替换为 claude-hud（当前配置会备份）"
+  - EN: "Keep my current statusline and exit setup (settings stay unchanged)" | ZH: "保留当前状态栏并退出（不改设置）"
+  - EN: "Cancel setup without changing settings" | ZH: "取消安装（不改设置）"
 
 Set `{REDACTED_COMMAND_PREVIEW}` to `EXISTING_COMMAND_PREVIEW` on macOS/Linux or `$existingCommandPreview` on Windows. Use only the redacted/truncated preview in the prompt and normal output. Do not print the full previous command because it may contain tokens or secrets.
 
@@ -650,15 +682,16 @@ Then continue directly to Step 4 in the same session.
 After the statusLine is applied, ask the user if they'd like to enable additional HUD features beyond the default 2-line display.
 
 Use AskUserQuestion:
-- header: "Extras"
-- question: "Enable any optional HUD features? (all hidden by default)"
+- header: "Extras" / "扩展功能"
+- question: EN: "Enable any optional HUD features? (all hidden by default)" | ZH: "要启用哪些可选 HUD 功能？（默认全部隐藏）"
 - multiSelect: true
 - options:
-  - "Tools activity" — Shows running/completed tools (◐ Edit: file.ts | ✓ Read ×3)
-  - "Agents & Todos" — Shows subagent status and todo progress
-  - "Session info" — Shows session duration and config counts (CLAUDE.md, rules, MCPs)
-  - "Session name" — Shows session slug or custom title from /rename
-  - "Custom line" — Display a custom phrase in the HUD
+  - "Tools activity" — EN: Shows running/completed tools (◐ Edit: file.ts | ✓ Read ×3) | ZH: 显示运行/完成中的工具
+  - "Agents & Todos" — EN: Shows subagent status and todo progress | ZH: 显示子代理状态和任务进度
+  - "Session info" — EN: Shows session duration and config counts (CLAUDE.md, rules, MCPs) | ZH: 显示会话时长和配置统计
+  - "Session name" — EN: Shows session slug or custom title from /rename | ZH: 显示会话名称
+  - "Custom line" — EN: Display a custom phrase in the HUD | ZH: 显示自定义短语
+  - "Plancost 额度显示" — EN: Third-party coding-plan usage/balance (Kimi/DeepSeek/GLM), requires API keys | ZH: 第三方套餐额度/余额显示（Kimi/DeepSeek/GLM），需填 API key
 
 **If user selects any options**, write `plugins/claude-hud/config.json` inside the Claude config directory (`${CLAUDE_CONFIG_DIR:-$HOME/.claude}` on bash, `$env:CLAUDE_CONFIG_DIR` or `Join-Path $HOME ".claude"` on PowerShell). Create directories if needed:
 
@@ -669,6 +702,7 @@ Use AskUserQuestion:
 | Session info | `display.showDuration: true, display.showConfigCounts: true` |
 | Session name | `display.showSessionName: true` |
 | Custom line | `display.customLine: "<user's text>"` — ask user for the text (max 80 chars) |
+| Plancost 额度显示 | `plancost.enabled: true` 及 `plancost.displayMode`、`plancost.providers`、`projectLineOrder`（见 Step 4.6 向导；未选中则**不写任何 plancost 键**） |
 
 Merge with existing config if the file already exists. Only write keys the user selected — don't write `false` for unselected items (defaults handle that).
 
@@ -680,13 +714,13 @@ Claude Code only re-runs the statusline after an interaction (a new assistant me
 
 Of those, only the usage reset countdown is shown by default — session duration and the prompt-cache countdown tick only if the user enabled them (e.g. "Session info" in Step 4, or via config). Mention this if the user seems unsure whether the timer is worth it.
 
-Ask with AskUserQuestion:
-- header: "Auto-refresh"
-- question: "Re-run the HUD on a timer so time-based info (session duration, usage countdowns) stays current between messages?"
+Ask with AskUserQuestion（按 `LANG_HUD` 选择语言）:
+- header: "Auto-refresh" / "自动刷新"
+- question: EN: "Re-run the HUD on a timer so time-based info (session duration, usage countdowns) stays current between messages?" | ZH: "是否定时刷新 HUD，让基于时间的信息（会话时长、额度倒计时）在消息间隙保持最新？"
 - options:
-  - "Every 5 seconds (Recommended)" — Keeps countdowns fresh with negligible overhead
-  - "Every 1 second" — Smoothest ticking; re-runs the HUD command far more often
-  - "No timer" — HUD updates only after interactions (Claude Code's default)
+  - EN: "Every 5 seconds (Recommended)" — Keeps countdowns fresh with negligible overhead | ZH: "每 5 秒（推荐）—— 开销可忽略"
+  - EN: "Every 1 second" — Smoothest ticking; re-runs the HUD command far more often | ZH: "每 1 秒 —— 最平滑的计时"
+  - EN: "No timer" — HUD updates only after interactions (Claude Code's default) | ZH: "不设定时 —— 仅在交互后更新（Claude Code 默认）"
 
 **If the user picks an interval**, merge `refreshInterval: <N>` into the **existing** `statusLine` object in `settings.json` — preserve `type`, `command`, and any other keys. Follow the same rules as Step 3: real JSON serializer, no BOM on Windows, retry once on a concurrent-modification error. Do not re-create the backup; the Step 2.5.3 backup already covers this session.
 
@@ -700,13 +734,122 @@ Each refresh re-runs the full HUD command (runtime startup, transcript parse, gi
 
 ---
 
+## Step 4.6: Plancost 额度显示向导（fork/PR 功能）
+
+**仅当用户在上一步勾选了 "Plancost 额度显示" 时执行本节**；未勾选则跳过，不写任何 `plancost` 键。
+
+### 4.6.0 官方登录检测（OAuth detection）
+
+**先用 Bash 检测当前 Claude Code 是否登录 Anthropic 官方账号**（官方 coding plan 用户：claude-hud 的 usage 段已显示官方 rate_limits 额度，第三方 plancost 可能重复）：
+
+**macOS/Linux**:
+```bash
+SETTINGS="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+CLAUDE_JSON="${CLAUDE_CONFIG_DIR:-$HOME/.claude}.json"
+BASE_URL=$(node -e "try { const s = JSON.parse(require('fs').readFileSync('$SETTINGS', 'utf8')); process.stdout.write(s.env?.ANTHROPIC_BASE_URL || s.env?.ANTHROPIC_API_BASE_URL || ''); } catch { }" 2>/dev/null)
+API_KEY=$(node -e "try { const s = JSON.parse(require('fs').readFileSync('$SETTINGS', 'utf8')); process.stdout.write(s.env?.ANTHROPIC_API_KEY || ''); } catch { }" 2>/dev/null)
+AUTH_TOKEN=$(node -e "try { const s = JSON.parse(require('fs').readFileSync('$SETTINGS', 'utf8')); process.stdout.write(s.env?.ANTHROPIC_AUTH_TOKEN || ''); } catch { }" 2>/dev/null)
+HAS_OAUTH=$(node -e "try { const c = JSON.parse(require('fs').readFileSync('$CLAUDE_JSON', 'utf8')); process.stdout.write(c.oauthAccount ? '1' : '0'); } catch { process.stdout.write('0'); }" 2>/dev/null)
+```
+
+**Windows (PowerShell)**:
+```powershell
+$settingsPath = if ($env:CLAUDE_CONFIG_DIR) { Join-Path $env:CLAUDE_CONFIG_DIR "settings.json" } else { Join-Path $HOME ".claude\settings.json" }
+$claudeJsonPath = if ($env:CLAUDE_CONFIG_DIR) { "$env:CLAUDE_CONFIG_DIR.json" } else { "$HOME\.claude.json" }
+$baseUrl = ""; $apiKey = ""; $authToken = ""; $hasOAuth = "0"
+try { $j = Get-Content $settingsPath -Raw | ConvertFrom-Json; $baseUrl = $j.env.ANTHROPIC_BASE_URL; $apiKey = $j.env.ANTHROPIC_API_KEY; $authToken = $j.env.ANTHROPIC_AUTH_TOKEN } catch {}
+try { $hasOAuth = if ((Get-Content $claudeJsonPath -Raw | ConvertFrom-Json).oauthAccount) { "1" } else { "0" } } catch {}
+```
+
+**判定逻辑（顺序判断，命中即止）**：
+1. 环境变量 `CLAUDE_CODE_USE_BEDROCK` 或 `CLAUDE_CODE_USE_VERTEX` 为 `1` → Bedrock/Vertex，**不提示**（usage 段被隐藏）
+2. `$BASE_URL` 非空且不是以 `https://api.anthropic.com` 开头 → **第三方中转**，**不提示**（正是 plancost 的目标用户）
+3. `$API_KEY` 非空 → API key 计费（无 rate_limits），**不提示**
+4. `$AUTH_TOKEN` 非空 → 中转 token，**不提示**
+5. `$HAS_OAUTH` = `1` → **OFFICIAL_OAUTH**（官方 coding plan）→ **提示**（继续下面的 AskUserQuestion）
+6. 其他 → UNKNOWN，**不提示**
+
+**仅当判定为 OFFICIAL_OAUTH 时**，用 AskUserQuestion（按 `LANG_HUD` 选择语言）：
+- header: "Official plan detected" / "检测到官方套餐"
+- question: EN: "You are signed in with an Anthropic official coding plan — the HUD's usage segment already shows the official rate limits. Do you also want to enable third-party plancost display (Kimi/DeepSeek/GLM)?" | ZH: "检测到你已登录 Anthropic 官方 coding plan，HUD 的 usage 段已显示官方额度。是否还要启用第三方 plancost 额度显示（Kimi/DeepSeek/GLM）？"
+- options:
+  - "Enable plancost" / "仍启用" — Continue to the plancost wizard below
+  - "Skip" / "跳过" — Do not write any plancost keys
+
+**If the user chooses Skip (or the detection is not OFFICIAL_OAUTH)**: continue below only when the user still wants plancost (they may have picked "Plancost" explicitly — treat the detection as informational; if they picked Skip, do not write plancost keys and skip 4.6.1-4.6.5).
+
+### 4.6.1 逐家询问启用并收集 key
+
+对 **Kimi → DeepSeek → 智谱 GLM** 依次询问（每家独立，用 AskUserQuestion，按 `LANG_HUD` 选择语言）：
+
+- header: "Provider" / "供应商"
+- question: EN: "Enable {provider} plancost display? ({key format hint})" | ZH: "启用 {provider} 的 plancost 额度显示？（{key 格式提示}）"
+- options:
+  - "Enter key and enable" / "填写 key 并启用"
+  - "Skip" / "跳过"
+  - Kimi：Kimi For Coding key，形如 `sk-kimi-...`，在 https://www.kimi.com/code/console 创建
+  - DeepSeek：形如 `sk-...`，在 https://platform.deepseek.com/api_keys 创建
+  - 智谱 GLM：形如 `{id}.{secret}`（不含 `sk-` 前缀），在 https://open.bigmodel.cn 创建
+- 用户选择 "填写 key 并启用" 后，用 AskUserQuestion 收集 key 文本（用户通过 Other 输入）
+
+**安全红线（全程遵守）**：API key 只能通过文件写入 API（Write/Edit 工具 + JSON 序列化）写入 `~/.claude/plugins/claude-hud/config.json`（Windows 上为 `%USERPROFILE%\.claude\plugins\claude-hud\config.json`）。**严禁**把 key 放进 shell 命令行参数、echo 输出、settings.json 或任何命令字符串（防进程列表泄露）。写入后提醒用户 key 为明文存储。
+
+### 4.6.2 确认模型前缀（可跳过用默认）
+
+每家启用后，确认 `models` 前缀（AskUserQuestion，可跳过用默认）：
+- 默认建议：Kimi `["k3", "kimi"]`、DeepSeek `["deepseek"]`、GLM `["glm", "chatglm"]`（按模型名前缀匹配，小写不敏感）
+- 用户可 Other 输入自定义前缀（逗号分隔）
+- 说明：EN: "Model names starting with these prefixes map to this provider (e.g. k3[1M] → Kimi, deepseek-v4-flash[1M] → DeepSeek)" | ZH: "模型名以这些前缀开头时视为该供应商（如 k3[1M] → Kimi、deepseek-v4-flash[1M] → DeepSeek）"
+
+### 4.6.3 显示模式
+
+AskUserQuestion（按 `LANG_HUD` 选择语言）:
+- header: "Display mode" / "显示模式"
+- question: EN: "Which providers should the plancost segment show?" | ZH: "plancost 段显示哪些供应商的额度？"
+- options:
+  - "auto（推荐）" — EN: Match the provider to the model actually used in the main session (subagents ignored) | ZH: 按主对话实际使用的模型自动切换对应供应商（subagent 不干扰）
+  - "all" — EN: Show every configured provider at once | ZH: 同时显示所有已配置 key 的供应商
+
+### 4.6.4 排布位置
+
+AskUserQuestion（按 `LANG_HUD` 选择语言）:
+- header: "Position" / "位置"
+- question: EN: "Where should the plancost segment sit on the first line?" | ZH: "plancost 段放在状态栏第一行的哪个位置？"
+- options:
+  - "After cost (default)" / "费用之后（默认）" — 不写 projectLineOrder，保持原生顺序（cost 之后）
+  - "After model" / "模型名之后" — 写 `"projectLineOrder": ["model", "plancost"]`
+  - "First" / "行首" — 写 `"projectLineOrder": ["plancost"]`
+  - "Last" / "行尾" — 写 `"projectLineOrder": ["model", "project", "advisor", "sessionName", "version", "extra", "duration", "cost", "speed", "auth", "plancost"]`
+
+### 4.6.5 写入 config.json
+
+把收集到的值合并进 `~/.claude/plugins/claude-hud/config.json`（与已有键合并，保留其它配置；文件不存在则创建）：
+
+```json
+{
+  "plancost": {
+    "enabled": true,
+    "displayMode": "auto",
+    "providers": {
+      "kimi": { "apiKey": "sk-kimi-...", "models": ["k3", "kimi"] },
+      "deepseek": { "apiKey": "sk-...", "models": ["deepseek"] },
+      "glm": { "apiKey": "id.secret", "models": ["glm", "chatglm"] }
+    }
+  }
+}
+```
+
+只写用户实际启用的 provider；未启用的不要写入。位置选择对应写入 `projectLineOrder`（见 4.6.4）。写入后提醒（双语按 `LANG_HUD`）：EN: "Keys are stored in plain text — do not share config.json." | ZH: "key 为明文存储，请勿把 config.json 分享出去。"
+
+---
+
 ## Step 5: Verify & Finish
 
 Settings reload automatically, so the HUD can appear in the same session where setup was run — it renders after the user's next interaction (their answer to the question below counts as one). No restart is needed on current Claude Code versions.
 
-Use AskUserQuestion:
-- Question: "Setup complete! The HUD should appear below your input field. Is it working?"
-- Options: "Yes, it's working" / "No, something's wrong"
+Use AskUserQuestion（按 `LANG_HUD` 选择语言）:
+- Question: EN: "Setup complete! The HUD should appear below your input field. Is it working?" | ZH: "安装完成！HUD 应显示在输入框下方。工作正常吗？"
+- Options: EN: "Yes, it's working" / "No, something's wrong" | ZH: "正常" / "有问题"
 
 **If yes**: Ask the user if they'd like to ⭐ star the claude-hud repository on GitHub to support the project. If they agree and `gh` CLI is available, first check whether their `gh` version supports `gh repo star`. If it does, run `gh repo star jarrodwatts/claude-hud`. Otherwise fall back to `gh api -X PUT /user/starred/jarrodwatts/claude-hud`. Only run the star command if they explicitly say yes.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import { getHudPluginDir } from './claude-config-dir.js';
 import { createDebug } from './debug.js';
 import type { Language } from './i18n/types.js';
+import { sanitizeDisplayText } from './utils/sanitize.js';
 import { MAX_TERMINAL_WIDTH } from './utils/terminal.js';
 
 const debug = createDebug('config');
@@ -76,9 +77,36 @@ export type FirstLineSegment =
   | 'duration'
   | 'cost'
   | 'speed'
-  | 'auth';
+  | 'auth'
+  | 'plancost';
 
 export type AddedDirsLayout = 'inline' | 'line';
+
+/**
+ * Plancost segment — shows third-party model-provider usage (Kimi /
+ * DeepSeek / GLM coding-plan quota or account balance). Configured manually
+ * with the provider API keys; see README for where each key comes from.
+ *
+ *   displayMode "auto": show only the provider whose `models` prefix matches
+ *                       the current main-session model (transcript-first).
+ *   displayMode "all":  show every provider that has a non-empty apiKey.
+ */
+export type PlancostDisplayMode = 'auto' | 'all';
+
+export interface PlancostProviderConfig {
+  apiKey: string;
+  /** Model-name prefixes matched case-insensitively (e.g. "k3" matches "k3[1M]"). */
+  models: string[];
+  /** Optional API base override (e.g. GLM international: https://api.z.ai). */
+  endpoint?: string;
+}
+
+export interface PlancostConfig {
+  enabled: boolean;
+  displayMode: PlancostDisplayMode;
+  providers: Record<string, PlancostProviderConfig>;
+}
+
 export type HudColorName =
   | 'dim'
   | 'red'
@@ -139,6 +167,7 @@ const PROJECT_LINE_SEGMENTS: FirstLineSegment[] = [
   'cost',
   'speed',
   'auth',
+  'plancost',
 ];
 
 // An empty order is deliberate: renderers retain their byte-for-byte native
@@ -171,6 +200,7 @@ export interface HudConfig {
     showDirty: boolean;
     showConflicts: boolean;
   };
+  plancost: PlancostConfig;
   display: {
     showModel: boolean;
     showProject: boolean;
@@ -289,6 +319,11 @@ export const DEFAULT_CONFIG: HudConfig = {
     enabled: false,
     showDirty: true,
     showConflicts: true,
+  },
+  plancost: {
+    enabled: false,
+    displayMode: 'auto',
+    providers: {},
   },
   display: {
     showModel: true,
@@ -511,6 +546,38 @@ function validateProjectLineOrder(value: unknown): FirstLineSegment[] {
   return order;
 }
 
+const KNOWN_PLANCOST_PROVIDERS = new Set(['kimi', 'deepseek', 'glm']);
+
+function validatePlancostDisplayMode(value: unknown): value is PlancostDisplayMode {
+  return value === 'auto' || value === 'all';
+}
+
+function mergePlancostProviders(raw: unknown): Record<string, PlancostProviderConfig> {
+  const out: Record<string, PlancostProviderConfig> = {};
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return out;
+  for (const [name, entry] of Object.entries(raw as Record<string, unknown>)) {
+    if (!KNOWN_PLANCOST_PROVIDERS.has(name)) continue;
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const e = entry as Record<string, unknown>;
+    const apiKey = typeof e.apiKey === 'string'
+      ? sanitizeDisplayText(e.apiKey).trim().slice(0, 512)
+      : '';
+    if (!apiKey) continue;
+    const models = Array.isArray(e.models)
+      ? e.models
+          .filter((m): m is string => typeof m === 'string')
+          .map(m => sanitizeDisplayText(m).trim().toLowerCase().slice(0, 64))
+          .filter(Boolean)
+          .slice(0, 8)
+      : [];
+    const endpoint = typeof e.endpoint === 'string'
+      ? sanitizeDisplayText(e.endpoint).trim().slice(0, 256)
+      : undefined;
+    out[name] = { apiKey, models, ...(endpoint ? { endpoint } : {}) };
+  }
+  return out;
+}
+
 function validateRightAlign(value: unknown): HudElement[] {
   if (!Array.isArray(value)) {
     return [...DEFAULT_CONFIG.display.rightAlign];
@@ -723,6 +790,16 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showConflicts: typeof migrated.jjStatus?.showConflicts === 'boolean'
       ? migrated.jjStatus.showConflicts
       : DEFAULT_CONFIG.jjStatus.showConflicts,
+  };
+
+  const plancost = {
+    enabled: typeof migrated.plancost?.enabled === 'boolean'
+      ? migrated.plancost.enabled
+      : DEFAULT_CONFIG.plancost.enabled,
+    displayMode: validatePlancostDisplayMode(migrated.plancost?.displayMode)
+      ? migrated.plancost.displayMode
+      : DEFAULT_CONFIG.plancost.displayMode,
+    providers: mergePlancostProviders(migrated.plancost?.providers),
   };
 
   const display = {
@@ -953,7 +1030,7 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
       : DEFAULT_CONFIG.colors.barEmpty,
   };
 
-  return { language, lineLayout, showSeparators, pathLevels, maxWidth, forceMaxWidth, elementOrder, projectLineOrder, gitStatus, jjStatus, display, colors };
+  return { language, lineLayout, showSeparators, pathLevels, maxWidth, forceMaxWidth, elementOrder, projectLineOrder, gitStatus, jjStatus, plancost, display, colors };
 }
 
 export async function loadConfig(): Promise<HudConfig> {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -5,6 +5,7 @@ export const en: Messages = {
   "label.context": "Context",
   "label.usage": "Usage",
   "label.weekly": "Weekly",
+  "label.plancostWeek": "week",
   "label.approxRam": "Approx RAM",
   "label.promptCache": "Cache",
   "label.rules": "rules",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -3,6 +3,7 @@ export type MessageKey =
   | "label.context"
   | "label.usage"
   | "label.weekly"
+  | "label.plancostWeek"
   | "label.approxRam"
   | "label.promptCache"
   | "label.rules"

--- a/src/i18n/zh-Hans.ts
+++ b/src/i18n/zh-Hans.ts
@@ -5,6 +5,7 @@ export const zhHans: Messages = {
   "label.context": "上下文",
   "label.usage": "用量",
   "label.weekly": "本周",
+  "label.plancostWeek": "周",
   "label.approxRam": "内存",
   "label.promptCache": "缓存",
   "label.rules": "规则",

--- a/src/i18n/zh-Hant.ts
+++ b/src/i18n/zh-Hant.ts
@@ -5,6 +5,7 @@ export const zhHant: Messages = {
   "label.context": "上下文",
   "label.usage": "用量",
   "label.weekly": "本週",
+  "label.plancostWeek": "週",
   "label.approxRam": "記憶體",
   "label.promptCache": "快取",
   "label.rules": "規則",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { getGitStatus } from "./git.js";
 import { getJjStatus, isJjRepo } from "./jj.js";
 import { loadConfig } from "./config.js";
 import { parseExtraCmdArg, runExtraCmd } from "./extra-cmd.js";
+import { collectPlancost } from "./plancost.js";
 import { getClaudeCodeVersion } from "./version.js";
 import { getMemoryUsage } from "./memory.js";
 import { readAuthInfo } from "./auth.js";
@@ -34,6 +35,7 @@ export type MainDeps = {
   loadConfig: typeof loadConfig;
   parseExtraCmdArg: typeof parseExtraCmdArg;
   runExtraCmd: typeof runExtraCmd;
+  collectPlancost: typeof collectPlancost;
   getClaudeCodeVersion: typeof getClaudeCodeVersion;
   getMemoryUsage: typeof getMemoryUsage;
   readAuthInfo: typeof readAuthInfo;
@@ -98,6 +100,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     loadConfig,
     parseExtraCmdArg,
     runExtraCmd,
+    collectPlancost,
     getClaudeCodeVersion,
     getMemoryUsage,
     readAuthInfo,
@@ -181,6 +184,10 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     const extraCmd = deps.parseExtraCmdArg();
     const extraLabel = extraCmd ? await deps.runExtraCmd(extraCmd) : null;
 
+    const plancostData = config.plancost.enabled
+      ? await deps.collectPlancost(config, stdin, transcript)
+      : [];
+
     const sessionDuration = formatSessionDuration(
       transcript.sessionStart,
       deps.now,
@@ -218,6 +225,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       effortLevel: effortInfo?.level,
       effortSymbol: effortInfo?.symbol,
       authInfo,
+      plancostData,
     };
 
     deps.render(ctx);

--- a/src/plancost.ts
+++ b/src/plancost.ts
@@ -1,0 +1,329 @@
+/**
+ * Plancost data collection for third-party model providers.
+ *
+ * Queries coding-plan usage or account balance directly from the provider
+ * APIs (Kimi / DeepSeek / GLM), with a 5-minute disk cache so the statusline
+ * process (spawned fresh on every refresh) does not hit the network each tick.
+ *
+ * Key design points:
+ *  - `collectPlancost` NEVER throws: failures degrade to fewer/missing segments.
+ *  - Cache is keyed by a hash of the apiKey — swapping keys invalidates old
+ *    data immediately (no cross-provider / cross-key contamination).
+ *  - Provider responses are untrusted terminal input: every displayed string
+ *    passes through `sanitizeDisplayText` before being cached or rendered.
+ */
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { getHudPluginDir } from './claude-config-dir.js';
+import type { PlancostConfig, PlancostProviderConfig } from './config.js';
+import { sanitizeTranscriptModel } from './model-source.js';
+import { getModelName } from './stdin.js';
+import { sanitizeDisplayText } from './utils/sanitize.js';
+import type { StdinData, TranscriptData } from './types.js';
+
+export type PlancostProviderId = 'kimi' | 'deepseek' | 'glm';
+
+export interface PlancostWindow {
+  label: '5h' | 'week';
+  /** 0-100 percentage of the window used. */
+  percent: number;
+  resetAt: Date | null;
+}
+
+export interface PlancostData {
+  provider: PlancostProviderId;
+  /** Windows present for coding-plan providers (kimi / glm). */
+  windows?: PlancostWindow[];
+  /** Balance present for pay-as-you-go providers (deepseek). */
+  balance?: { amount: number; currency: string };
+}
+
+export type PlancostDeps = {
+  fetchImpl: typeof fetch;
+  now: () => number;
+  cacheDir: () => string;
+};
+
+const TTL = 300_000; // 5 minutes
+const TIMEOUT_MS = 2_000; // per-request timeout; keep the statusline refresh snappy
+
+/**
+ * Resolve the model the plancost segment should match against.
+ *
+ * Transcript `lastAssistantModel` reflects the model the API actually served
+ * (proxy redirects included) and is preferred for 'auto'/'transcript'; stdin
+ * model (what Claude Code thinks it is using) is the fallback, covering
+ * sessions that have not produced an assistant message yet.
+ */
+export function resolvePlancostModel(
+  stdin: StdinData,
+  transcript: TranscriptData,
+  modelSource: 'auto' | 'stdin' | 'transcript',
+): string {
+  const transcriptModel = sanitizeTranscriptModel(transcript?.lastAssistantModel);
+  if (modelSource === 'stdin') return getModelName(stdin);
+  return transcriptModel ?? getModelName(stdin);
+}
+
+/**
+ * Select the providers to display.
+ *  - "auto": the first provider (config key order) whose `models` prefix
+ *    matches the current model; none when nothing matches.
+ *  - "all": every provider with a non-empty apiKey, in config key order.
+ */
+export function matchPlancostProviders(cfg: PlancostConfig, model: string): PlancostProviderId[] {
+  const withKey = Object.entries(cfg.providers)
+    .filter(([, p]) => p.apiKey)
+    .map(([name]) => name) as PlancostProviderId[];
+  if (cfg.displayMode === 'all') return withKey;
+  const low = model.toLowerCase();
+  for (const name of withKey) {
+    const p = cfg.providers[name];
+    if (p.models.some(m => low.startsWith(m))) return [name];
+  }
+  return [];
+}
+
+// ---------- response parsers (pure functions) ----------
+
+function clampPercent(value: unknown): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+function parseDate(value: unknown): Date | null {
+  if (typeof value === 'string') {
+    const t = Date.parse(value);
+    if (!Number.isNaN(t)) return new Date(t);
+    return null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    // GLM sends millisecond timestamps; seconds fallback via the >1e12 heuristic.
+    return new Date(value > 1e12 ? value : value * 1000);
+  }
+  return null;
+}
+
+function windowFrom(o: Record<string, unknown>, label: PlancostWindow['label']): PlancostWindow | null {
+  const limit = Number(o.limit);
+  if (!(limit > 0)) return null;
+  const used = Number(o.used);
+  if (!Number.isFinite(used) || used < 0) return null;
+  return { label, percent: clampPercent((used / limit) * 100), resetAt: parseDate(o.resetTime) };
+}
+
+/** Kimi For Coding: 5h window in limits[0].detail, weekly quota in usage. */
+export function parseKimiResponse(raw: unknown): PlancostData | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const d = raw as Record<string, unknown>;
+  const windows: PlancostWindow[] = [];
+  const limits = d.limits;
+  const detail = Array.isArray(limits)
+    ? (limits[0] as Record<string, unknown> | undefined)?.detail
+    : undefined;
+  if (detail && typeof detail === 'object') {
+    const w = windowFrom(detail as Record<string, unknown>, '5h');
+    if (w) windows.push(w);
+  }
+  if (d.usage && typeof d.usage === 'object') {
+    const w = windowFrom(d.usage as Record<string, unknown>, 'week');
+    if (w) windows.push(w);
+  }
+  return windows.length ? { provider: 'kimi', windows } : null;
+}
+
+/** DeepSeek: account balance. total_balance is a string; currency CNY/USD. */
+export function parseDeepSeekResponse(raw: unknown): PlancostData | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const infos = (raw as Record<string, unknown>).balance_infos;
+  if (!Array.isArray(infos) || !infos[0] || typeof infos[0] !== 'object') return null;
+  const b = infos[0] as Record<string, unknown>;
+  const amount = Number(b.total_balance);
+  if (!Number.isFinite(amount)) return null;
+  const currency = typeof b.currency === 'string'
+    ? sanitizeDisplayText(b.currency).trim().slice(0, 8)
+    : '';
+  return { provider: 'deepseek', balance: { amount, currency: currency || 'CNY' } };
+}
+
+/**
+ * GLM (Zhipu): TOKENS_LIMIT windows. unit 3 → 5h window, unit 6 → weekly;
+ * other units fill the missing slots ordered by next reset time.
+ */
+export function parseGlmResponse(raw: unknown): PlancostData | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const data = (raw as Record<string, unknown>).data;
+  const limits = data && typeof data === 'object' && Array.isArray((data as Record<string, unknown>).limits)
+    ? (data as Record<string, unknown>).limits as unknown[]
+    : [];
+  const slots: PlancostWindow[] = [];
+  const others: { percent: number; resetAt: Date | null }[] = [];
+  for (const item of limits) {
+    if (!item || typeof item !== 'object') continue;
+    const l = item as Record<string, unknown>;
+    if (String(l.type ?? '').toUpperCase() !== 'TOKENS_LIMIT') continue;
+    const percent = clampPercent(l.percentage);
+    const resetAt = parseDate(l.nextResetTime);
+    if (l.unit === 3) slots.push({ label: '5h', percent, resetAt });
+    else if (l.unit === 6) slots.push({ label: 'week', percent, resetAt });
+    else others.push({ percent, resetAt });
+  }
+  others.sort((a, b) => (a.resetAt?.getTime() ?? Infinity) - (b.resetAt?.getTime() ?? Infinity));
+  if (!slots.some(s => s.label === '5h') && others.length) slots.push({ label: '5h', ...others.shift()! });
+  if (!slots.some(s => s.label === 'week') && others.length) slots.push({ label: 'week', ...others.shift()! });
+  slots.sort((a, b) => (a.label === '5h' ? 0 : 1) - (b.label === '5h' ? 0 : 1));
+  return slots.length ? { provider: 'glm', windows: slots } : null;
+}
+
+// ---------- fetch ----------
+
+async function getJson(url: string, headers: Record<string, string>, fetchImpl: typeof fetch): Promise<unknown> {
+  const res = await fetchImpl(url, { headers, signal: AbortSignal.timeout(TIMEOUT_MS) });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+async function fetchKimi(key: string, fetchImpl: typeof fetch): Promise<PlancostData> {
+  const raw = await getJson(
+    'https://api.kimi.com/coding/v1/usages',
+    { Authorization: `Bearer ${key}`, Accept: 'application/json' },
+    fetchImpl,
+  );
+  const data = parseKimiResponse(raw);
+  if (!data) throw new Error('invalid kimi payload');
+  return data;
+}
+
+async function fetchDeepSeek(key: string, fetchImpl: typeof fetch): Promise<PlancostData> {
+  const raw = await getJson(
+    'https://api.deepseek.com/user/balance',
+    { Authorization: `Bearer ${key}`, Accept: 'application/json' },
+    fetchImpl,
+  );
+  const data = parseDeepSeekResponse(raw);
+  if (!data) throw new Error('invalid deepseek payload');
+  return data;
+}
+
+async function fetchGlm(key: string, endpoint: string | undefined, fetchImpl: typeof fetch): Promise<PlancostData> {
+  const base = endpoint || 'https://open.bigmodel.cn';
+  const raw = await getJson(
+    `${base}/api/monitor/usage/quota/limit`,
+    // GLM authenticates with the bare key — no Bearer prefix (auth fails with one).
+    { Authorization: key, 'Accept-Language': 'en-US,en' },
+    fetchImpl,
+  );
+  const data = parseGlmResponse(raw);
+  if (!data) throw new Error('invalid glm payload');
+  return data;
+}
+
+// ---------- disk cache ----------
+
+interface CacheEntry {
+  keyHash: string;
+  updatedAt: number;
+  data: PlancostData;
+}
+
+interface CacheRead {
+  data: PlancostData;
+  updatedAt: number;
+}
+
+function keyHashOf(apiKey: string): string {
+  return crypto.createHash('sha256').update(apiKey).digest('hex').slice(0, 12);
+}
+
+function cachePathFor(cacheDir: string, provider: string): string {
+  return path.join(cacheDir, `${provider}.json`);
+}
+
+/** JSON round-trips Date to an ISO string; restore it on cache read. */
+function revivePlancostData(data: PlancostData): PlancostData {
+  if (!data.windows) return data;
+  return {
+    ...data,
+    windows: data.windows.map(w => ({
+      ...w,
+      resetAt: typeof w.resetAt === 'string' ? new Date(w.resetAt) : w.resetAt,
+    })),
+  };
+}
+
+function readCache(cacheDir: string, provider: string, keyHash: string): CacheRead | null {
+  try {
+    const entry = JSON.parse(fs.readFileSync(cachePathFor(cacheDir, provider), 'utf8')) as CacheEntry;
+    if (entry.keyHash !== keyHash || !entry.data) return null;
+    return { data: revivePlancostData(entry.data), updatedAt: entry.updatedAt };
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(cacheDir: string, provider: string, keyHash: string, updatedAt: number, data: PlancostData): void {
+  try {
+    fs.mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
+    const target = cachePathFor(cacheDir, provider);
+    const tmp = `${target}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify({ keyHash, updatedAt, data } satisfies CacheEntry), { mode: 0o600 });
+    fs.renameSync(tmp, target);
+  } catch { /* cache write failures must not break the segment */ }
+}
+
+// ---------- collect ----------
+
+async function fetchOrCache(provider: PlancostProviderId, cfg: PlancostProviderConfig, deps: PlancostDeps): Promise<PlancostData> {
+  const keyHash = keyHashOf(cfg.apiKey);
+  const dir = deps.cacheDir();
+  const cached = readCache(dir, provider, keyHash);
+  if (cached && deps.now() - cached.updatedAt <= TTL) return cached.data;
+  try {
+    const data = provider === 'kimi'
+      ? await fetchKimi(cfg.apiKey, deps.fetchImpl)
+      : provider === 'deepseek'
+        ? await fetchDeepSeek(cfg.apiKey, deps.fetchImpl)
+        : await fetchGlm(cfg.apiKey, cfg.endpoint, deps.fetchImpl);
+    writeCache(dir, provider, keyHash, deps.now(), data);
+    return data;
+  } catch {
+    // Network failure: fall back to stale cache for the same key, if any.
+    if (cached) return cached.data;
+    throw new Error(`plancost fetch failed: ${provider}`);
+  }
+}
+
+export async function collectPlancost(
+  config: HudConfigLike,
+  stdin: StdinData,
+  transcript: TranscriptData,
+  deps?: Partial<PlancostDeps>,
+): Promise<PlancostData[]> {
+  const d: PlancostDeps = {
+    fetchImpl: globalThis.fetch,
+    now: () => Date.now(),
+    cacheDir: () => path.join(getHudPluginDir(os.homedir()), 'plancost-cache'),
+    ...deps,
+  };
+  try {
+    const plancostCfg = config.plancost;
+    if (!plancostCfg?.enabled) return [];
+    const model = resolvePlancostModel(stdin, transcript, config.display?.modelSource ?? 'auto');
+    const providers = matchPlancostProviders(plancostCfg, model);
+    if (providers.length === 0) return [];
+    const settled = await Promise.allSettled(providers.map(p => fetchOrCache(p, plancostCfg.providers[p], d)));
+    return settled.flatMap(r => (r.status === 'fulfilled' ? [r.value] : []));
+  } catch {
+    return [];
+  }
+}
+
+// Type-only shape so the module does not import the whole config module
+// (avoids any import cycle through types.ts).
+type HudConfigLike = {
+  plancost?: PlancostConfig;
+  display?: { modelSource?: 'auto' | 'stdin' | 'transcript' };
+};

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -12,6 +12,7 @@ import { hyperlink, getFileHref, safeHyperlink } from '../../utils/hyperlinks.js
 import { formatModelDisplay } from '../model-display.js';
 import { formatAuthSegment } from '../../auth.js';
 import { formatProjectPath } from '../project-path.js';
+import { formatPlancostLabel } from '../plancost-label.js';
 import { DEFAULT_CONFIG, DEFAULT_PROJECT_LINE_ORDER } from '../../config.js';
 import type { FirstLineSegment } from '../../config.js';
 import { orderFirstLineParts } from '../first-line-order.js';
@@ -150,6 +151,13 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   const costEstimate = renderCostEstimate(ctx);
   if (costEstimate) {
     push(costEstimate, 'cost');
+  }
+
+  if (ctx.plancostData?.length) {
+    const plancostLabel = formatPlancostLabel(ctx.plancostData, t);
+    if (plancostLabel) {
+      push(label(plancostLabel, colors), 'plancost');
+    }
   }
 
   if (display?.showSpeed) {

--- a/src/render/plancost-label.ts
+++ b/src/render/plancost-label.ts
@@ -1,0 +1,53 @@
+/**
+ * Render the plancost segment label from collected PlancostData.
+ *
+ * Plain text + emoji health markers (claude-hud strips ANSI from external
+ * data; emoji survive and read instantly). Thresholds:
+ *   🟢 < 60%  🟡 60–84%  🔴 ≥ 85%
+ */
+import type { PlancostProviderId, PlancostData } from '../plancost.js';
+import type { MessageKey } from '../i18n/types.js';
+
+const PROVIDER_LABELS: Record<PlancostProviderId, string> = { kimi: 'Kimi', deepseek: 'DS', glm: 'GLM' };
+const CURRENCY_SYMBOLS: Record<string, string> = { CNY: '¥', USD: '$' };
+
+function emojiOf(percent: number): '🟢' | '🟡' | '🔴' {
+  return percent >= 85 ? '🔴' : percent >= 60 ? '🟡' : '🟢';
+}
+
+/** Reset time: same day → "(HH:MM)", later day → "(MM/DD)", unknown → "". */
+export function fmtReset(resetAt: Date | null): string {
+  if (!resetAt || Number.isNaN(resetAt.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const now = new Date();
+  if (resetAt.toDateString() === now.toDateString()) {
+    return ` (${pad(resetAt.getHours())}:${pad(resetAt.getMinutes())})`;
+  }
+  return ` (${pad(resetAt.getMonth() + 1)}/${pad(resetAt.getDate())})`;
+}
+
+function windowsLabel(data: PlancostData, t: (k: MessageKey) => string): string {
+  const windows = data.windows ?? [];
+  if (windows.length === 0) return '';
+  const max = Math.max(...windows.map(w => w.percent));
+  const parts = windows.map(w => `${w.label === 'week' ? t('label.plancostWeek') : w.label} ${w.percent}%${fmtReset(w.resetAt)}`);
+  return `${emojiOf(max)} ${PROVIDER_LABELS[data.provider]} ${parts.join(' · ')}`;
+}
+
+function balanceLabel(data: PlancostData): string {
+  const b = data.balance;
+  if (!b) return '';
+  const symbol = CURRENCY_SYMBOLS[b.currency] ?? `${b.currency} `;
+  const amount = Number.isFinite(b.amount) ? b.amount.toFixed(2) : String(b.amount);
+  return `💰 ${PROVIDER_LABELS[data.provider]} ${symbol}${amount}`;
+}
+
+/** Join all providers into a single segment; null when there is nothing to show. */
+export function formatPlancostLabel(data: PlancostData[], t: (k: MessageKey) => string): string | null {
+  const parts: string[] = [];
+  for (const d of data) {
+    const label = d.balance ? balanceLabel(d) : windowsLabel(d, t);
+    if (label) parts.push(label);
+  }
+  return parts.length ? parts.join(' · ') : null;
+}

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -13,6 +13,7 @@ import type { TimeFormatMode, UsageValueMode } from '../config.js';
 import { formatResetTime, type WallClockOptions } from './format-reset-time.js';
 import { formatTokens, formatContextValue } from '../utils/format.js';
 import { formatAuthSegment } from '../auth.js';
+import { formatPlancostLabel } from './plancost-label.js';
 import { createDebug } from '../debug.js';
 import { formatModelDisplay } from './model-display.js';
 import { formatSessionTokenSummary } from './lines/session-tokens.js';
@@ -365,6 +366,13 @@ export function renderSessionLine(ctx: RenderContext): string {
   const costEstimate = renderCostEstimate(ctx);
   if (costEstimate) {
     push(costEstimate, 'cost');
+  }
+
+  if (ctx.plancostData?.length) {
+    const plancostLabel = formatPlancostLabel(ctx.plancostData, t);
+    if (plancostLabel) {
+      push(label(plancostLabel, colors), 'plancost');
+    }
   }
 
   if (display?.showSpeed) {

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -14,6 +14,10 @@ const debug = createDebug('transcript');
 interface TranscriptLine {
   timestamp?: string;
   type?: string;
+  // Harness flag for sidechain (subagent) conversation records. Currently
+  // always false on the main transcript, but filtering on it is a cheap
+  // defense if a future Claude Code version writes subagent turns inline.
+  isSidechain?: boolean;
   subtype?: string;
   operation?: string;
   content?: string;
@@ -478,7 +482,9 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
         // Capture the actual model from the assistant message's `model` field.
         // This reflects what the API actually served, which may differ from the
         // model Claude Code thinks it's using (e.g. proxy redirect via cc-switch).
-        if (entry.type === 'assistant') {
+        // isSidechain guard keeps subagent turns (if a future version writes
+        // them inline) from overriding the main-session model.
+        if (entry.type === 'assistant' && entry.isSidechain !== true) {
           const transcriptModel = sanitizeTranscriptModel(entry.message?.model);
           if (transcriptModel) {
             result.lastAssistantModel = transcriptModel;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { HudConfig } from './config.js';
 import type { GitStatus } from './git.js';
 import type { AuthInfo } from './auth.js';
+import type { PlancostData } from './plancost.js';
 
 export interface StdinData {
   transcript_path?: string;
@@ -205,4 +206,7 @@ export interface RenderContext {
   // Auth method + account for the current login (see auth.ts). Only populated
   // when display.showAuth or display.showAuthUser is enabled.
   authInfo?: AuthInfo | null;
+  // Third-party provider quota/balance data (see plancost.ts). Populated when
+  // plancost.enabled is true; empty array otherwise.
+  plancostData?: PlancostData[];
 }

--- a/tests/plancost-render.test.js
+++ b/tests/plancost-render.test.js
@@ -1,0 +1,106 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatPlancostLabel, fmtReset } from '../dist/render/plancost-label.js';
+import { setLanguage, t } from '../dist/i18n/index.js';
+
+function kimiData(overrides = {}) {
+  return [{
+    provider: 'kimi',
+    windows: [
+      { label: '5h', percent: 15, resetAt: todayAt(3, 44) },
+      { label: 'week', percent: 69, resetAt: tomorrow() },
+    ],
+    ...overrides,
+  }];
+}
+
+function todayAt(hours, minutes) {
+  const d = new Date();
+  d.setHours(hours, minutes, 0, 0);
+  return d;
+}
+
+function tomorrow() {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d;
+}
+
+test('formatPlancostLabel matches the Kimi example verbatim', () => {
+  setLanguage('en');
+  const label = formatPlancostLabel(kimiData(), t);
+  // week 69% falls in the 60-84 band, so the health marker is 🟡 (not 🟢).
+  assert.equal(label, `🟡 Kimi 5h 15% (03:44) · week 69%${fmtReset(tomorrow())}`);
+});
+
+test('formatPlancostLabel renders DeepSeek balance', () => {
+  setLanguage('en');
+  const label = formatPlancostLabel([
+    { provider: 'deepseek', balance: { amount: 40.96, currency: 'CNY' } },
+  ], t);
+  assert.equal(label, '💰 DS ¥40.96');
+});
+
+test('formatPlancostLabel renders USD balance with $ symbol', () => {
+  setLanguage('en');
+  const label = formatPlancostLabel([
+    { provider: 'deepseek', balance: { amount: 5.5, currency: 'USD' } },
+  ], t);
+  assert.equal(label, '💰 DS $5.50');
+});
+
+test('formatPlancostLabel renders GLM windows with the GLM brand', () => {
+  setLanguage('en');
+  const label = formatPlancostLabel([{
+    provider: 'glm',
+    windows: [
+      { label: '5h', percent: 15, resetAt: todayAt(3, 44) },
+      { label: 'week', percent: 69, resetAt: tomorrow() },
+    ],
+  }], t);
+  assert.equal(label.startsWith('🟡 GLM 5h 15% (03:44)'), true);
+});
+
+test('formatPlancostLabel joins multiple providers with separator', () => {
+  setLanguage('en');
+  const label = formatPlancostLabel([
+    ...kimiData(),
+    { provider: 'deepseek', balance: { amount: 40.96, currency: 'CNY' } },
+  ], t);
+  assert.equal(label.includes(' · 💰 DS ¥40.96'), true);
+});
+
+test('formatPlancostLabel emoji thresholds at 59/60/84/85', () => {
+  setLanguage('en');
+  const at = p => formatPlancostLabel([{ provider: 'kimi', windows: [{ label: '5h', percent: p, resetAt: null }] }], t);
+  assert.equal(at(59).startsWith('🟢'), true);
+  assert.equal(at(60).startsWith('🟡'), true);
+  assert.equal(at(84).startsWith('🟡'), true);
+  assert.equal(at(85).startsWith('🔴'), true);
+});
+
+test('formatPlancostLabel returns null for empty data', () => {
+  setLanguage('en');
+  assert.equal(formatPlancostLabel([], t), null);
+});
+
+test('formatPlancostLabel uses localized week label in zh-Hans', () => {
+  setLanguage('zh-Hans');
+  const label = formatPlancostLabel([{
+    provider: 'kimi',
+    windows: [
+      { label: '5h', percent: 10, resetAt: null },
+      { label: 'week', percent: 20, resetAt: null },
+    ],
+  }], t);
+  assert.equal(label, '🟢 Kimi 5h 10% · 周 20%');
+});
+
+test('fmtReset same-day shows HH:MM, later day shows MM/DD, null shows empty', () => {
+  const same = fmtReset(todayAt(3, 44));
+  assert.equal(same, ' (03:44)');
+  const later = fmtReset(tomorrow());
+  const m = /^ \((\d{2})\/(\d{2})\)$/.exec(later);
+  assert.ok(m, `expected (MM/DD), got: ${later}`);
+  assert.equal(fmtReset(null), '');
+});

--- a/tests/plancost.test.js
+++ b/tests/plancost.test.js
@@ -1,0 +1,350 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { DEFAULT_CONFIG } from '../dist/config.js';
+import {
+  collectPlancost,
+  resolvePlancostModel,
+  matchPlancostProviders,
+  parseKimiResponse,
+  parseDeepSeekResponse,
+  parseGlmResponse,
+} from '../dist/plancost.js';
+
+const KIMI_FIXTURE = {
+  limits: [{ window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' }, detail: { limit: '200', used: '30', resetTime: '2026-08-12T03:44:00Z' } }],
+  usage: { limit: '2048', used: '1413', resetTime: '2026-08-15T05:44:00Z' },
+};
+
+const DEEPSEEK_FIXTURE = {
+  is_available: true,
+  balance_infos: [{ currency: 'CNY', total_balance: '40.955', granted_balance: '0.00', topped_up_balance: '40.96' }],
+};
+
+const GLM_FIXTURE = {
+  code: 200,
+  data: {
+    limits: [
+      { type: 'TOKENS_LIMIT', unit: 3, percentage: 15, nextResetTime: 1786537440000 },
+      { type: 'TOKENS_LIMIT', unit: 6, percentage: 69, nextResetTime: 1787137440000 },
+      { type: 'CONCURRENCY_LIMIT', unit: 1, percentage: 5, nextResetTime: 0 },
+    ],
+  },
+};
+
+function makePlancostConfig(overrides = {}) {
+  return {
+    ...DEFAULT_CONFIG,
+    plancost: {
+      enabled: true,
+      displayMode: 'auto',
+      providers: {
+        kimi: { apiKey: 'sk-kimi-test', models: ['k3'] },
+        deepseek: { apiKey: 'sk-test-deepseek', models: ['deepseek'] },
+      },
+      ...overrides,
+    },
+  };
+}
+
+function okJson(payload) {
+  return { ok: true, status: 200, json: async () => payload };
+}
+
+// ---------- resolvePlancostModel ----------
+
+test('resolvePlancostModel prefers transcript model on auto', () => {
+  const stdin = { model: { display_name: 'k3[1M]' } };
+  const transcript = { lastAssistantModel: 'deepseek-v4-flash' };
+  assert.equal(resolvePlancostModel(stdin, transcript, 'auto'), 'deepseek-v4-flash');
+});
+
+test('resolvePlancostModel falls back to stdin model when transcript is empty', () => {
+  const stdin = { model: { display_name: 'k3[1M]' } };
+  assert.equal(resolvePlancostModel(stdin, {}, 'auto'), 'k3[1M]');
+});
+
+test('resolvePlancostModel honors explicit stdin mode', () => {
+  const stdin = { model: { display_name: 'k3[1M]' } };
+  const transcript = { lastAssistantModel: 'deepseek-v4-flash' };
+  assert.equal(resolvePlancostModel(stdin, transcript, 'stdin'), 'k3[1M]');
+});
+
+test('resolvePlancostModel sanitizes transcript model', () => {
+  const stdin = { model: { display_name: 'k3[1M]' } };
+  const transcript = { lastAssistantModel: '\x1b[31mdeepseek\x1b[0m' };
+  assert.equal(resolvePlancostModel(stdin, transcript, 'auto'), 'deepseek');
+});
+
+// ---------- matchPlancostProviders ----------
+
+test('matchPlancostProviders auto matches k3 prefix to kimi', () => {
+  const cfg = makePlancostConfig().plancost;
+  assert.deepEqual(matchPlancostProviders(cfg, 'k3[1M]'), ['kimi']);
+});
+
+test('matchPlancostProviders auto returns [] when nothing matches', () => {
+  const cfg = makePlancostConfig().plancost;
+  assert.deepEqual(matchPlancostProviders(cfg, 'claude-opus'), []);
+});
+
+test('matchPlancostProviders auto is case-insensitive', () => {
+  const cfg = makePlancostConfig().plancost;
+  assert.deepEqual(matchPlancostProviders(cfg, 'K3-256'), ['kimi']);
+});
+
+test('matchPlancostProviders all returns every provider with a key', () => {
+  const cfg = makePlancostConfig({ displayMode: 'all' }).plancost;
+  assert.deepEqual(matchPlancostProviders(cfg, 'anything'), ['kimi', 'deepseek']);
+});
+
+test('matchPlancostProviders skips providers with empty apiKey', () => {
+  const cfg = makePlancostConfig({
+    providers: { kimi: { apiKey: 'sk-kimi-test', models: ['k3'] }, glm: { apiKey: '', models: ['glm'] } },
+    displayMode: 'all',
+  }).plancost;
+  assert.deepEqual(matchPlancostProviders(cfg, 'anything'), ['kimi']);
+});
+
+// ---------- response parsers ----------
+
+test('parseKimiResponse extracts 5h and week windows', () => {
+  const d = parseKimiResponse(KIMI_FIXTURE);
+  assert.ok(d);
+  assert.equal(d.provider, 'kimi');
+  assert.equal(d.windows.length, 2);
+  assert.equal(d.windows[0].label, '5h');
+  assert.equal(d.windows[0].percent, 15);
+  assert.equal(d.windows[1].label, 'week');
+  assert.equal(d.windows[1].percent, 69);
+});
+
+test('parseKimiResponse returns null without valid limits', () => {
+  assert.equal(parseKimiResponse({ usage: {} }), null);
+  assert.equal(parseKimiResponse({ limits: [{ detail: { limit: '0', used: '10' } }] }), null);
+  assert.equal(parseKimiResponse(null), null);
+});
+
+test('parseDeepSeekResponse extracts CNY balance', () => {
+  const d = parseDeepSeekResponse(DEEPSEEK_FIXTURE);
+  assert.ok(d);
+  assert.equal(d.provider, 'deepseek');
+  assert.equal(d.balance.amount, 40.955);
+  assert.equal(d.balance.currency, 'CNY');
+});
+
+test('parseDeepSeekResponse returns null without balance_infos', () => {
+  assert.equal(parseDeepSeekResponse({ is_available: false, balance_infos: [] }), null);
+  assert.equal(parseDeepSeekResponse({ balance_infos: [{ currency: 'CNY', total_balance: 'abc' }] }), null);
+});
+
+test('parseGlmResponse maps unit 3/6 and filters non-TOKENS_LIMIT', () => {
+  const d = parseGlmResponse(GLM_FIXTURE);
+  assert.ok(d);
+  assert.equal(d.provider, 'glm');
+  assert.equal(d.windows.length, 2);
+  assert.equal(d.windows[0].label, '5h');
+  assert.equal(d.windows[0].percent, 15);
+  assert.equal(d.windows[1].label, 'week');
+  assert.equal(d.windows[1].percent, 69);
+});
+
+test('parseGlmResponse fills missing slots from other units ordered by reset', () => {
+  const raw = {
+    data: {
+      limits: [
+        { type: 'TOKENS_LIMIT', unit: 6, percentage: 30, nextResetTime: 1787137440000 },
+        { type: 'TOKENS_LIMIT', unit: 1, percentage: 10, nextResetTime: 1786537440000 },
+      ],
+    },
+  };
+  const d = parseGlmResponse(raw);
+  assert.ok(d);
+  const five = d.windows.find(w => w.label === '5h');
+  assert.ok(five);
+  assert.equal(five.percent, 10); // 最近的 reset 条目补进 5h 槽
+});
+
+test('parseGlmResponse clamps percentage to 0-100', () => {
+  const raw = { data: { limits: [{ type: 'TOKENS_LIMIT', unit: 3, percentage: 250, nextResetTime: 0 }] } };
+  const d = parseGlmResponse(raw);
+  assert.equal(d.windows[0].percent, 100);
+});
+
+// ---------- collectPlancost: caching & degradation ----------
+
+async function withTempDir() {
+  return mkdtemp(path.join(tmpdir(), 'claude-hud-quota-test-'));
+}
+
+test('collectPlancost returns [] when plancost is disabled', async () => {
+  const cfg = { ...DEFAULT_CONFIG, plancost: { ...DEFAULT_CONFIG.plancost, enabled: false } };
+  const data = await collectPlancost(cfg, { model: { display_name: 'k3[1M]' } }, {});
+  assert.deepEqual(data, []);
+});
+
+test('collectPlancost fetches and caches fresh data', async () => {
+  const dir = await withTempDir();
+  try {
+    let calls = 0;
+    const deps = { fetchImpl: async () => { calls += 1; return okJson(KIMI_FIXTURE); }, now: () => 1000000, cacheDir: () => dir };
+    const cfg = makePlancostConfig();
+    const first = await collectPlancost(cfg, { model: { display_name: 'k3[1M]' } }, {}, deps);
+    assert.equal(first.length, 1);
+    assert.equal(first[0].provider, 'kimi');
+    assert.equal(calls, 1);
+    const cacheRaw = await readFile(path.join(dir, 'kimi.json'), 'utf8');
+    const cacheEntry = JSON.parse(cacheRaw);
+    assert.ok(cacheEntry.keyHash);
+    assert.equal(cacheEntry.data.provider, 'kimi');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('collectPlancost serves fresh cache without network', async () => {
+  const dir = await withTempDir();
+  try {
+    let calls = 0;
+    const deps = {
+      fetchImpl: async () => { calls += 1; return okJson(KIMI_FIXTURE); },
+      now: () => 1000000,
+      cacheDir: () => dir,
+    };
+    const cfg = makePlancostConfig();
+    await collectPlancost(cfg, { model: { display_name: 'k3[1M]' } }, {}, deps);
+    // Cache is now fresh; second call within TTL must not hit the network.
+    const second = await collectPlancost(cfg, { model: { display_name: 'k3[1M]' } }, {}, { ...deps, now: () => 1000000 + 60_000 });
+    assert.equal(second.length, 1);
+    assert.equal(calls, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('collectPlancost cache roundtrip restores Date resetAt', async () => {
+  const dir = await withTempDir();
+  try {
+    const deps = { fetchImpl: async () => okJson(KIMI_FIXTURE), now: () => 1000000, cacheDir: () => dir };
+    const cfg = makePlancostConfig();
+    await collectPlancost(cfg, { model: { display_name: 'k3[1M]' } }, {}, deps);
+    // Second call hits the cache written by the first; resetAt must be a Date
+    // again after the JSON round-trip, otherwise rendering crashes.
+    const second = await collectPlancost(cfg, { model: { display_name: 'k3[1M]' } }, {}, { ...deps, now: () => 1000000 + 60_000 });
+    assert.equal(second.length, 1);
+    assert.ok(second[0].windows[0].resetAt instanceof Date);
+    assert.ok(second[0].windows[1].resetAt instanceof Date);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('collectPlancost refetches when cache is stale', async () => {
+  const dir = await withTempDir();
+  try {
+    let calls = 0;
+    const deps = {
+      fetchImpl: async () => { calls += 1; return okJson(KIMI_FIXTURE); },
+      now: () => 1000000,
+      cacheDir: () => dir,
+    };
+    const cfg = makePlancostConfig();
+    await collectPlancost(cfg, { model: { display_name: 'k3[1M]' } }, {}, deps);
+    await collectPlancost(cfg, { model: { display_name: 'k3[1M]' } }, {}, { ...deps, now: () => 1000000 + 301_000 });
+    assert.equal(calls, 2);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('collectPlancost ignores cache when the key changed (keyHash mismatch)', async () => {
+  const dir = await withTempDir();
+  try {
+    let calls = 0;
+    const firstDeps = { fetchImpl: async () => { calls += 1; return okJson(KIMI_FIXTURE); }, now: () => 1000000, cacheDir: () => dir };
+    const cfg1 = makePlancostConfig();
+    await collectPlancost(cfg1, { model: { display_name: 'k3[1M]' } }, {}, firstDeps);
+    // Same provider, different key: cached entry must be ignored.
+    const cfg2 = makePlancostConfig({ providers: { kimi: { apiKey: 'sk-kimi-other-key', models: ['k3'] } } });
+    await collectPlancost(cfg2, { model: { display_name: 'k3[1M]' } }, {}, { ...firstDeps, now: () => 1000000 + 60_000 });
+    assert.equal(calls, 2);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('collectPlancost falls back to stale cache when fetch fails', async () => {
+  const dir = await withTempDir();
+  try {
+    const okDeps = { fetchImpl: async () => okJson(KIMI_FIXTURE), now: () => 1000000, cacheDir: () => dir };
+    const cfg = makePlancostConfig();
+    await collectPlancost(cfg, { model: { display_name: 'k3[1M]' } }, {}, okDeps);
+    // Stale cache + failing fetch → stale data returned, no crash.
+    const failDeps = {
+      fetchImpl: async () => { throw new Error('network down'); },
+      now: () => 1000000 + 10_000_000,
+      cacheDir: () => dir,
+    };
+    const data = await collectPlancost(cfg, { model: { display_name: 'k3[1M]' } }, {}, failDeps);
+    assert.equal(data.length, 1);
+    assert.equal(data[0].provider, 'kimi');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('collectPlancost returns [] on fetch failure without cache', async () => {
+  const dir = await withTempDir();
+  try {
+    const deps = {
+      fetchImpl: async () => { throw new Error('network down'); },
+      now: () => 1000000,
+      cacheDir: () => dir,
+    };
+    const data = await collectPlancost(makePlancostConfig(), { model: { display_name: 'k3[1M]' } }, {}, deps);
+    assert.deepEqual(data, []);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('collectPlancost sanitizes malicious strings from provider responses', async () => {
+  const dir = await withTempDir();
+  try {
+    const poisoned = {
+      is_available: true,
+      balance_infos: [{ currency: '\x1b[31mCNY\x1b[0m', total_balance: '12.34' }],
+    };
+    const deps = { fetchImpl: async () => okJson(poisoned), now: () => 1000000, cacheDir: () => dir };
+    const cfg = makePlancostConfig({
+      providers: { deepseek: { apiKey: 'sk-ds-test', models: ['deepseek'] } },
+    });
+    const data = await collectPlancost(cfg, { model: { display_name: 'deepseek-v4-flash[1M]' } }, {}, deps);
+    assert.equal(data.length, 1);
+    assert.equal(data[0].balance.currency, 'CNY'); // ANSI stripped
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('collectPlancost all mode returns every provider concurrently', async () => {
+  const dir = await withTempDir();
+  try {
+    const deps = {
+      fetchImpl: async (url) => {
+        if (url.includes('kimi.com')) return okJson(KIMI_FIXTURE);
+        if (url.includes('deepseek.com')) return okJson(DEEPSEEK_FIXTURE);
+        throw new Error('unexpected url');
+      },
+      now: () => 1000000,
+      cacheDir: () => dir,
+    };
+    const cfg = makePlancostConfig({ displayMode: 'all' });
+    const data = await collectPlancost(cfg, { model: { display_name: 'anything' } }, {}, deps);
+    assert.deepEqual(data.map(d => d.provider).sort(), ['deepseek', 'kimi']);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds a **plancost** first-line segment that shows coding-plan usage or account balance for third-party model providers (Kimi For Coding, DeepSeek, Zhipu GLM), queried directly from each provider API.

```
🟡 Kimi 5h 15% (03:44) · week 69% (08/13)      ← coding-plan windows
💰 DS ¥40.96                                   ← account balance
```

Health markers: 🟢 < 60% / 🟡 60–84% / 🔴 ≥ 85% (worst window wins).

### Relationship to the existing usage / external snapshot features

The official `rate_limits` display requires an Anthropic subscriber login — API-key and proxy users get no `rate_limits` on stdin. The external usage snapshot path (#690) covers model-scoped windows for Anthropic models via a sidecar file that an external feeder writes. Plancost is the complementary path for **third-party providers**: it fetches the provider's own usage/balance API itself (with a 5-minute disk cache), so users of unified relays that mix e.g. Kimi K3 and DeepSeek can see both quotas without running a feeder.

### Key design points

- **Provider model matching**: `displayMode: "auto"` shows the provider whose `models` prefix matches the **actually served model** (transcript `message.model`, stdin fallback); `"all"` shows every configured provider. Transcript matching skips future sidechain (subagent) records.
- **Caching**: one JSON file per provider under `~/.claude/plugins/claude-hud/plancost-cache/`, 5-minute TTL, keyed by a hash of the apiKey — swapping keys invalidates stale data immediately; network failure falls back to stale cache; the segment silently hides when nothing is available.
- **Safety**: provider responses are sanitized before display; the module never throws; keys are plain-text in `config.json` (documented).
- **Setup wizard**: `/claude-hud:setup` Step 4 and `/claude-hud:configure` Q7 gain a bilingual (EN / 简体中文) wizard for enabling providers, entering keys, display mode, and `projectLineOrder` placement. The wizard detects an **Anthropic official OAuth login** (no custom base URL + `oauthAccount` present) and asks whether third-party plancost is still wanted, since the official `rate_limits` usage is already shown.

## Testing

- [x] `npm test`
- [x] `npm run test:coverage`
- [x] Tests updated (35 new cases: provider parsing, model matching, cache/TTL/key-hash behavior, stale fallback, rendering format, i18n)

Docs updated: README (Plancost section + Security Notes), CHANGELOG ([Unreleased]).

Note: `dist/` is intentionally excluded per CONTRIBUTING — CI compiles and commits it after merge.