### PR TITLE
feat(usage): add display.showModelScopedUsage toggle for model-scoped windows (e.g. Fable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 | `display.usageBarEnabled` | boolean | true | Display usage as visual bar instead of text |
 | `display.usageCompact` | boolean | false | Display usage in a shorter text form such as `5h: 25% (1h 30m)`; takes precedence over `display.usageBarEnabled` |
 | `display.showResetLabel` | boolean | true | Show the `resets in` prefix before usage countdowns |
+| `display.showModelScopedUsage` | boolean | true | Show the per-model weekly windows (`model_scoped`, e.g. Fable), whether they arrive on stdin or from the external usage snapshot. Set to `false` to render the usage line as if the payload carried none of them |
 | `display.timeFormat` | `relative` \| `absolute` \| `both` \| `elapsed` \| `elapsedAndAbsolute` | `relative` | How usage-window time is shown: countdown only (`resets in 2h 30m`), wall-clock reset (`resets at 14:30`), both, elapsed window percentage (`53% elapsed`), or elapsed plus wall-clock reset |
 | `display.hourCycle` | `auto` \| `h11` \| `h12` \| `h23` \| `h24` | `auto` | Hour cycle for wall-clock reset times (`absolute`/`both`/`elapsedAndAbsolute` modes). `auto` defers to the system locale; `h23` forces 24-hour time (`14:30`) regardless of locale |
 | `display.showClockSeconds` | boolean | false | Show seconds in wall-clock reset times, e.g. `at 14:30:07` |
@@ -327,6 +328,8 @@ seconds in the wall-clock time, e.g. `at 14:30:07`.
 Set `display.showResetLabel` to `false` if you want shorter usage countdowns such as `(3h 17m)` instead of `(resets in 3h 17m)`.
 
 Set `display.usageCompact` to `true` if you want the shorter usage-only form, for example `5h: 25% (1h 30m)`. Compact usage takes precedence over `display.usageBarEnabled`.
+
+Set `display.showModelScopedUsage` to `false` to hide the per-model weekly windows (e.g. Fable). The usage line then renders exactly as it would for an account that has none: the 5h/7d windows stay, snapshot windows are hidden along with the stdin ones, and a hidden window no longer counts toward a configured usage threshold, so it can no longer keep the line on screen by itself.
 
 ### Security Notes
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -197,6 +197,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `display.usageBarEnabled` | boolean | true | 将使用率显示为可视化进度条而非文本 |
 | `display.usageCompact` | boolean | false | 以较短的文本形式显示使用率，如 `5h: 25% (1h 30m)`；优先于 `display.usageBarEnabled` |
 | `display.showResetLabel` | boolean | true | 在使用率倒计时前显示 `resets in` 前缀 |
+| `display.showModelScopedUsage` | boolean | true | 显示按模型每周窗口（`model_scoped`，例如 Fable），无论其来自 stdin 还是外部用量快照。设为 `false` 后，使用率行的渲染效果等同于负载中本就没有这些窗口 |
 | `display.timeFormat` | `relative` \| `absolute` \| `both` \| `elapsed` \| `elapsedAndAbsolute` | `relative` | 控制使用率窗口时间的显示方式：仅倒计时（`resets in 2h 30m`）、墙钟重置时间（`resets at 14:30`）、两者同时显示、窗口已过百分比（`53% elapsed`），或已过百分比加墙钟重置时间 |
 | `display.hourCycle` | `auto` \| `h11` \| `h12` \| `h23` \| `h24` | `auto` | 墙钟重置时间（`absolute`/`both`/`elapsedAndAbsolute` 模式）的时制。`auto` 跟随系统区域设置；`h23` 强制使用 24 小时制（`14:30`），不受区域设置影响 |
 | `display.showClockSeconds` | boolean | false | 在墙钟重置时间中显示秒数，如 `at 14:30:07` |
@@ -296,6 +297,8 @@ ClaudeHUD 优先使用官方 statusline stdin 负载中的使用率数据。如�
 将 `display.showResetLabel` 设为 `false` 可使用较短的使用率倒计时格式，如 `(3h 17m)` 而非 `(resets in 3h 17m)`。
 
 将 `display.usageCompact` 设为 `true` 可使用更短的使用率格式，如 `5h: 25% (1h 30m)`。紧凑模式优先于 `display.usageBarEnabled`。
+
+将 `display.showModelScopedUsage` 设为 `false` 可隐藏按模型每周窗口（例如 Fable）。此后使用率行的渲染效果，与该账号本就没有这些窗口时完全一致：5h/7d 窗口保留，来自外部快照的窗口会与 stdin 的一并隐藏，且被隐藏的窗口不再计入已配置的使用率阈值，因此无法再单独让该行保持显示。
 
 **前提条件：**
 - Claude Code 必须在当前会话的 stdin 上包含订阅用户 `rate_limits` 数据

--- a/commands/configure.md
+++ b/commands/configure.md
@@ -98,6 +98,7 @@ Save as `language: "en"`, `language: "zh-Hans"`, or `language: "zh-Hant"`.
   - "Usage limits" - 5h: 25% | 7d: 10%
   - "Usage reset label" - show or hide the `resets in` prefix
   - "Compact usage" - 5h: 25% (1h 30m) shorter format
+  - "Model-scoped usage" - Fable ██░░ 38% per-model weekly windows
   - "Session duration" - ⏱️ 5m
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
@@ -165,6 +166,7 @@ If user chooses "Enter custom text", use AskUserQuestion to get their text. Save
   - "Usage bar style" - ██░░ 25% visual bar (only if usageBarEnabled is true)
   - "Usage reset label" - show or hide the `resets in` prefix
   - "Compact usage" - 5h: 25% (1h 30m) shorter format (only if usageCompact is false)
+  - "Model-scoped usage" - Fable ██░░ 38% per-model weekly windows (only if showModelScopedUsage is true)
 
 If more than 4 items ON, show Activity items (Tools, Agents, Todos, Project, Git) first.
 Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset to Minimal" in Q4.
@@ -181,6 +183,7 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
   - "Usage bar style" - ██░░ 25% visual bar (only if usageBarEnabled is false)
   - "Usage reset label" - show or hide the `resets in` prefix
   - "Compact usage" - 5h: 25% (1h 30m) shorter format (only if usageCompact is false)
+  - "Model-scoped usage" - Fable ██░░ 38% per-model weekly windows (only if showModelScopedUsage is false)
   - "Added directories" - +repo +shared workspace directories from /add-dir
   - "Jujutsu status" - jj:(bookmark*) opt-in indicator
   - "Session name" - fix-auth-bug (session slug or custom title)
@@ -328,6 +331,7 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 | Compact usage | `display.usageCompact` |
 | Usage value | `display.usageValue` |
 | Usage reset label | `display.showResetLabel` |
+| Model-scoped usage | `display.showModelScopedUsage` (per-model weekly windows, e.g. Fable) |
 | Session name | `display.showSessionName` |
 | Auth method | `display.showAuth` (plan label, e.g. "Claude Max 20x", own segment at end of first line) |
 | Auth user | `display.showAuthUser` (login account, truncated to `display.authUserLength` chars, 0 = full) |

--- a/src/config.ts
+++ b/src/config.ts
@@ -208,6 +208,9 @@ export interface HudConfig {
     usageBarEnabled: boolean;
     showResetLabel: boolean;
     usageCompact: boolean;
+    // Show the per-model weekly windows (`rate_limits.model_scoped`, e.g. Fable)
+    // next to the 5h/7d windows. Set to false to keep only 5h/7d. Default on.
+    showModelScopedUsage: boolean;
     showTools: boolean;
     showSkills: boolean;
     showMcp: boolean;
@@ -329,6 +332,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     usageBarEnabled: true,
     showResetLabel: true,
     usageCompact: false,
+    showModelScopedUsage: true,
     showTools: false,
     showSkills: false,
     showMcp: false,
@@ -823,6 +827,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     usageCompact: typeof migrated.display?.usageCompact === 'boolean'
       ? migrated.display.usageCompact
       : DEFAULT_CONFIG.display.usageCompact,
+    showModelScopedUsage: typeof migrated.display?.showModelScopedUsage === 'boolean'
+      ? migrated.display.showModelScopedUsage
+      : DEFAULT_CONFIG.display.showModelScopedUsage,
     showTools: typeof migrated.display?.showTools === 'boolean'
       ? migrated.display.showTools
       : DEFAULT_CONFIG.display.showTools,

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -36,7 +36,9 @@ export function renderUsageLine(
 
   const usageLabel = progressLabel("label.usage", colors, labelOptions);
   const balanceLabel = ctx.usageData.balanceLabel ?? null;
-  const scopedWindows = ctx.usageData.scopedWindows ?? [];
+  const scopedWindows = display?.showModelScopedUsage === false
+    ? []
+    : ctx.usageData.scopedWindows ?? [];
   const hasWindowData = ctx.usageData.fiveHour !== null
     || ctx.usageData.sevenDay !== null
     || scopedWindows.length > 0;

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -180,7 +180,12 @@ export function renderSessionLine(ctx: RenderContext): string {
     const usageCompact = display?.usageCompact ?? false;
     const showResetLabel = display?.showResetLabel ?? true;
     const usageValueMode = display?.usageValue ?? 'percent';
-    const scopedWindows = ctx.usageData.scopedWindows ?? [];
+    // Only "hidden" when something was actually suppressed. With no scoped
+    // windows there is nothing to hide, and the ghost-placeholder fallback
+    // below has to keep behaving exactly as it does without this flag.
+    const scopedHidden = display?.showModelScopedUsage === false
+      && (ctx.usageData.scopedWindows?.length ?? 0) > 0;
+    const scopedWindows = scopedHidden ? [] : ctx.usageData.scopedWindows ?? [];
     const hasGenericWindowData = ctx.usageData.fiveHour !== null || ctx.usageData.sevenDay !== null;
     const hasWindowData = hasGenericWindowData || scopedWindows.length > 0;
     const scopedParts = scopedWindows.map((window) =>
@@ -271,7 +276,7 @@ export function renderSessionLine(ctx: RenderContext): string {
           });
           push(weeklyOnlyPart);
           scopedParts.forEach((part) => push(part));
-        } else if (hasGenericWindowData || !hasWindowData) {
+        } else if (hasGenericWindowData || (!hasWindowData && !scopedHidden)) {
           const fiveHourPart = formatUsageWindowPart({
             label: '5h',
             percent: fiveHour,

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1214,6 +1214,24 @@ test('mergeConfig rejects non-boolean showCompactions', () => {
   assert.equal(config.display.showCompactions, false);
 });
 
+test('mergeConfig defaults showModelScopedUsage to true', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.showModelScopedUsage, true);
+  assert.equal(DEFAULT_CONFIG.display.showModelScopedUsage, true);
+});
+
+test('mergeConfig preserves explicit showModelScopedUsage=false', () => {
+  const config = mergeConfig({ display: { showModelScopedUsage: false } });
+  assert.equal(config.display.showModelScopedUsage, false);
+});
+
+test('mergeConfig rejects non-boolean showModelScopedUsage', () => {
+  // A falsy probe is the load-bearing one: against a `true` default, a truthy
+  // probe alone would still pass under a Boolean()-coercing implementation.
+  assert.equal(mergeConfig({ display: { showModelScopedUsage: 0 } }).display.showModelScopedUsage, true);
+  assert.equal(mergeConfig({ display: { showModelScopedUsage: 'no' } }).display.showModelScopedUsage, true);
+});
+
 test('mergeConfig preserves explicit showAdvisor=true', () => {
   const config = mergeConfig({ display: { showAdvisor: true } });
   assert.equal(config.display.showAdvisor, true);

--- a/tests/scoped-usage.test.js
+++ b/tests/scoped-usage.test.js
@@ -212,6 +212,85 @@ test('renderSessionLine includes scoped usage and preserves a custom usage color
   assert.match(line, /\x1b\[36m38%\x1b\[0m/);
 });
 
+// display.showModelScopedUsage — render-time gate for model_scoped windows.
+
+test('renderUsageLine keeps scoped windows alongside 5h/7d by default', () => {
+  const line = stripAnsi(renderUsageLine(renderContext(scopedUsage({ fiveHour: 25, sevenDay: 85 }))) ?? '');
+
+  assert.match(line, /5h 25%/);
+  assert.match(line, /Weekly 85%/);
+  assert.match(line, /Fable 38%/);
+});
+
+test('renderUsageLine hides scoped windows when showModelScopedUsage is false', () => {
+  const ctx = renderContext(scopedUsage({ fiveHour: 25, sevenDay: 85 }), { showModelScopedUsage: false });
+  const line = stripAnsi(renderUsageLine(ctx) ?? '');
+
+  assert.match(line, /5h 25%/);
+  assert.match(line, /Weekly 85%/);
+  assert.doesNotMatch(line, /Fable/);
+});
+
+test('renderUsageLine drops the usage line when only hidden scoped windows exist', () => {
+  const ctx = renderContext(scopedUsage(), { showModelScopedUsage: false });
+
+  assert.equal(renderUsageLine(ctx), null);
+});
+
+test('renderUsageLine keeps the balance when scoped windows are hidden', () => {
+  const ctx = renderContext(scopedUsage({ balanceLabel: '$12 left' }), { showModelScopedUsage: false });
+  const line = stripAnsi(renderUsageLine(ctx) ?? '');
+
+  assert.match(line, /Usage\s+\$12 left/);
+  assert.doesNotMatch(line, /Fable/);
+});
+
+test('renderSessionLine hides scoped windows when showModelScopedUsage is false', () => {
+  const ctx = renderContext(scopedUsage({ fiveHour: 25 }), { showModelScopedUsage: false });
+  const line = stripAnsi(renderSessionLine(ctx));
+
+  assert.match(line, /5h 25%/);
+  assert.doesNotMatch(line, /Fable/);
+});
+
+test('renderSessionLine drops the usage segment when only hidden scoped windows exist', () => {
+  const ctx = renderContext(scopedUsage(), { showModelScopedUsage: false });
+  const line = stripAnsi(renderSessionLine(ctx));
+
+  assert.doesNotMatch(line, /Fable/);
+  assert.doesNotMatch(line, /Usage/);
+  assert.doesNotMatch(line, /5h/);
+});
+
+test('showModelScopedUsage=false stays inert when model_scoped is present but empty', () => {
+  // An explicit empty model_scoped array has nothing to hide, so the flag must
+  // not change either layout: hiding "no windows" is not the same as hiding
+  // windows, and the two must not diverge.
+  const empty = scopedUsage({ scopedWindows: [] });
+  const shown = renderContext(empty);
+  const hidden = renderContext(empty, { showModelScopedUsage: false });
+
+  assert.equal(renderUsageLine(hidden), renderUsageLine(shown));
+  assert.equal(renderSessionLine(hidden), renderSessionLine(shown));
+});
+
+test('hidden scoped windows no longer lift the usage line over usageThreshold', () => {
+  // The gate runs before effectiveUsage is computed, so a hidden window stops
+  // holding the line open: with only the scoped window above the threshold,
+  // the whole usage group goes away, 5h included, exactly as it would for a
+  // payload that never carried scoped windows.
+  const usage = scopedUsage({
+    fiveHour: 42,
+    scopedWindows: [{ label: 'Fable', percent: 100, resetAt: null }],
+  });
+  const shown = renderContext(usage, { usageThreshold: 80 });
+  const hidden = renderContext(usage, { usageThreshold: 80, showModelScopedUsage: false });
+
+  assert.match(stripAnsi(renderUsageLine(shown) ?? ''), /5h 42%/);
+  assert.equal(renderUsageLine(hidden), null);
+  assert.doesNotMatch(stripAnsi(renderSessionLine(hidden)), /5h|Fable/);
+});
+
 test('shared limit warnings retain bounded scoped usage in both layouts', () => {
   const usage = scopedUsage({ fiveHour: 100 });
   const ctx = renderContext(usage);


### PR DESCRIPTION
## Summary

Model-scoped weekly windows render as their own segment on the usage line, for example `Fable ██████░░░░ 38% (resets in 2d)`. They are appended last, so on a narrow terminal they are usually the first thing that pushes the line into a wrap, and there is currently no way to drop just that segment short of turning off `display.showUsage` entirely.

This adds `display.showModelScopedUsage` (boolean, default `true`). Setting it to `false` renders the usage line exactly as it would for an account that has no model-scoped windows at all.

The gate is applied at render time, in `renderUsageLine` and in the compact `renderSessionLine`, right where `scopedWindows` is first read. That keeps the "has any usage" check, the scoped suffix, and the `effectiveUsage` threshold computation consistent with each other, and it covers every source: stdin (#669), the external snapshot (#690), and the CLI usage cache if #720 lands. Default `true` preserves current behavior exactly.

Three consequences of gating at that one point, all covered by tests:

- Hidden windows drop out of the `effectiveUsage` maximum, so with a non-zero `display.usageThreshold` a hidden window can no longer hold the usage line open on its own. The README says so rather than promising the 5h/7d windows always survive.
- `renderSessionLine` needed its `!hasWindowData` fallback guarded, so hiding the last remaining window renders no usage segment rather than a ghost `5h --` placeholder.
- Hiding nothing stays a no-op: an explicit empty `model_scoped` array renders identically whether the flag is set or unset.

`CHANGELOG.md` is the one doc left untouched, so the branch keeps merging cleanly while #718 and #721 are both queued under the same `[Unreleased]` anchor. Happy to add it if you would rather have it in this PR.

## Testing

- [x] `npm test` (1084 pass, 6 skip, 0 fail; baseline on `main`: 1073 pass, 6 skip, 0 fail)
- [x] `npm run test:coverage` (94.23% statements overall, up from 94.22% on `main`; `usage.ts` 98.28%, `session-line.ts` 96.36%, `config.ts` 100%)

New tests in `tests/scoped-usage.test.js`: default renders scoped windows; `false` hides them while 5h/7d still render; `false` with scoped-only windows renders no usage segment; `false` with an empty `model_scoped` array changes nothing; a hidden window stops lifting the line over `display.usageThreshold`; the balance label survives; all in both layouts. And in `tests/config.test.js`: default `true`, explicit `false`, non-boolean rejected, probed with a falsy value so a coercing implementation would fail.

I also ran each new test against a deliberately broken build to confirm none of them passes for trivial reasons, and rendered the built `dist/` against mock payloads across both `lineLayout` values, `usageCompact` on and off, scoped-only / mixed / absent / explicitly empty `rate_limits`, limit-reached, and a `usageThreshold` above every non-scoped window. With the flag left unset the output is byte-identical to v0.8.0.

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed (README.md and README.zh.md get a row plus a paragraph; `commands/configure.md` gets the option in all three question lists and in the element mapping table, matching how `showResetLabel` and `usageCompact` were added)

Only `src/`, `tests/`, the two READMEs, and `commands/configure.md` are touched; no `dist/` changes per CONTRIBUTING.
