### PR TITLE
feat: add OrcaRouter provider label for Anthropic-compatible gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Claude HUD gives you better insights into what's happening in your Claude Code s
 [Opus] │ my-project git:(main*)
 Context █████░░░░░ 45% │ Usage ██░░░░░░░░ 25% (1h 30m / 5h)
 ```
-- **Line 1** — Model, provider label when positively identified (for example `Bedrock`, `Vertex`, `MiniMax`), project path, git branch
+- **Line 1** — Model, provider label when positively identified (for example `Bedrock`, `Vertex`, `MiniMax`, `OrcaRouter`), project path, git branch
 - **Line 2** — Context bar (green → yellow → red) and usage rate limits
 
 ### Optional lines (enable via `/claude-hud:configure`)
@@ -198,7 +198,7 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 | `display.showModel` | boolean | true | Show model name `[Opus]` |
 | `display.modelSource` | `stdin` \| `auto` \| `transcript` | `stdin` | Controls which source the model name comes from. `stdin` preserves the default behavior and always uses what Claude Code reports. `auto` opts into proxy redirect detection by using transcript models only for non-Claude models. `transcript` always uses the model from the API response. Transcript model values are terminal-sanitized and capped at 80 characters |
 | `display.showProvider` | boolean | false | Show the provider label *before* the model name, e.g. `[Bedrock \| Opus 4.6]`. Useful when a custom proxy serves identically-named models from different providers. When off, an auto-detected provider still trails the model as before |
-| `display.providerName` | string | `""` | Explicit provider label used with `display.showProvider`, e.g. for a custom proxy that can't be auto-detected. Falls back to the auto-detected provider (Bedrock/Vertex/MiniMax/Enterprise) when empty; capped at 40 chars |
+| `display.providerName` | string | `""` | Explicit provider label used with `display.showProvider`, e.g. for a custom proxy that can't be auto-detected. Falls back to the auto-detected provider (Bedrock/Vertex/MiniMax/OrcaRouter/Enterprise) when empty; capped at 40 chars |
 | `display.showAddedDirs` | boolean | true | Show extra workspace directories from `/add-dir` (e.g. `+sparkle +lib-foo`); empty array renders nothing. In both layouts at most 5 dirs render (overflow shown as `+N more`) and basenames are truncated to 24 chars with `…` |
 | `display.addedDirsLayout` | `inline` \| `line` | `inline` | `inline` puts dirs next to the project name with a `+name` prefix per dir; `line` renders them on a separate `Added dirs: name1, name2` line (no `+` prefix, comma-separated) |
 | `display.showContextBar` | boolean | true | Show visual context bar `████░░░░░░` |
@@ -268,6 +268,8 @@ Supported color names: `dim`, `red`, `green`, `yellow`, `magenta`, `cyan`, `brig
 `display.showCost` is fully opt-in. ClaudeHUD prefers the native `cost.total_cost_usd` field that Claude Code provides on stdin when it is available. If that field is absent or invalid for a direct Anthropic session, ClaudeHUD falls back to the existing local transcript-based estimate so the cost line still works on older payloads. The native field is absent before the first API response in a session, so the cost display may stay hidden until then. ClaudeHUD also keeps the cost hidden for known routed providers such as Bedrock and Vertex AI, because cloud-provider billed sessions may report `$0.00` or omit the field even though the session was not literally free. Set `display.showRoutedCost: true` (alongside `showCost`) to opt into cost for those providers anyway: the native `cost.total_cost_usd` is shown as `Cost` when positive, otherwise ClaudeHUD falls back to a token-based `Est.` from the Anthropic pricing table.
 
 Official MiniMax Anthropic-compatible endpoints receive a `MiniMax` provider label. MiniMax M2.7 can use its published token and cache prices for local estimates; M3 pricing depends on each request's context tier, which cumulative session tokens cannot safely infer, so ClaudeHUD does not guess an M3 estimate.
+
+The [OrcaRouter](https://www.orcarouter.ai) gateway exposes an Anthropic-compatible `POST https://api.orcarouter.ai/v1/messages` endpoint, so pointing Claude Code at `ANTHROPIC_BASE_URL=https://api.orcarouter.ai` makes ClaudeHUD show an `OrcaRouter` provider label. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
 
 `display.showPromptCache` is fully opt-in. When enabled, ClaudeHUD shows **the wall-clock time the session's prompt cache expires** (e.g. `Cache ⏱ at 14:30`), or `expired` once that time has passed. It follows `display.hourCycle` and `display.showClockSeconds` like every other clock time in the HUD. If the transcript has no main-session response yet, the cache element stays hidden.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -98,7 +98,7 @@ Claude HUD 让你在 Claude Code 会话中获得更清晰的洞察。
 [Opus] │ my-project git:(main*)
 上下文 █████░░░░░ 45% │ 使用率 ██░░░░░░░░ 25%（1小时30分 / 5小时）
 ```
-- **第 1 行** — 模型、提供商标签（如能正面识别，例如 `Bedrock`、`Vertex`、`MiniMax`）、项目路径、git 分支
+- **第 1 行** — 模型、提供商标签（如能正面识别，例如 `Bedrock`、`Vertex`、`MiniMax`、`OrcaRouter`）、项目路径、git 分支
 - **第 2 行** — 上下文进度条（绿 → 黄 → 红）和使用率限制
 
 ### 可选行（通过 `/claude-hud:configure` 启用）
@@ -243,6 +243,8 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 `display.showCost` 为完全 opt-in 选项。ClaudeHUD 优先使用 Claude Code 在 stdin 上提供的原生 `cost.total_cost_usd` 字段（可用时）。如果该字段缺失或对直连 Anthropic 会话无效，ClaudeHUD 会回退到现有的基于本地转录文件的估算方案，确保费用行在旧负载下仍能工作。原生字段在会话中首个 API 响应之前为空，因此费用显示可能在响应到达前保持隐藏。对于已知的路由提供商（如 Bedrock、Vertex AI），ClaudeHUD 也会隐藏费用显示，因为云提供商计费会话可能报告 `$0.00` 或省略该字段，即使会话并非真正免费。设置 `display.showRoutedCost: true`（并同时开启 `showCost`）即可为这些提供商启用费用显示：原生 `cost.total_cost_usd` 为正值时显示为 `Cost`，否则回退到基于 Anthropic 定价表的 token 估算 `Est.`。
 
 官方 MiniMax Anthropic 兼容端点会显示 `MiniMax` 提供商标签。MiniMax M2.7 可使用其公开 token 和缓存价格进行本地估算；M3 的价格取决于单次请求的上下文层级，而累计会话 token 无法安全推断该层级，因此不会猜测 M3 费用。
+
+[OrcaRouter](https://www.orcarouter.ai) 网关提供 Anthropic 兼容的 `POST https://api.orcarouter.ai/v1/messages` 端点，因此把 Claude Code 指向 `ANTHROPIC_BASE_URL=https://api.orcarouter.ai` 后，ClaudeHUD 会显示 `OrcaRouter` 提供商标签。它在同一端点上还运行网关级零信任 AI agent 安全——默认拒绝地审查每次提示/响应并管控每次工具调用，无需改动任何应用代码。
 
 `display.showPromptCache` 为完全 opt-in 选项。启用后，ClaudeHUD 会显示 **prompt cache 的过期时刻**（例如 `Cache ⏱ at 14:30`），过期后显示 `expired`。它与 HUD 中其他时刻一样遵循 `display.hourCycle` 和 `display.showClockSeconds`。如果 transcript 里还没有主会话响应，这个元素会继续隐藏。
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -265,7 +265,8 @@ export interface HudConfig {
     //                 the actual served model, not the configured one.
     modelSource: 'auto' | 'stdin' | 'transcript';
     // Show the provider label (custom name or auto-detected Bedrock/Vertex/
-    // Enterprise) BEFORE the model name on the project line. Default off.
+    // MiniMax/OrcaRouter/Enterprise) BEFORE the model name on the project line.
+    // Default off.
     showProvider: boolean;
     // Explicit provider label, e.g. for custom proxies where the provider can't
     // be auto-detected. Falls back to auto-detection when empty.

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -318,6 +318,10 @@ const MINIMAX_ANTHROPIC_ENDPOINTS = new Set([
   'https://api.minimaxi.com/anthropic',
 ]);
 
+const ORCAROUTER_ANTHROPIC_ENDPOINTS = new Set([
+  'https://api.orcarouter.ai',
+]);
+
 function isMiniMaxAnthropicEndpoint(env: NodeJS.ProcessEnv = process.env): boolean {
   const baseUrl = env.ANTHROPIC_BASE_URL?.trim() || env.ANTHROPIC_API_BASE_URL?.trim();
   if (!baseUrl) {
@@ -328,6 +332,21 @@ function isMiniMaxAnthropicEndpoint(env: NodeJS.ProcessEnv = process.env): boole
     const url = new URL(baseUrl);
     const normalized = `${url.origin}${url.pathname.replace(/\/+$/, '')}`;
     return MINIMAX_ANTHROPIC_ENDPOINTS.has(normalized);
+  } catch {
+    return false;
+  }
+}
+
+function isOrcaRouterAnthropicEndpoint(env: NodeJS.ProcessEnv = process.env): boolean {
+  const baseUrl = env.ANTHROPIC_BASE_URL?.trim() || env.ANTHROPIC_API_BASE_URL?.trim();
+  if (!baseUrl) {
+    return false;
+  }
+
+  try {
+    const url = new URL(baseUrl);
+    const normalized = `${url.origin}${url.pathname.replace(/\/+$/, '')}`;
+    return ORCAROUTER_ANTHROPIC_ENDPOINTS.has(normalized);
   } catch {
     return false;
   }
@@ -349,6 +368,9 @@ export function getProviderLabel(stdin: StdinData): string | null {
   }
   if (isMiniMaxAnthropicEndpoint()) {
     return 'MiniMax';
+  }
+  if (isOrcaRouterAnthropicEndpoint()) {
+    return 'OrcaRouter';
   }
   if (isEnterpriseModelId(stdin.model?.id)) {
     return 'Enterprise';

--- a/tests/stdin.test.js
+++ b/tests/stdin.test.js
@@ -239,3 +239,39 @@ test('getProviderLabel rejects lookalike MiniMax endpoints', () => {
     else process.env.ANTHROPIC_API_BASE_URL = originalApiBaseUrl;
   }
 });
+
+test('getProviderLabel recognizes the OrcaRouter Anthropic endpoint', () => {
+  const originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
+  const originalApiBaseUrl = process.env.ANTHROPIC_API_BASE_URL;
+
+  try {
+    delete process.env.ANTHROPIC_API_BASE_URL;
+    process.env.ANTHROPIC_BASE_URL = 'https://api.orcarouter.ai';
+    assert.equal(getProviderLabel({ model: { id: 'anthropic/claude-sonnet-5' } }), 'OrcaRouter');
+
+    delete process.env.ANTHROPIC_BASE_URL;
+    process.env.ANTHROPIC_API_BASE_URL = 'https://api.orcarouter.ai/';
+    assert.equal(getProviderLabel({ model: { id: 'anthropic/claude-sonnet-5' } }), 'OrcaRouter');
+  } finally {
+    if (originalBaseUrl === undefined) delete process.env.ANTHROPIC_BASE_URL;
+    else process.env.ANTHROPIC_BASE_URL = originalBaseUrl;
+    if (originalApiBaseUrl === undefined) delete process.env.ANTHROPIC_API_BASE_URL;
+    else process.env.ANTHROPIC_API_BASE_URL = originalApiBaseUrl;
+  }
+});
+
+test('getProviderLabel rejects lookalike OrcaRouter endpoints', () => {
+  const originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
+  const originalApiBaseUrl = process.env.ANTHROPIC_API_BASE_URL;
+
+  try {
+    delete process.env.ANTHROPIC_API_BASE_URL;
+    process.env.ANTHROPIC_BASE_URL = 'https://proxy.orcarouter.ai';
+    assert.equal(getProviderLabel({ model: { id: 'anthropic/claude-sonnet-5' } }), null);
+  } finally {
+    if (originalBaseUrl === undefined) delete process.env.ANTHROPIC_BASE_URL;
+    else process.env.ANTHROPIC_BASE_URL = originalBaseUrl;
+    if (originalApiBaseUrl === undefined) delete process.env.ANTHROPIC_API_BASE_URL;
+    else process.env.ANTHROPIC_API_BASE_URL = originalApiBaseUrl;
+  }
+});


### PR DESCRIPTION
Add a named **OrcaRouter** provider label to Claude HUD.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI/Anthropic-compatible model gateway. It exposes an Anthropic-compatible `POST https://api.orcarouter.ai/v1/messages` endpoint, so Claude Code can be pointed at it via `ANTHROPIC_BASE_URL=https://api.orcarouter.ai` with no code changes. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

**What changed**
- `src/stdin.ts`: detect the OrcaRouter Anthropic-compatible endpoint (`https://api.orcarouter.ai`) and return an `OrcaRouter` provider label, mirroring the existing MiniMax detection.
- `src/config.ts`: update the `showProvider` comment to list the new auto-detected provider.
- `tests/stdin.test.js`: 2 new tests — recognizes the OrcaRouter endpoint (both with and without a trailing slash) and rejects lookalike endpoints.
- `README.md` / `README.zh.md`: document the new `OrcaRouter` provider label.

**Verification**
- `npm run build` — passes.
- `npm test` — 1075 passed, 0 failed, 6 skipped (CI env; the container's `ANTHROPIC_BASE_URL` points at OrcaRouter, so tests are run with it unset).
- Live: `POST https://api.orcarouter.ai/v1/messages` returns `200` with `ORCA-LIVE-OK`.

Disclosure: I'm an engineer on the OrcaRouter team.
