### PR TITLE
feat(usage): read model-scoped windows from the Claude CLI usage cache, opt-in auto-refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 | `display.externalUsagePath` | string | `""` | Optional absolute path to a local usage snapshot file. Relative paths are ignored. When stdin `rate_limits` are present, `balance_label` is appended and `model_scoped` windows fill in when stdin lacks them; when stdin windows are missing, valid usage windows can be used as a fallback |
 | `display.externalUsageWritePath` | string | `""` | Optional absolute `.json` path in an existing directory. When stdin `rate_limits` exists, ClaudeHUD writes a private snapshot for other local tools. Relative paths, non-json files, and missing parent directories are ignored |
 | `display.externalUsageFreshnessMs` | number | `300000` | Maximum allowed age for the external usage snapshot before it is ignored |
+| `display.refreshModelScopedUsage` | boolean | false | The HUD always reads model-scoped weekly windows (e.g. Fable) from the usage cache the Claude CLI keeps in `{CLAUDE_CONFIG_DIR}.json` as the last fallback. This opt-in keeps that cache fresh via a detached headless `claude -p /usage` when it is older than five minutes, which promotes the cache above external snapshots. Stdin always wins |
 | `display.showTokenBreakdown` | boolean | true | Show token details at high context (85%+) |
 | `display.showTools` | boolean | false | Show tools activity line |
 | `display.showSkills` | boolean | false | Show active Skills detected from `Skill` tool invocations |
@@ -301,6 +302,10 @@ The snapshot may also carry `model_scoped` windows using the same shape Claude C
 ```
 
 One zero-credential way to produce such a snapshot is Claude Code's own `get_usage` control request, which returns `rate_limits.model_scoped` without spending tokens; a scheduled job can pipe it through `jq` into the snapshot file. The HUD itself never fetches anything: it only reads the file.
+
+ClaudeHUD also reads the usage cache the Claude CLI already maintains in `{CLAUDE_CONFIG_DIR}.json` (written on every `/usage` fetch, including model-scoped windows). This needs no setup: if you have run `/usage` recently, its scoped windows appear as the last fallback, behind stdin and external snapshots, and entries older than the one hour the CLI itself trusts are never rendered.
+
+If you would rather not maintain a scheduled job, `display.refreshModelScopedUsage` keeps that cache fresh automatically: when it is older than five minutes — the interval the CLI itself throttles cache writes to — ClaudeHUD spawns one detached, headless `claude -p /usage` so the CLI refreshes its own cache, and that freshness guarantee promotes the cache above external snapshots (stdin still always wins). The subprocess spends no tokens and no model is invoked; the CLI resolves authentication itself and ClaudeHUD never sees credentials or talks to the network — the cache file is the only channel. A private marker under `~/.claude/plugins/claude-hud` prevents concurrent renders from stampeding duplicate refreshes, and because stdin scoped windows take priority outright, the whole path retires naturally once Claude Code forwards `rate_limits.model_scoped` on stdin.
 
 Set `display.externalUsageWritePath` if you want ClaudeHUD to write the official stdin `rate_limits` into a local snapshot for other tools. The path must be absolute, end in `.json`, and live in an existing directory. ClaudeHUD writes the file with private permissions and ignores invalid paths quietly.
 

--- a/src/cli-usage.ts
+++ b/src/cli-usage.ts
@@ -1,0 +1,231 @@
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { getClaudeConfigJsonPath, getHudPluginDir } from './claude-config-dir.js';
+import { parseScopedWindows } from './stdin.js';
+import { createDebug } from './debug.js';
+import type { ScopedUsageWindow } from './types.js';
+
+const debug = createDebug('cli-usage');
+
+/**
+ * Feeds model-scoped weekly usage (e.g. the Fable window on /usage) from the
+ * cache Claude Code itself maintains, without touching credentials or the
+ * network.
+ *
+ * Recent Claude Code releases surface model-scoped weekly windows on /usage,
+ * and the CLI persists each /usage fetch into {CLAUDE_CONFIG_DIR}.json under
+ * `cachedUsageUtilization` (limits[] entries whose scope.model names the
+ * window). Statusline stdin still lacks rate_limits.model_scoped (#669), so
+ * until Claude Code forwards it, this module:
+ *
+ *   1. always reads that cache on render as the lowest-priority scoped-window
+ *      source (a plain local file read — no subprocess, no network), and
+ *   2. only when display.refreshModelScopedUsage is enabled and the cache is
+ *      stale, spawns a single detached, headless `claude -p /usage` so the
+ *      CLI refreshes its own cache — the CLI resolves auth itself, and the
+ *      HUD never sees a token.
+ *
+ * Stdin wins whenever it starts carrying scoped windows; this feeder then
+ * never runs (see index.ts) and can eventually be retired.
+ */
+
+/**
+ * Refresh interval. Fixed at five minutes: Claude Code throttles writes of
+ * `cachedUsageUtilization` to once per five minutes, so refreshing more often
+ * cannot yield newer data.
+ */
+export const CLI_USAGE_REFRESH_MS = 300_000;
+
+/**
+ * Claude Code treats its own usage cache as stale after one hour; mirror that
+ * bound so the HUD never renders older data than /usage itself would trust.
+ */
+export const CLI_USAGE_MAX_AGE_MS = 3_600_000;
+
+/**
+ * After scheduling one refresh, hold off re-spawning for this long. The
+ * statusline renders far more often than a headless `claude -p /usage`
+ * completes (a few seconds), so without this a stale cache would stampede
+ * one subprocess per render until the first one lands.
+ */
+export const CLI_USAGE_REFRESH_HOLDOFF_MS = 120_000;
+
+const REFRESH_MARKER_FILENAME = 'cli-usage-refresh.marker';
+
+type SpawnLike = (
+  command: string,
+  args: string[],
+  options: { detached: boolean; stdio: 'ignore' },
+) => { unref: () => void; on: (event: string, listener: (...args: unknown[]) => void) => unknown };
+
+export type CliUsageDeps = {
+  homeDir: () => string;
+  readFileSync: typeof fs.readFileSync;
+  statSync: typeof fs.statSync;
+  mkdirSync: typeof fs.mkdirSync;
+  writeFileSync: typeof fs.writeFileSync;
+  utimesSync: typeof fs.utimesSync;
+  spawn: SpawnLike;
+};
+
+const defaultDeps: CliUsageDeps = {
+  homeDir: () => os.homedir(),
+  readFileSync: fs.readFileSync,
+  statSync: fs.statSync,
+  mkdirSync: fs.mkdirSync,
+  writeFileSync: fs.writeFileSync,
+  utimesSync: fs.utimesSync,
+  spawn: spawn as unknown as SpawnLike,
+};
+
+export type CliUsageCache = {
+  fetchedAtMs: number;
+  scopedWindows: ScopedUsageWindow[];
+};
+
+/**
+ * Reads `cachedUsageUtilization` from {CLAUDE_CONFIG_DIR}.json and projects
+ * its model-scoped limits[] entries into ScopedUsageWindow[]. Model names are
+ * taken from the cache verbatim (no hardcoded model list), so any future
+ * model-scoped window is picked up automatically. Returns null when the file,
+ * the cache block, or its timestamp is missing or malformed. Never throws.
+ */
+export function readCliUsageCache(deps: CliUsageDeps = defaultDeps): CliUsageCache | null {
+  const configJsonPath = getClaudeConfigJsonPath(deps.homeDir());
+  let root: unknown;
+  try {
+    root = JSON.parse(deps.readFileSync(configJsonPath, 'utf8') as string);
+  } catch (err) {
+    debug('Failed to read claude config json:', err instanceof Error ? err.message : err);
+    return null;
+  }
+
+  const cached = (root && typeof root === 'object')
+    ? (root as Record<string, unknown>).cachedUsageUtilization
+    : null;
+  if (!cached || typeof cached !== 'object' || Array.isArray(cached)) {
+    return null;
+  }
+
+  const cachedRecord = cached as Record<string, unknown>;
+  const fetchedAtMs = cachedRecord.fetchedAtMs;
+  if (typeof fetchedAtMs !== 'number' || !Number.isFinite(fetchedAtMs) || fetchedAtMs <= 0) {
+    return null;
+  }
+
+  const utilization = cachedRecord.utilization;
+  const limits = (utilization && typeof utilization === 'object')
+    ? (utilization as Record<string, unknown>).limits
+    : null;
+
+  const modelScoped: Array<{ display_name?: unknown; utilization?: unknown; resets_at?: unknown }> = [];
+  if (Array.isArray(limits)) {
+    for (const raw of limits) {
+      const entry = raw as {
+        scope?: { model?: { display_name?: unknown } | null } | null;
+        percent?: unknown;
+        resets_at?: unknown;
+      } | null;
+      const displayName = entry?.scope?.model?.display_name;
+      if (typeof displayName !== 'string' || !displayName.trim()) {
+        continue;
+      }
+      modelScoped.push({
+        display_name: displayName,
+        utilization: entry?.percent,
+        resets_at: entry?.resets_at,
+      });
+    }
+  }
+
+  return {
+    fetchedAtMs,
+    // parseScopedWindows applies the shared bounds: entry cap, label
+    // sanitization/length cap, percent clamping, reset-string validation.
+    scopedWindows: parseScopedWindows(modelScoped),
+  };
+}
+
+function refreshMarkerPath(homeDir: string): string {
+  return path.join(getHudPluginDir(homeDir), REFRESH_MARKER_FILENAME);
+}
+
+function markerIsRecent(markerPath: string, now: number, deps: CliUsageDeps): boolean {
+  try {
+    const stat = deps.statSync(markerPath);
+    const age = now - stat.mtimeMs;
+    return age >= 0 && age < CLI_USAGE_REFRESH_HOLDOFF_MS;
+  } catch {
+    return false;
+  }
+}
+
+function touchMarker(markerPath: string, now: number, deps: CliUsageDeps): boolean {
+  try {
+    deps.mkdirSync(path.dirname(markerPath), { recursive: true, mode: 0o700 });
+    deps.writeFileSync(markerPath, '', { encoding: 'utf8', mode: 0o600 });
+    const date = new Date(now);
+    deps.utimesSync(markerPath, date, date);
+    return true;
+  } catch (err) {
+    debug('Failed to touch refresh marker:', err instanceof Error ? err.message : err);
+    return false;
+  }
+}
+
+function scheduleRefresh(now: number, deps: CliUsageDeps): boolean {
+  const markerPath = refreshMarkerPath(deps.homeDir());
+  if (markerIsRecent(markerPath, now, deps)) {
+    return false;
+  }
+  // Claim the slot before spawning so concurrent renders (multiple sessions
+  // share one statusline binary) do not race into duplicate subprocesses.
+  if (!touchMarker(markerPath, now, deps)) {
+    return false;
+  }
+
+  try {
+    // Headless /usage is a local command: Claude Code fetches usage, rewrites
+    // its cache, and exits without invoking a model. No shell is involved and
+    // no output is consumed — the cache file is the only channel.
+    const child = deps.spawn('claude', ['-p', '/usage'], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.on('error', (err: unknown) => {
+      debug('Refresh spawn failed:', err instanceof Error ? err.message : err);
+    });
+    child.unref();
+    return true;
+  } catch (err) {
+    debug('Refresh spawn failed:', err instanceof Error ? err.message : err);
+    return false;
+  }
+}
+
+/**
+ * Returns fresh model-scoped windows from the Claude CLI's own usage cache.
+ * Reading is unconditional; `refreshEnabled` (display.refreshModelScopedUsage)
+ * additionally schedules a background refresh when the cache is stale. Single
+ * entry point used by main(); reads the cache once per render. Never throws.
+ */
+export function getScopedUsageFromCliCache(
+  now: number,
+  refreshEnabled: boolean,
+  deps: CliUsageDeps = defaultDeps,
+): ScopedUsageWindow[] | null {
+  const cache = readCliUsageCache(deps);
+
+  const age = cache ? now - cache.fetchedAtMs : Number.POSITIVE_INFINITY;
+  if (refreshEnabled && (age >= CLI_USAGE_REFRESH_MS || age < 0)) {
+    scheduleRefresh(now, deps);
+  }
+
+  if (!cache || age < 0 || age > CLI_USAGE_MAX_AGE_MS) {
+    return null;
+  }
+
+  return cache.scopedWindows.length > 0 ? cache.scopedWindows : null;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -253,6 +253,14 @@ export interface HudConfig {
     externalUsagePath: string;
     externalUsageWritePath: string;
     externalUsageFreshnessMs: number;
+    // The HUD always reads model-scoped weekly windows (e.g. Fable) from the
+    // usage cache the Claude CLI itself maintains in {CLAUDE_CONFIG_DIR}.json
+    // as the last scoped-window fallback. This opt-in keeps that cache fresh:
+    // when it is older than five minutes (the CLI's own write-throttle
+    // interval) the HUD spawns a detached headless `claude -p /usage`, and
+    // the freshness guarantee promotes the cache above external snapshots.
+    // Stdin always wins while it carries rate_limits.model_scoped.
+    refreshModelScopedUsage: boolean;
     modelFormat: ModelFormatMode;
     modelOverride: string;
     // Controls which source the model name comes from:
@@ -362,6 +370,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     externalUsagePath: '',
     externalUsageWritePath: '',
     externalUsageFreshnessMs: 300000,
+    refreshModelScopedUsage: false,
     modelFormat: 'full',
     modelOverride: '',
     modelSource: 'stdin',
@@ -921,6 +930,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     externalUsagePath: validateOptionalPath(migrated.display?.externalUsagePath),
     externalUsageWritePath: validateOptionalPath(migrated.display?.externalUsageWritePath),
     externalUsageFreshnessMs: validateFreshnessMs(migrated.display?.externalUsageFreshnessMs),
+    refreshModelScopedUsage: typeof migrated.display?.refreshModelScopedUsage === 'boolean'
+      ? migrated.display.refreshModelScopedUsage
+      : DEFAULT_CONFIG.display.refreshModelScopedUsage,
     modelFormat: validateModelFormat(migrated.display?.modelFormat)
       ? migrated.display.modelFormat
       : DEFAULT_CONFIG.display.modelFormat,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { readAuthInfo } from "./auth.js";
 import { resolveEffortLevel } from "./effort.js";
 import { applyContextWindowFallback } from "./context-cache.js";
 import { getUsageFromExternalSnapshot, writeExternalUsageSnapshot } from "./external-usage.js";
+import { getScopedUsageFromCliCache } from "./cli-usage.js";
 import { setLanguage, t } from "./i18n/index.js";
 import type { RenderContext } from "./types.js";
 import type { GitStatus } from "./git.js";
@@ -26,6 +27,7 @@ export type MainDeps = {
   getUsageFromStdin: typeof getUsageFromStdin;
   getUsageFromExternalSnapshot: typeof getUsageFromExternalSnapshot;
   writeExternalUsageSnapshot: typeof writeExternalUsageSnapshot;
+  getScopedUsageFromCliCache: typeof getScopedUsageFromCliCache;
   parseTranscript: typeof parseTranscript;
   countConfigs: typeof countConfigs;
   getGitStatus: typeof getGitStatus;
@@ -90,6 +92,7 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
     getUsageFromStdin,
     getUsageFromExternalSnapshot,
     writeExternalUsageSnapshot,
+    getScopedUsageFromCliCache,
     parseTranscript,
     countConfigs,
     getGitStatus,
@@ -174,6 +177,32 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
               scopedWindows: ext.scopedWindows,
             }),
           };
+        }
+      }
+
+      // Scoped-window fallback from the usage cache the Claude CLI maintains
+      // itself (see cli-usage.ts). Reading is unconditional — the cache exists
+      // whenever the user has run /usage — so it always serves as the last
+      // fallback. display.refreshModelScopedUsage additionally keeps the cache
+      // fresh via a detached headless `claude -p /usage`, and that freshness
+      // guarantee promotes this source above external snapshots. Stdin always
+      // wins when it carries its own scoped windows, so the whole block
+      // retires naturally once Claude Code forwards rate_limits.model_scoped.
+      // `== null` deliberately: an explicit empty model_scoped array on stdin
+      // is Claude Code stating "no scoped windows" and is preserved as-is.
+      const refreshScopedUsage = config.display.refreshModelScopedUsage;
+      if (stdinUsage?.scopedWindows == null) {
+        const cliWindows = deps.getScopedUsageFromCliCache(deps.now(), refreshScopedUsage);
+        if (cliWindows != null && (refreshScopedUsage || !usageData?.scopedWindows?.length)) {
+          usageData = usageData
+            ? { ...usageData, scopedWindows: cliWindows }
+            : {
+              fiveHour: null,
+              sevenDay: null,
+              fiveHourResetAt: null,
+              sevenDayResetAt: null,
+              scopedWindows: cliWindows,
+            };
         }
       }
     }

--- a/tests/cli-usage.test.js
+++ b/tests/cli-usage.test.js
@@ -1,0 +1,451 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as path from 'node:path';
+import { DEFAULT_CONFIG, mergeConfig } from '../dist/config.js';
+import {
+  CLI_USAGE_MAX_AGE_MS,
+  CLI_USAGE_REFRESH_MS,
+  CLI_USAGE_REFRESH_HOLDOFF_MS,
+  getScopedUsageFromCliCache,
+  readCliUsageCache,
+} from '../dist/cli-usage.js';
+import { main } from '../dist/index.js';
+import { setLanguage } from '../dist/i18n/index.js';
+
+setLanguage('en');
+
+const HOME = '/home/hud-test';
+const NOW = 1_800_000_000_000;
+
+// Mirrors the `cachedUsageUtilization` block Claude Code persists in
+// {CLAUDE_CONFIG_DIR}.json after a /usage fetch. Only the fields this
+// feeder consumes are modeled; extra fields must be ignored.
+function claudeJson({ fetchedAtMs = NOW, limits, extra = {} } = {}) {
+  return JSON.stringify({
+    someUnrelatedKey: true,
+    cachedUsageUtilization: {
+      fetchedAtMs,
+      accountUuid: 'account-1',
+      utilization: {
+        five_hour: { utilization: 5 },
+        limits: limits ?? [
+          {
+            kind: 'session',
+            percent: 5,
+            resets_at: '2026-08-20T05:49:59+00:00',
+            scope: null,
+          },
+          {
+            kind: 'weekly_all',
+            percent: 20,
+            resets_at: '2026-08-25T05:59:59+00:00',
+            scope: null,
+          },
+          {
+            kind: 'weekly_scoped',
+            percent: 36,
+            resets_at: '2026-08-25T06:00:00+00:00',
+            scope: { model: { id: null, display_name: 'Fable' }, surface: null },
+          },
+        ],
+      },
+      ...extra,
+    },
+  });
+}
+
+function makeDeps({ file, markerAgeMs = null } = {}) {
+  const spawned = [];
+  const markerWrites = [];
+  let markerMtime = markerAgeMs != null ? NOW - markerAgeMs : null;
+  const configJsonPath = path.join(HOME, '.claude.json');
+  return {
+    spawned,
+    markerWrites,
+    deps: {
+      homeDir: () => HOME,
+      readFileSync: (filePath) => {
+        if (filePath !== configJsonPath) {
+          throw new Error(`ENOENT: ${filePath}`);
+        }
+        if (file == null) {
+          throw new Error('ENOENT');
+        }
+        return file;
+      },
+      statSync: (filePath) => {
+        if (markerMtime == null || !filePath.endsWith('cli-usage-refresh.marker')) {
+          throw new Error('ENOENT');
+        }
+        return { mtimeMs: markerMtime };
+      },
+      mkdirSync: () => {},
+      writeFileSync: (filePath) => {
+        markerWrites.push(filePath);
+      },
+      utimesSync: (_filePath, _atime, mtime) => {
+        markerMtime = mtime.getTime();
+      },
+      spawn: (command, args, options) => {
+        spawned.push({ command, args, options });
+        return { unref: () => {}, on: () => {} };
+      },
+    },
+  };
+}
+
+function makeConfig(displayOverrides = {}) {
+  return {
+    ...DEFAULT_CONFIG,
+    display: {
+      ...DEFAULT_CONFIG.display,
+      refreshModelScopedUsage: true,
+      ...displayOverrides,
+    },
+  };
+}
+
+// --- readCliUsageCache -------------------------------------------------
+
+test('readCliUsageCache projects model-scoped limits and skips generic windows', () => {
+  const { deps } = makeDeps({ file: claudeJson() });
+  const cache = readCliUsageCache(deps);
+  assert.equal(cache.fetchedAtMs, NOW);
+  assert.equal(cache.scopedWindows.length, 1);
+  assert.equal(cache.scopedWindows[0].label, 'Fable');
+  assert.equal(cache.scopedWindows[0].percent, 36);
+  assert.ok(cache.scopedWindows[0].resetAt instanceof Date);
+});
+
+test('readCliUsageCache keeps every model-scoped window, not just one model', () => {
+  const { deps } = makeDeps({
+    file: claudeJson({
+      limits: [
+        { kind: 'weekly_scoped', percent: 36, resets_at: null, scope: { model: { display_name: 'Fable' } } },
+        { kind: 'weekly_scoped', percent: 12, resets_at: null, scope: { model: { display_name: 'Some Future Model' } } },
+      ],
+    }),
+  });
+  const cache = readCliUsageCache(deps);
+  assert.deepEqual(
+    cache.scopedWindows.map((window) => [window.label, window.percent]),
+    [['Fable', 36], ['Some Future Model', 12]],
+  );
+});
+
+test('readCliUsageCache drops entries without a model display name', () => {
+  const { deps } = makeDeps({
+    file: claudeJson({
+      limits: [
+        { kind: 'weekly_scoped', percent: 36, scope: { model: { display_name: '' } } },
+        { kind: 'weekly_scoped', percent: 36, scope: { model: {} } },
+        { kind: 'weekly_scoped', percent: 36, scope: {} },
+        { kind: 'weekly_scoped', percent: 36, scope: null },
+        null,
+      ],
+    }),
+  });
+  assert.deepEqual(readCliUsageCache(deps).scopedWindows, []);
+});
+
+test('readCliUsageCache preserves null percent and drops invalid reset strings', () => {
+  const { deps } = makeDeps({
+    file: claudeJson({
+      limits: [
+        { kind: 'weekly_scoped', percent: null, resets_at: 'not-a-date', scope: { model: { display_name: 'Fable' } } },
+      ],
+    }),
+  });
+  const [window] = readCliUsageCache(deps).scopedWindows;
+  assert.equal(window.percent, null);
+  assert.equal(window.resetAt, null);
+});
+
+test('readCliUsageCache returns null for missing file, missing cache, or bad timestamp', () => {
+  assert.equal(readCliUsageCache(makeDeps({ file: null }).deps), null);
+  assert.equal(readCliUsageCache(makeDeps({ file: '{"otherKey":1}' }).deps), null);
+  assert.equal(readCliUsageCache(makeDeps({ file: 'not json' }).deps), null);
+  assert.equal(
+    readCliUsageCache(makeDeps({ file: claudeJson({ fetchedAtMs: 'soon' }) }).deps),
+    null,
+  );
+  assert.equal(
+    readCliUsageCache(makeDeps({ file: claudeJson({ fetchedAtMs: -5 }) }).deps),
+    null,
+  );
+});
+
+// --- getScopedUsageFromCliCache: freshness and refresh ------------------
+
+test('fresh cache returns windows without spawning a refresh', () => {
+  const { deps, spawned } = makeDeps({ file: claudeJson({ fetchedAtMs: NOW - 60_000 }) });
+  const windows = getScopedUsageFromCliCache(NOW, true, deps);
+  assert.equal(windows.length, 1);
+  assert.equal(spawned.length, 0);
+});
+
+test('stale-but-usable cache returns windows and schedules one refresh', () => {
+  const { deps, spawned } = makeDeps({
+    file: claudeJson({ fetchedAtMs: NOW - CLI_USAGE_REFRESH_MS - 1 }),
+  });
+  const windows = getScopedUsageFromCliCache(NOW, true, deps);
+  assert.equal(windows.length, 1);
+  assert.equal(spawned.length, 1);
+  assert.equal(spawned[0].command, 'claude');
+  assert.deepEqual(spawned[0].args, ['-p', '/usage']);
+  assert.deepEqual(spawned[0].options, { detached: true, stdio: 'ignore' });
+});
+
+test('cache older than the CLI trusts is not rendered but still triggers a refresh', () => {
+  const { deps, spawned } = makeDeps({
+    file: claudeJson({ fetchedAtMs: NOW - CLI_USAGE_MAX_AGE_MS - 1 }),
+  });
+  assert.equal(getScopedUsageFromCliCache(NOW, true, deps), null);
+  assert.equal(spawned.length, 1);
+});
+
+test('cache from the future is rejected and a refresh is scheduled', () => {
+  const { deps, spawned } = makeDeps({ file: claudeJson({ fetchedAtMs: NOW + 60_000 }) });
+  assert.equal(getScopedUsageFromCliCache(NOW, true, deps), null);
+  assert.equal(spawned.length, 1);
+});
+
+test('missing cache schedules a refresh so the first render primes it', () => {
+  const { deps, spawned } = makeDeps({ file: null });
+  assert.equal(getScopedUsageFromCliCache(NOW, true, deps), null);
+  assert.equal(spawned.length, 1);
+});
+
+test('cache without any scoped window returns null and stays quiet while fresh', () => {
+  const { deps, spawned } = makeDeps({
+    file: claudeJson({ limits: [{ kind: 'session', percent: 5, scope: null }] }),
+  });
+  assert.equal(getScopedUsageFromCliCache(NOW, true, deps), null);
+  assert.equal(spawned.length, 0);
+});
+
+test('a recent refresh marker suppresses duplicate spawns across renders', () => {
+  const { deps, spawned } = makeDeps({
+    file: claudeJson({ fetchedAtMs: NOW - CLI_USAGE_MAX_AGE_MS - 1 }),
+    markerAgeMs: CLI_USAGE_REFRESH_HOLDOFF_MS - 1,
+  });
+  getScopedUsageFromCliCache(NOW, true, deps);
+  assert.equal(spawned.length, 0);
+});
+
+test('an expired refresh marker allows a retry', () => {
+  const { deps, spawned } = makeDeps({
+    file: claudeJson({ fetchedAtMs: NOW - CLI_USAGE_MAX_AGE_MS - 1 }),
+    markerAgeMs: CLI_USAGE_REFRESH_HOLDOFF_MS + 1,
+  });
+  getScopedUsageFromCliCache(NOW, true, deps);
+  assert.equal(spawned.length, 1);
+});
+
+test('consecutive stale renders spawn only once thanks to the marker', () => {
+  const { deps, spawned } = makeDeps({
+    file: claudeJson({ fetchedAtMs: NOW - CLI_USAGE_MAX_AGE_MS - 1 }),
+  });
+  getScopedUsageFromCliCache(NOW, true, deps);
+  getScopedUsageFromCliCache(NOW + 1_000, true, deps);
+  assert.equal(spawned.length, 1);
+});
+
+test('reading works with refresh disabled: stale cache still renders, nothing spawns', () => {
+  const { deps, spawned } = makeDeps({
+    file: claudeJson({ fetchedAtMs: NOW - CLI_USAGE_REFRESH_MS - 1 }),
+  });
+  const windows = getScopedUsageFromCliCache(NOW, false, deps);
+  assert.equal(windows.length, 1);
+  assert.equal(spawned.length, 0);
+});
+
+test('spawn failures are swallowed and never break the render', () => {
+  const { deps } = makeDeps({ file: claudeJson({ fetchedAtMs: NOW - CLI_USAGE_MAX_AGE_MS - 1 }) });
+  deps.spawn = () => {
+    throw new Error('spawn ENOENT');
+  };
+  assert.equal(getScopedUsageFromCliCache(NOW, true, deps), null);
+});
+
+// --- config parsing ------------------------------------------------------
+
+test('mergeConfig keeps the feeder off by default and validates the opt-in', () => {
+  assert.equal(mergeConfig({}).display.refreshModelScopedUsage, false);
+  assert.equal(
+    mergeConfig({ display: { refreshModelScopedUsage: true } }).display.refreshModelScopedUsage,
+    true,
+  );
+  assert.equal(
+    mergeConfig({ display: { refreshModelScopedUsage: 'yes' } }).display.refreshModelScopedUsage,
+    false,
+  );
+});
+
+// --- main() integration --------------------------------------------------
+
+function mainDeps({ config, stdinRateLimits, cliWindows, extUsage, calls, ctxSink }) {
+  return {
+    readStdin: async () => ({
+      cwd: '/tmp/project',
+      model: { display_name: 'Opus' },
+      context_window: { context_window_size: 100, current_usage: { input_tokens: 10 } },
+      ...(stdinRateLimits !== undefined && { rate_limits: stdinRateLimits }),
+    }),
+    parseTranscript: async () => ({ tools: [], agents: [], todos: [] }),
+    countConfigs: async () => ({ claudeMdCount: 0, rulesCount: 0, mcpCount: 0, hooksCount: 0 }),
+    loadConfig: async () => config,
+    getGitStatus: async () => null,
+    isJjRepo: () => false,
+    applyContextWindowFallback: () => {},
+    getUsageFromExternalSnapshot: () => extUsage ?? null,
+    getScopedUsageFromCliCache: (...args) => {
+      calls.push(args);
+      return cliWindows;
+    },
+    render: (ctx) => ctxSink.push(ctx),
+    now: () => NOW,
+    log: () => {},
+  };
+}
+
+test('main backfills scopedWindows from the CLI cache and forwards the refresh flag', async () => {
+  const calls = [];
+  const ctxSink = [];
+  const config = makeConfig();
+  config.gitStatus = { ...config.gitStatus, enabled: false };
+  await main(mainDeps({
+    config,
+    stdinRateLimits: { five_hour: { used_percentage: 12 } },
+    cliWindows: [{ label: 'Fable', percent: 36, resetAt: null }],
+    calls,
+    ctxSink,
+  }));
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][1], true);
+  assert.equal(ctxSink[0].usageData.fiveHour, 12);
+  assert.deepEqual(ctxSink[0].usageData.scopedWindows, [
+    { label: 'Fable', percent: 36, resetAt: null },
+  ]);
+});
+
+test('main builds usageData from the CLI cache alone when stdin has no rate limits', async () => {
+  const calls = [];
+  const ctxSink = [];
+  const config = makeConfig();
+  config.gitStatus = { ...config.gitStatus, enabled: false };
+  await main(mainDeps({
+    config,
+    stdinRateLimits: undefined,
+    cliWindows: [{ label: 'Fable', percent: 36, resetAt: null }],
+    calls,
+    ctxSink,
+  }));
+  assert.equal(ctxSink[0].usageData.fiveHour, null);
+  assert.equal(ctxSink[0].usageData.scopedWindows.length, 1);
+});
+
+test('main lets stdin scoped windows win over the CLI cache', async () => {
+  const calls = [];
+  const ctxSink = [];
+  const config = makeConfig();
+  config.gitStatus = { ...config.gitStatus, enabled: false };
+  await main(mainDeps({
+    config,
+    stdinRateLimits: {
+      five_hour: { used_percentage: 12 },
+      model_scoped: [{ display_name: 'Fable', utilization: 40, resets_at: null }],
+    },
+    cliWindows: [{ label: 'Stale', percent: 1, resetAt: null }],
+    calls,
+    ctxSink,
+  }));
+  assert.equal(calls.length, 0);
+  assert.equal(ctxSink[0].usageData.scopedWindows[0].label, 'Fable');
+  assert.equal(ctxSink[0].usageData.scopedWindows[0].percent, 40);
+});
+
+test('main still reads the CLI cache with refresh disabled, passing the flag through', async () => {
+  const calls = [];
+  const ctxSink = [];
+  const config = makeConfig({ refreshModelScopedUsage: false });
+  config.gitStatus = { ...config.gitStatus, enabled: false };
+  await main(mainDeps({
+    config,
+    stdinRateLimits: { five_hour: { used_percentage: 12 } },
+    cliWindows: [{ label: 'Fable', percent: 36, resetAt: null }],
+    calls,
+    ctxSink,
+  }));
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][1], false);
+  assert.deepEqual(ctxSink[0].usageData.scopedWindows, [
+    { label: 'Fable', percent: 36, resetAt: null },
+  ]);
+});
+
+test('main prefers the external snapshot over the CLI cache when refresh is off', async () => {
+  const calls = [];
+  const ctxSink = [];
+  const config = makeConfig({ refreshModelScopedUsage: false, externalUsagePath: '/abs/snapshot.json' });
+  config.gitStatus = { ...config.gitStatus, enabled: false };
+  await main(mainDeps({
+    config,
+    stdinRateLimits: { five_hour: { used_percentage: 12 } },
+    extUsage: {
+      fiveHour: null,
+      sevenDay: null,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      scopedWindows: [{ label: 'FromSnapshot', percent: 50, resetAt: null }],
+    },
+    cliWindows: [{ label: 'FromCliCache', percent: 36, resetAt: null }],
+    calls,
+    ctxSink,
+  }));
+  assert.equal(ctxSink[0].usageData.scopedWindows[0].label, 'FromSnapshot');
+});
+
+test('main promotes the CLI cache above the external snapshot when refresh is on', async () => {
+  const calls = [];
+  const ctxSink = [];
+  const config = makeConfig({ externalUsagePath: '/abs/snapshot.json' });
+  config.gitStatus = { ...config.gitStatus, enabled: false };
+  await main(mainDeps({
+    config,
+    stdinRateLimits: { five_hour: { used_percentage: 12 } },
+    extUsage: {
+      fiveHour: null,
+      sevenDay: null,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      scopedWindows: [{ label: 'FromSnapshot', percent: 50, resetAt: null }],
+    },
+    cliWindows: [{ label: 'FromCliCache', percent: 36, resetAt: null }],
+    calls,
+    ctxSink,
+  }));
+  assert.equal(ctxSink[0].usageData.scopedWindows[0].label, 'FromCliCache');
+});
+
+test('main keeps the external snapshot when refresh is on but the CLI cache is empty', async () => {
+  const calls = [];
+  const ctxSink = [];
+  const config = makeConfig({ externalUsagePath: '/abs/snapshot.json' });
+  config.gitStatus = { ...config.gitStatus, enabled: false };
+  await main(mainDeps({
+    config,
+    stdinRateLimits: { five_hour: { used_percentage: 12 } },
+    extUsage: {
+      fiveHour: null,
+      sevenDay: null,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      scopedWindows: [{ label: 'FromSnapshot', percent: 50, resetAt: null }],
+    },
+    cliWindows: null,
+    calls,
+    ctxSink,
+  }));
+  assert.equal(ctxSink[0].usageData.scopedWindows[0].label, 'FromSnapshot');
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -424,6 +424,7 @@ test("main includes usageData from stdin when available", async () => {
       },
     }),
     parseTranscript: async () => makeTranscript(),
+    getScopedUsageFromCliCache: () => null,
     countConfigs: async () => makeCounts(),
     loadConfig: async () => makeConfig(),
     getGitStatus: async () => null,
@@ -452,6 +453,7 @@ test("main leaves usageData null when stdin rate limits are absent and external 
   await main({
     readStdin: async () => makeStdin({ rate_limits: null }),
     parseTranscript: async () => makeTranscript(),
+    getScopedUsageFromCliCache: () => null,
     countConfigs: async () => makeCounts(),
     loadConfig: async () => makeConfig(),
     getGitStatus: async () => null,
@@ -512,6 +514,7 @@ test("main prefers stdin usage over external usage fallback", async () => {
       },
     }),
     parseTranscript: async () => makeTranscript(),
+    getScopedUsageFromCliCache: () => null,
     countConfigs: async () => makeCounts(),
     loadConfig: async () => makeConfig(),
     getGitStatus: async () => null,
@@ -550,6 +553,7 @@ test("main appends external balance label to stdin usage when snapshot path is c
       },
     }),
     parseTranscript: async () => makeTranscript(),
+    getScopedUsageFromCliCache: () => null,
     countConfigs: async () => makeCounts(),
     loadConfig: async () => makeConfig({
       display: { externalUsagePath: "/tmp/usage.json" },
@@ -591,6 +595,7 @@ test("main fills missing seven-day usage from external snapshot", async () => {
       },
     }),
     parseTranscript: async () => makeTranscript(),
+    getScopedUsageFromCliCache: () => null,
     countConfigs: async () => makeCounts(),
     loadConfig: async () => makeConfig({
       display: { externalUsagePath: "/tmp/usage.json" },


### PR DESCRIPTION
## Problem

`/usage` in Claude Code shows a weekly window scoped to a specific model (the "Fable" weekly quota, for example) alongside the account-wide 5h and 7d windows. #669 taught the HUD to render those scoped windows, reading them from `rate_limits.model_scoped` on statusline stdin.

Claude Code does not send that field over statusline stdin. So the rendering added in #669 has no data source out of the box, and nothing shows.

The README's only alternative is `display.externalUsagePath`: point the HUD at a JSON snapshot you keep fresh yourself with a cron/launchd job piping `get_usage` through `jq`. It works, but it is a scheduled job most people will never set up.

Two things changed on the Claude Code side in recent releases, both verified empirically against the current CLI binary:

1. The CLI persists every `/usage` fetch into `{CLAUDE_CONFIG_DIR}.json` under `cachedUsageUtilization`, including the model-scoped weekly windows, each carrying `scope.model.display_name`.
2. Headless `claude -p /usage` finishes in a few seconds, spends zero tokens, invokes no model, and rewrites that same cache.

So the data the HUD wants is already sitting in a file the CLI maintains for itself, and there is a zero-cost way to make the CLI refresh it.

## What this adds

Two separate things, deliberately split:

**Reading the cache is unconditional.** The HUD now always consults `cachedUsageUtilization` as the last scoped-window fallback. No configuration: if you have run `/usage` recently, the scoped windows appear. This is a plain local file read of a file the HUD already opens — `{CLAUDE_CONFIG_DIR}.json` is the same file it reads for auth info today — so it adds no new capability, only a new field read from a path already in use.

**Auto-refresh is opt-in**, via `display.refreshModelScopedUsage` (default `false`):

```json
{ "display": { "refreshModelScopedUsage": true } }
```

Enabling it does two things: the HUD keeps the cache fresh by spawning a detached headless `claude -p /usage` when the cache is older than five minutes, and — because that freshness is then guaranteed — the CLI cache is promoted above external snapshots as the more trustworthy source.

Priority for scoped windows:

| | order |
|---|---|
| refresh **off** (default) | stdin → external snapshot → CLI cache |
| refresh **on** | stdin → CLI cache → external snapshot |

Stdin always wins. One subtlety worth calling out: an explicit *empty* `model_scoped` array on stdin is preserved as-is, because that is Claude Code stating "there are no scoped windows". Only a genuinely missing field falls through to the fallbacks. That keeps the retirement story exact — the day Claude Code forwards the field, this whole block stops contributing, whether the array has entries or not.

## How it works

1. On render, the HUD reads `cachedUsageUtilization` from `{CLAUDE_CONFIG_DIR}.json` and projects its model-scoped `limits[]` entries into scoped windows. No subprocess in this path.
2. Fresh entries render, through the same `parseScopedWindows` bounds the stdin path uses, so label sanitization, entry caps, percent clamping, and reset-string validation all still apply. Anything older than one hour is not rendered at all — that is the staleness bound the CLI itself applies to this cache, so the HUD never shows data `/usage` would no longer trust.
3. **Only if `refreshModelScopedUsage` is enabled** and the cache is older than five minutes, the HUD spawns one detached, headless `claude -p /usage`. Five minutes is the CLI's own cache write-throttle interval, so polling faster cannot produce newer data.
4. The CLI does its own fetch and rewrites its own cache file. The next render picks it up.

Model names come from the cache verbatim; there is no hardcoded model list, so any future model-scoped window works without a code change.

## Security

The README promises the HUD is local-only and never fetches anything. Both halves of this keep that promise, and the always-on half is the passive one:

- **The always-on part is a local file read and nothing else.** No subprocess, no network, no new file path — it reads one more field out of a JSON file the HUD already opens for auth info.
- **The subprocess is strictly opt-in.** With the default config, nothing is ever spawned; the HUD only reads whatever the CLI happens to have cached.
- **The HUD never reads or handles credentials.** When refresh is enabled, the CLI performs its own fetch with its own auth, exactly as if you had typed `/usage` yourself. The cache file is the only channel between the two.
- **No tokens are spent and no model is invoked.** `claude -p /usage` runs the local command and exits.
- **The subprocess is spawned without a shell**, detached, with `stdio: 'ignore'`. Nothing is parsed from its output; spawn failures are swallowed and never break a render.
- **No stampede.** Statusline renders happen far more often than a headless `/usage` completes, and several sessions share one binary. A private marker file under `~/.claude/plugins/claude-hud` (dir `0700`, file `0600`) is claimed *before* spawning, so concurrent renders cannot fan out into duplicate subprocesses.

The exit condition is unchanged: once Claude Code starts forwarding `rate_limits.model_scoped` on stdin, stdin wins and this path stops executing. It can then be deleted without touching the rendering from #669.

## Tests

`tests/cli-usage.test.js`, 24 tests:

- cache parsing and projection (multiple models, entries missing a display name, null percent, invalid reset strings, missing file / missing cache block / bad timestamp)
- freshness windows (fresh, stale-but-usable, past the one-hour bound, timestamps from the future)
- refresh scheduling (stale schedules exactly one, fresh schedules none, missing cache primes the first render, and reading still works with refresh disabled without spawning anything)
- stampede suppression via the marker (recent marker suppresses, expired marker retries, consecutive stale renders spawn once)
- spawn failures swallowed
- config validation of the opt-in
- `main()` integration: backfill onto existing stdin usage, build usage from the cache alone, stdin scoped windows win, the refresh flag is forwarded through, and priority in all three directions — external snapshot wins when refresh is off, CLI cache wins when refresh is on, snapshot is kept when refresh is on but the cache is empty

One honest note on test isolation: five pre-existing `main()` usage tests in `tests/index.test.js` now stub `getScopedUsageFromCliCache` to return `null`. Because the read is unconditional, those tests would otherwise pick up a real populated `claude.json` on a developer's machine and stop being deterministic. The stub is the whole change to that file.

Full suite: 1103 tests, 1097 pass, 0 fail, 6 pre-existing skips.

Per CONTRIBUTING, only `src/`, `tests/`, and `README.md` are touched — no `dist/` changes. README gets one options-table row and two paragraphs in the usage section next to the existing `externalUsagePath` guidance.
