### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,4 +538,4 @@ MIT — see [LICENSE](LICENSE)
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jarrodwatts/claude-hud&type=Date)](https://star-history.com/#jarrodwatts/claude-hud&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jarrodwatts/claude-hud&type=Date)](https://star-history.dera.page/#jarrodwatts/claude-hud&Date)

--- a/README.zh.md
+++ b/README.zh.md
@@ -482,4 +482,4 @@ MIT — 详见 [LICENSE](LICENSE)
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jarrodwatts/claude-hud&type=Date)](https://star-history.com/#jarrodwatts/claude-hud&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jarrodwatts/claude-hud&type=Date)](https://star-history.dera.page/#jarrodwatts/claude-hud&Date)


### PR DESCRIPTION
The Star History chart in the README has been broken for a while: the current star history service is impacted by GitHub stargazer API restrictions and no longer renders. This PR points the chart to star-history.dera.page, a working alternative used by many other projects, so the chart is visible again. Updated in both README.md and README.zh.md.