### PR TITLE
fix(cache): refresh the prompt cache clock when a request starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Claude HUD will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Refresh the prompt-cache clock when a request starts rather than when its response arrives, ignoring client-side slash command records, interrupt markers, and subagent requests (#719).
+
 ## [0.8.0] - 2026-08-18
 
 ### Added

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -79,6 +79,7 @@ interface ContentBlock {
   type: string;
   id?: string;
   name?: string;
+  text?: string;
   input?: Record<string, unknown>;
   tool_use_id?: string;
   is_error?: boolean;
@@ -127,7 +128,7 @@ interface TranscriptCacheFile {
   data: SerializedTranscriptData;
 }
 
-const TRANSCRIPT_CACHE_VERSION = 16;
+const TRANSCRIPT_CACHE_VERSION = 17;
 const MCP_TOOL_NAME_PATTERN = /^mcp__(.+?)__(.+)$/;
 const ACTIVITY_NAME_MAX_LEN = 64;
 const MESSAGE_ID_MAX_LEN = 128;
@@ -140,6 +141,16 @@ const MCP_ERROR_SERVERS_MAX = 64;
 // cap exists to prevent a malformed transcript from persisting an oversized
 // string through the JSON cache and onto every statusline refresh.
 const ADVISOR_MODEL_MAX_LEN = 64;
+
+// Openers of user text that never leaves the machine. Client-side slash
+// commands write their invocation, their output, and their caveat as user
+// records, and an interrupt writes a marker; none of them sends a request.
+const LOCAL_ONLY_USER_TEXT_PREFIXES = [
+  '<command-name>',
+  '<command-message>',
+  '<local-command-',
+  '[Request interrupted by user',
+];
 
 let createReadStreamImpl: typeof fs.createReadStream = fs.createReadStream;
 
@@ -177,6 +188,40 @@ function detectPromptCacheTtlSeconds(
   }
 
   return undefined;
+}
+
+/**
+ * True for user text that Claude Code produced locally rather than sending. A
+ * slash command that runs in the client writes its invocation and its output as
+ * user records without any request going out, and an interrupted request leaves
+ * a marker record behind for the same reason. None of them refreshes the cache.
+ */
+function isLocalOnlyUserText(text: string): boolean {
+  return LOCAL_ONLY_USER_TEXT_PREFIXES.some((prefix) => text.startsWith(prefix));
+}
+
+/**
+ * True when a user record is the start of a request rather than a local note.
+ *
+ * Claude Code sends a request as soon as a prompt is submitted or a tool result
+ * comes back, so the record itself marks the request start. Unknown shapes are
+ * treated as prompts: a record the harness writes without recognizable content
+ * is far more likely to be a message than a client-side aside.
+ */
+function isPromptCacheRequestStart(entry: TranscriptLine): boolean {
+  const content = entry.message?.content;
+
+  if (typeof content === 'string') {
+    return !isLocalOnlyUserText(content);
+  }
+
+  if (Array.isArray(content)) {
+    // Tool results always trigger the follow-up request that carries them.
+    return content.some((block) => block?.type === 'tool_result')
+      || !content.some((block) => block?.type === 'text' && isLocalOnlyUserText(block.text ?? ''));
+  }
+
+  return true;
 }
 
 function normalizeMessageId(value: unknown): string | null {
@@ -489,6 +534,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   let promptCacheTtlSeconds: number | undefined;
   let promptCacheRequestId: string | undefined;
   let promptCacheRequestAnchorAt: Date | undefined;
+  let promptCachePendingRequestAt: Date | undefined;
 
   let parsedCleanly = false;
 
@@ -659,6 +705,17 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
             if (detectedTtl !== undefined) {
               promptCacheTtlSeconds = detectedTtl;
             }
+            // A response closes the request the pending anchor was holding.
+            promptCachePendingRequestAt = undefined;
+          }
+
+          // A request whose response has not been written yet has still already
+          // refreshed the cache, so the record that opened it is the live anchor.
+          // Only a record with no assistant record after it can be that opener,
+          // which is what keeps a user record carrying a skewed future timestamp
+          // from displacing the response it precedes in the file.
+          if (entry.type === 'user' && entryHasTime && isPromptCacheRequestStart(entry)) {
+            promptCachePendingRequestAt = entryAt;
           }
 
           if (entryHasTime) {
@@ -705,7 +762,18 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   result.compactionCount = compactionCount;
   result.advisorModel = latestAdvisorModel;
   result.ultracodeActive = latestUltracodeActive;
-  result.promptCacheAnchorAt = promptCacheAnchorAt;
+  // Promote the pending request only when it moves the clock forward. A record
+  // stamped before the response it follows is skew, and the earlier anchor is
+  // the one that cannot overstate how much cache lifetime is left.
+  result.promptCacheAnchorAt = (
+    promptCachePendingRequestAt
+    && (
+      !promptCacheAnchorAt
+      || promptCachePendingRequestAt.getTime() > promptCacheAnchorAt.getTime()
+    )
+  )
+    ? promptCachePendingRequestAt
+    : promptCacheAnchorAt;
   result.promptCacheTtlSeconds = promptCacheTtlSeconds;
   if (parsedCleanly) {
     writeTranscriptCache(canonicalTranscriptPath, transcriptState, result);

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1011,6 +1011,99 @@ test('parseTranscript re-anchors on each new request', async () => {
   assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:30.000Z');
 });
 
+/** User record carrying a submitted prompt. */
+function userPrompt(timestamp, text = 'do the thing', fields = {}) {
+  return {
+    type: 'user',
+    timestamp,
+    ...fields,
+    message: { role: 'user', content: [{ type: 'text', text }] },
+  };
+}
+
+/** User record carrying the result of a tool the assistant asked for. */
+function toolResult(timestamp, fields = {}) {
+  return {
+    type: 'user',
+    timestamp,
+    ...fields,
+    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tool-1' }] },
+  };
+}
+
+test('parseTranscript anchors a prompt whose response has not landed yet', async () => {
+  const result = await parseTempTranscript('cache-pending-prompt.jsonl', [
+    userPrompt('2024-01-01T00:00:00.000Z'),
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '5m'),
+    // The next prompt went out at 00:04:00 and refreshed the cache there. Waiting
+    // for its response would report the cache draining from 00:00:00 instead.
+    userPrompt('2024-01-01T00:04:00.000Z', 'and now the next thing'),
+  ]);
+
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:04:00.000Z');
+});
+
+test('parseTranscript anchors a tool result whose response has not landed yet', async () => {
+  const result = await parseTempTranscript('cache-pending-tool-result.jsonl', [
+    userPrompt('2024-01-01T00:00:00.000Z'),
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '5m'),
+    toolResult('2024-01-01T00:02:00.000Z'),
+  ]);
+
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:02:00.000Z');
+});
+
+test('parseTranscript keeps client-side slash command records off the cache clock', async () => {
+  const entries = [
+    userPrompt('2024-01-01T00:00:00.000Z'),
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '5m'),
+  ];
+
+  const invocation = await parseTempTranscript('cache-pending-command.jsonl', [
+    ...entries,
+    { type: 'user', timestamp: '2024-01-01T00:03:00.000Z', message: { role: 'user', content: '<command-name>/model</command-name>' } },
+  ]);
+  assert.equal(invocation.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:00.000Z');
+
+  const output = await parseTempTranscript('cache-pending-command-output.jsonl', [
+    ...entries,
+    { type: 'user', timestamp: '2024-01-01T00:03:00.000Z', message: { role: 'user', content: '<local-command-stdout>Set model to Opus</local-command-stdout>' } },
+  ]);
+  assert.equal(output.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:00.000Z');
+});
+
+test('parseTranscript keeps an interrupt marker off the cache clock', async () => {
+  const result = await parseTempTranscript('cache-pending-interrupt.jsonl', [
+    userPrompt('2024-01-01T00:00:00.000Z'),
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '5m'),
+    userPrompt('2024-01-01T00:03:00.000Z', '[Request interrupted by user]'),
+  ]);
+
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:00.000Z');
+});
+
+test('parseTranscript keeps a pending subagent request off the main cache clock', async () => {
+  const result = await parseTempTranscript('cache-pending-sidechain.jsonl', [
+    userPrompt('2024-01-01T00:00:00.000Z'),
+    cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '5m'),
+    userPrompt('2024-01-01T00:03:00.000Z', 'subagent prompt', { isSidechain: true }),
+  ]);
+
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:00:00.000Z');
+});
+
+test('parseTranscript never moves the anchor backwards for a pending request', async () => {
+  const result = await parseTempTranscript('cache-pending-skew.jsonl', [
+    userPrompt('2024-01-01T00:05:00.000Z'),
+    cacheWrite({ timestamp: '2024-01-01T00:05:10.000Z', requestId: 'req-1' }, '5m'),
+    // Stamped before the request it follows, so it is clock skew rather than a
+    // later request. The anchor holds instead of surrendering cache lifetime.
+    toolResult('2024-01-01T00:01:00.000Z'),
+  ]);
+
+  assert.equal(result.promptCacheAnchorAt?.toISOString(), '2024-01-01T00:05:00.000Z');
+});
+
 test('parseTranscript falls back to the response when nothing precedes it', async () => {
   const result = await parseTempTranscript('cache-no-parent.jsonl', [
     cacheWrite({ timestamp: '2024-01-01T00:00:10.000Z', requestId: 'req-1' }, '5m'),


### PR DESCRIPTION
## What happens today

`promptCacheAnchorAt` is only assigned inside the `entry.type === 'assistant'` branch. #702 pointed that assignment at the record the response answers, which is the right target, but it still has to wait for the response to exist. So on a slow turn the statusline renders the previous request's expiry for the whole duration of the current one, which is #719.

## What it should do

Anthropic's cache lifetime is refreshed by a request that reads or writes the cache, so the clock belongs to the moment the request goes out. Claude Code sends one as soon as a prompt is submitted or a tool result comes back, so the user record opening the request is the correct anchor and is written well before the response.

This keeps the response-driven anchor and adds a pending anchor on top. A main-chain user record sets it, a main-chain assistant record clears it, and after the parse the pending anchor is promoted only when it is later than the response-derived one. Clearing on the assistant record is what keeps file order authoritative: a user record can only stay pending if nothing answered it, so a record carrying a skewed future timestamp that sits before its own response cannot displace that response. The existing `ignores an anchor stamped after the response` test still passes unchanged.

## Why the transcript and not stdin

The stdin payload has no timing for the current request. `context_window.current_usage` reports cache read and write token counts but no timestamp, and nothing marks the start of a turn. User records, by contrast, are flushed when written, independent of any response.

Not every user record is a request, and anchoring on one that is not would report the cache as warmer than it is. Four openers are excluded because nothing leaves the machine: `<command-name>`, `<command-message>`, `<local-command-`, and `[Request interrupted by user`. Sidechain records stay excluded per #702, so a subagent's pending request does not touch the main clock. An unrecognized shape is treated as a prompt, which is far more likely than a client-side aside.

Residual: a prompt-type slash command does send a request, and its `<command-name>` record is excluded here, so its in-flight window is not covered. The anchor still lands when the response arrives, which is current behavior, and that seemed better than every `/model` pushing the clock forward with no request behind it.

`TRANSCRIPT_CACHE_VERSION` goes to 17: the serialized shape is unchanged but the anchor's meaning is not. No new config option, since the old value was simply wrong for the duration of a request.

## Testing

Six tests in `tests/core.test.js` alongside the existing prompt cache clock block: a pending prompt and a pending tool result each anchoring to themselves, `<command-name>`/`<local-command-stdout>` and interrupt markers leaving the anchor alone, a pending sidechain record leaving the main anchor alone, and a pending record stamped earlier not moving it backwards.

The existing clock tests and the renderer tests in `tests/prompt-cache.test.js` pass unchanged, including the request grouping, subagent, timestamp skew and TTL detection cases from #702. `dist/` is left to CI.

Fixes #719
