### PR TITLE
feat(effort): add display.effortFormat to render the effort symbol without the level text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `display.effortFormat` option (`full` | `symbol` | `text`) to render the effort indicator as symbol only or level text only; `full` keeps the current output (#691).
+
 ## [0.7.2] - 2026-08-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 | `display.showLastResponseAt` | boolean | false | Show how long ago the last assistant response was written |
 | `display.showCompactions` | boolean | false | Show how many context compactions (manual `/compact` or auto) have occurred this session, counted from transcript `compact_boundary` entries, e.g. `Compactions: 2`. Hidden until the first compaction |
 | `display.showEffortLevel` | boolean | false | Show the current reasoning effort in the model badge. Ultracode renders as `ultracode(xhigh)`, detected from the session transcript so it tracks `/effort` changes made at runtime |
+| `display.effortFormat` | `full` \| `symbol` \| `text` | `full` | How the effort renders when `display.showEffortLevel` is on: symbol and level text (`◑ high`), symbol only (`◑`), or level text only (`high`). Ultracode keeps the full `◕ ultracode(xhigh)` form under `symbol` so the marker is not lost, and levels without a known symbol fall back to the level text |
 | `display.showClaudeCodeVersion` | boolean | false | Show the installed Claude Code version, e.g. `CC v2.1.81` |
 | `display.showMemoryUsage` | boolean | false | Show an approximate system RAM usage line in expanded layout |
 | `display.showPromptCache` | boolean | false | Show the wall-clock time the session's prompt cache expires, read from the transcript |

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -19,7 +19,7 @@ enabled — toggle them by editing `config.json` directly if needed:
 
 Advanced settings such as `colors.*`, `pathLevels`, `maxWidth`, `forceMaxWidth`,
 `elementOrder`, `projectLineOrder`, `display.mergeGroups`, `display.timeFormat`, `display.contextValue`,
-`display.modelFormat`, `display.modelOverride`, `display.modelSource`, `display.showProvider`,
+`display.modelFormat`, `display.modelOverride`, `display.modelSource`, `display.effortFormat`, `display.showProvider`,
 `display.providerName`, `display.autocompactBuffer`,
 `display.autoCompactWindow`,
 `display.usageThreshold`, `display.sevenDayThreshold`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,19 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
  *   short:   Strip context suffix AND "Claude " prefix (e.g. "Opus 4.6")
  */
 export type ModelFormatMode = 'full' | 'compact' | 'short';
+
+/**
+ * Controls how the reasoning effort renders in the model badge when
+ * `display.showEffortLevel` is enabled.
+ *
+ *   full:   Symbol + level text (e.g. "◑ high"); default, matches the
+ *           pre-option output byte-for-byte
+ *   symbol: Symbol only (e.g. "◑"). Ultracode keeps the full form because its
+ *           marker lives in the level text, and levels without a known symbol
+ *           fall back to the level text
+ *   text:   Level text only (e.g. "high")
+ */
+export type EffortFormatMode = 'full' | 'symbol' | 'text';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both' | 'elapsed' | 'elapsedAndAbsolute';
 export type CustomLinePosition = 'first' | 'last';
 // Hour cycle for wall-clock time display; 'auto' defers to the system locale.
@@ -208,6 +221,8 @@ export interface HudConfig {
     authUserLength: number;
     showClaudeCodeVersion: boolean;
     showEffortLevel: boolean;
+    // How the effort renders when showEffortLevel is on (see EffortFormatMode).
+    effortFormat: EffortFormatMode;
     showMemoryUsage: boolean;
     showPromptCache: boolean;
     // Compatibility fallback used only until transcript tier detection has a
@@ -323,6 +338,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     authUserLength: 8,
     showClaudeCodeVersion: false,
     showEffortLevel: false,
+    effortFormat: 'full',
     showMemoryUsage: false,
     showPromptCache: false,
     promptCacheTtlSeconds: 300,
@@ -408,6 +424,10 @@ function validateLanguage(value: unknown): value is Language {
 
 function validateModelFormat(value: unknown): value is ModelFormatMode {
   return value === 'full' || value === 'compact' || value === 'short';
+}
+
+function validateEffortFormat(value: unknown): value is EffortFormatMode {
+  return value === 'full' || value === 'symbol' || value === 'text';
 }
 
 function validateTimeFormat(value: unknown): value is TimeFormatMode {
@@ -821,6 +841,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     showEffortLevel: typeof migrated.display?.showEffortLevel === 'boolean'
       ? migrated.display.showEffortLevel
       : DEFAULT_CONFIG.display.showEffortLevel,
+    effortFormat: validateEffortFormat(migrated.display?.effortFormat)
+      ? migrated.display.effortFormat
+      : DEFAULT_CONFIG.display.effortFormat,
     showMemoryUsage: typeof migrated.display?.showMemoryUsage === 'boolean'
       ? migrated.display.showMemoryUsage
       : DEFAULT_CONFIG.display.showMemoryUsage,

--- a/src/render/model-display.ts
+++ b/src/render/model-display.ts
@@ -1,15 +1,27 @@
 import type { RenderContext } from '../types.js';
+import type { EffortFormatMode } from '../config.js';
 import { getProviderLabel } from '../stdin.js';
 
-export function formatModelDisplay(model: string, ctx: RenderContext): string {
-  let effortSuffix = '';
-  if (ctx.effortLevel && ctx.effortSymbol) {
-    effortSuffix = ` ${ctx.effortSymbol} ${ctx.effortLevel}`;
-  } else if (ctx.effortLevel) {
-    effortSuffix = ` ${ctx.effortLevel}`;
+function formatEffortSuffix(ctx: RenderContext, format: EffortFormatMode): string {
+  if (!ctx.effortLevel) {
+    return '';
   }
+  // Ultracode's marker lives in the level text ("ultracode(xhigh)"), so the
+  // symbol alone cannot represent it; keep the full form in symbol mode.
+  const isUltracode = ctx.effortLevel.startsWith('ultracode(');
+  if (format === 'symbol' && ctx.effortSymbol && !isUltracode) {
+    return ` ${ctx.effortSymbol}`;
+  }
+  if (format === 'text' || !ctx.effortSymbol) {
+    return ` ${ctx.effortLevel}`;
+  }
+  return ` ${ctx.effortSymbol} ${ctx.effortLevel}`;
+}
 
+export function formatModelDisplay(model: string, ctx: RenderContext): string {
   const display = ctx.config?.display;
+  const effortSuffix = formatEffortSuffix(ctx, display?.effortFormat ?? 'full');
+
   const autoProvider = getProviderLabel(ctx.stdin);
   if (display?.showProvider) {
     const providerLabel = display.providerName?.trim() || autoProvider;

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -364,6 +364,24 @@ test('mergeConfig falls back to full for invalid modelFormat', () => {
   assert.equal(mergeConfig({ display: { modelFormat: null } }).display.modelFormat, 'full');
 });
 
+test('mergeConfig defaults effortFormat to full', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.effortFormat, 'full');
+  assert.equal(DEFAULT_CONFIG.display.effortFormat, 'full');
+});
+
+test('mergeConfig preserves valid effortFormat values', () => {
+  assert.equal(mergeConfig({ display: { effortFormat: 'symbol' } }).display.effortFormat, 'symbol');
+  assert.equal(mergeConfig({ display: { effortFormat: 'text' } }).display.effortFormat, 'text');
+  assert.equal(mergeConfig({ display: { effortFormat: 'full' } }).display.effortFormat, 'full');
+});
+
+test('mergeConfig falls back to full for invalid effortFormat', () => {
+  assert.equal(mergeConfig({ display: { effortFormat: 'invalid' } }).display.effortFormat, 'full');
+  assert.equal(mergeConfig({ display: { effortFormat: 123 } }).display.effortFormat, 'full');
+  assert.equal(mergeConfig({ display: { effortFormat: null } }).display.effortFormat, 'full');
+});
+
 test('mergeConfig defaults modelOverride to empty string', () => {
   const config = mergeConfig({});
   assert.equal(config.display.modelOverride, '');

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1065,6 +1065,70 @@ test('renderSessionLine composes the effort label with a custom provider (compac
   assert.ok(line.includes('[MyProxy | Claude Opus 4.6 ◕ ultracode(xhigh)]'), `got: ${line}`);
 });
 
+test('renderProjectLine renders only the effort symbol when effortFormat is symbol', () => {
+  const ctx = baseContext();
+  ctx.stdin.model = { display_name: 'Claude Opus 4.6' };
+  ctx.config.display.effortFormat = 'symbol';
+  ctx.effortLevel = 'high';
+  ctx.effortSymbol = '◑';
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(line.includes('[Claude Opus 4.6 ◑]'), `got: ${line}`);
+  assert.ok(!line.includes('high'), `level text must be dropped: ${line}`);
+});
+
+test('renderProjectLine renders only the effort level when effortFormat is text', () => {
+  const ctx = baseContext();
+  ctx.stdin.model = { display_name: 'Claude Opus 4.6' };
+  ctx.config.display.effortFormat = 'text';
+  ctx.effortLevel = 'high';
+  ctx.effortSymbol = '◑';
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(line.includes('[Claude Opus 4.6 high]'), `got: ${line}`);
+  assert.ok(!line.includes('◑'), `symbol must be dropped: ${line}`);
+});
+
+test('renderProjectLine keeps full effort output when effortFormat is full', () => {
+  const ctx = baseContext();
+  ctx.stdin.model = { display_name: 'Claude Opus 4.6' };
+  ctx.config.display.effortFormat = 'full';
+  ctx.effortLevel = 'high';
+  ctx.effortSymbol = '◑';
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(line.includes('[Claude Opus 4.6 ◑ high]'), `got: ${line}`);
+});
+
+test('renderProjectLine keeps the full ultracode label under effortFormat symbol', () => {
+  const ctx = baseContext();
+  ctx.stdin.model = { display_name: 'Claude Opus 4.6' };
+  ctx.config.display.effortFormat = 'symbol';
+  ctx.effortLevel = 'ultracode(xhigh)';
+  ctx.effortSymbol = '◕';
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(line.includes('[Claude Opus 4.6 ◕ ultracode(xhigh)]'), `got: ${line}`);
+});
+
+test('renderProjectLine falls back to the level text under effortFormat symbol without a known symbol', () => {
+  const ctx = baseContext();
+  ctx.stdin.model = { display_name: 'Claude Opus 4.6' };
+  ctx.config.display.effortFormat = 'symbol';
+  ctx.effortLevel = 'unknown';
+  ctx.effortSymbol = '';
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  assert.ok(line.includes('[Claude Opus 4.6 unknown]'), `got: ${line}`);
+});
+
+test('renderSessionLine renders only the effort symbol when effortFormat is symbol (compact layout)', () => {
+  const ctx = baseContext();
+  ctx.config.lineLayout = 'compact';
+  ctx.stdin.model = { display_name: 'Claude Opus 4.6' };
+  ctx.config.display.effortFormat = 'symbol';
+  ctx.effortLevel = 'high';
+  ctx.effortSymbol = '◑';
+  const line = stripAnsi(renderSessionLine(ctx));
+  assert.ok(line.includes('[Claude Opus 4.6 ◑]'), `got: ${line}`);
+  assert.ok(!line.includes('high'), `level text must be dropped: ${line}`);
+});
+
 test('renderProjectLine uses configurable element colors', () => {
   const ctx = baseContext();
   ctx.stdin.cwd = '/tmp/my-project';


### PR DESCRIPTION
Adds a `display.effortFormat` option (`full`, `symbol`, or `text`) for the effort indicator shown by `display.showEffortLevel`, with `full` as the default so existing output is unchanged byte for byte. `symbol` renders just the symbol to free width on compact layouts, except for ultracode sessions, which keep the full form because the `ultracode(...)` marker lives in the level text; a distinct symbol works too if you would rather go that route. The option is wired through config the same way as `display.modelFormat` (typed union, validator, merge fallback to `full` on invalid values), covered by new mergeConfig and render tests, and includes no `dist/` changes per CONTRIBUTING.

Verified with `npm test`: all new tests pass and the failing-test set is identical to a clean main checkout (69 pre-existing environment-dependent failures in the context-cache and config-reader suites on my machine, unrelated to this change).

Fixes #691
