### PR TITLE
release: prepare v0.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-    "version": "0.7.2"
+    "version": "0.8.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hud",
   "description": "Real-time statusline HUD for Claude Code - context health, tool activity, agent tracking, and todo progress",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-18
+
 ### Added
 - Load optional per-config-directory overrides from `$CLAUDE_CONFIG_DIR/claude-hud.json` while preserving shared plugin settings (#714).
 - `display.effortFormat` option (`full` | `symbol` | `text`) to render the effort indicator as symbol only or level text only; `full` keeps the current output (#691).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hud",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hud",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hud",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Real-time statusline HUD for Claude Code",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- release hardened per-config-directory overrides from #714
- release configurable effort display formatting from #715
- align plugin, marketplace, package, and lockfile versions at 0.8.0

## Validation

- npm ci --ignore-scripts
- npm run build
- npm test: 1,073 passed, 6 platform skips
- npm run test:coverage: 94.26% statements, 87.43% branches, 94.85% functions, 94.26% lines
- npm pack --dry-run: 309 files, 283.7 kB
- npm audit --omit=dev: 0 vulnerabilities
- git diff --check
- no release-branch dist diff; trusted main dist builds already contain both accepted changes