### PR TITLE
test: fix time-of-day flake in format-reset-time clock assertions

### DIFF
--- a/tests/format-reset-time.test.js
+++ b/tests/format-reset-time.test.js
@@ -133,17 +133,24 @@ test('opts: default (auto) matches the pre-existing locale-driven output', () =>
   assert.equal(withoutOpts, withAutoOpts);
 });
 
+// A reset two hours out lands on the next calendar day whenever these run
+// between 22:00 and midnight local time, and the formatter then prefixes a
+// localized date. That prefix is correct and is covered by its own test above,
+// so these assert the clock component rather than the whole string.
+
 test('opts: h23 avoids AM/PM and uses 00-23 hours', () => {
   const resetAt = future(2 * HOUR);
   const result = formatResetTime(resetAt, 'absolute', { hourCycle: 'h23', showSeconds: false });
   assert.doesNotMatch(result, /AM|PM/i);
-  assert.match(result, /^at \d{2}:\d{2}$/);
+  assert.ok(result.startsWith('at '), `Expected "at " prefix, got: ${result}`);
+  assert.match(result, /\d{2}:\d{2}$/);
 });
 
 test('opts: showSeconds adds a seconds component', () => {
   const resetAt = future(2 * HOUR);
   const result = formatResetTime(resetAt, 'absolute', { hourCycle: 'h23', showSeconds: true });
-  assert.match(result, /^at \d{2}:\d{2}:\d{2}$/);
+  assert.ok(result.startsWith('at '), `Expected "at " prefix, got: ${result}`);
+  assert.match(result, /\d{2}:\d{2}:\d{2}$/);
 });
 
 test('opts: midnight boundary — h23 shows 00, not 24', () => {


### PR DESCRIPTION
## What is wrong

Two tests in `tests/format-reset-time.test.js` fail on any run that starts between 22:00 and 23:59 local time. That is a two hour window out of twenty four, so roughly 8.3% of runs go red for reasons that have nothing to do with the code being tested.

Both cases build a reset timestamp two hours in the future and then match the entire formatted result against an anchored clock pattern:

```js
test('opts: h23 avoids AM/PM and uses 00-23 hours', () => {
  const resetAt = future(2 * HOUR);
  const result = formatResetTime(resetAt, 'absolute', { hourCycle: 'h23', showSeconds: false });
  assert.doesNotMatch(result, /AM|PM/i);
  assert.match(result, /^at \d{2}:\d{2}$/);
});
```

After 22:00 a reset two hours out lands on the next calendar day, and `formatAbsoluteTime` prepends a localized date exactly as it is supposed to. The result becomes `at Aug 21 01:26` instead of `at 01:26`, and the anchored pattern rejects it.

The formatter is behaving correctly here. The assertion was written as though a reset two hours out always stays inside today, and that assumption is only true for 22 hours of the day.

## Where it came from

The two assertions arrived in d406afb, merged as PR #692 on 2026-08-07. Nothing in the formatter has changed since. The failure has presumably gone unreported because most CI runs simply miss the window.

This is a pre-existing flake in the test file. It is not connected to any feature work and the fix touches no source code.

## The fix

Both cases now assert the `at ` prefix and the trailing clock component rather than pinning the whole string. That is what `hourCycle` and `showSeconds` actually control, and it holds whether or not the reset crosses midnight.

```js
assert.doesNotMatch(result, /AM|PM/i);
assert.ok(result.startsWith('at '), `Expected "at " prefix, got: ${result}`);
assert.match(result, /\d{2}:\d{2}$/);
```

The date prefix is not left untested. It keeps its own dedicated case in `absolute: includes date component when reset is tomorrow or later`, which builds a reset 30 hours out and checks the localized date and time against what the reset timestamp itself produces.

The relaxed pattern still catches the regression the original was guarding against. Under `h12` the formatter returns `at Aug 21 01:28 a.m.`, which fails the trailing clock match. The `/AM|PM/i` guard on its own does not catch that string, because the marker comes back as `a.m.` with periods, so the trailing match is carrying real weight here.

The change is nine added lines and two removed lines in one test file.

## Verification

Test file run in five timezones, chosen so that two of them sit inside the failing window at the time of the run:

| TZ | Local time at run | Before | After |
| --- | --- | --- | --- |
| UTC | 19:26 | 28 pass, 0 fail | 28 pass, 0 fail |
| Asia/Dubai | 23:26 | 26 pass, 2 fail | 28 pass, 0 fail |
| Europe/Moscow | 22:26 | 26 pass, 2 fail | 28 pass, 0 fail |
| America/New_York | 15:26 | 28 pass, 0 fail | 28 pass, 0 fail |
| Asia/Karachi | 00:26 | 28 pass, 0 fail | 28 pass, 0 fail |

The two failures under Asia/Dubai and Europe/Moscow before the change were `opts: h23 avoids AM/PM and uses 00-23 hours` and `opts: showSeconds adds a seconds component`, reporting `at Aug 21 01:26` and `at Aug 21 01:26:56` against patterns that allow no date.

The full suite was also run before and after, and the set of failing test names was compared rather than just the counts. Under UTC the failing set is byte for byte identical before and after. Under Asia/Dubai the set loses exactly the two tests above and gains nothing. This machine has a number of environment dependent failures in the wider suite that are unrelated to this file and are present on a clean checkout of main, so the comparison is against that baseline rather than against zero.