### PR TITLE
fix(config): close TOCTOU between config validation and read

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1055,23 +1055,45 @@ function mergeOverrides(
 
 function readConfigFile(configPath: string): Record<string, unknown> | null {
   try {
-    const stat = fs.lstatSync(configPath);
-    if (stat.isSymbolicLink() || !stat.isFile()) {
-      debug('Ignoring %s: expected a regular, non-symlink file', configPath);
-      return null;
-    }
-    if (stat.size > MAX_CONFIG_FILE_BYTES) {
-      debug('Ignoring %s: file exceeds %d bytes', configPath, MAX_CONFIG_FILE_BYTES);
-      return null;
-    }
+    // Validate and read through a single open file descriptor so a path swap
+    // (symlink or growth) between check and read can't bypass either guard.
+    // O_NOFOLLOW is the symlink defense on POSIX (open fails with ELOOP,
+    // caught below); it is undefined on Windows, so it's OR'd in only when
+    // present.
+    const flags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0);
+    const fd = fs.openSync(configPath, flags);
+    try {
+      const stat = fs.fstatSync(fd);
+      if (!stat.isFile()) {
+        debug('Ignoring %s: expected a regular, non-symlink file', configPath);
+        return null;
+      }
 
-    const content = fs.readFileSync(configPath, 'utf-8');
-    const parsed: unknown = JSON.parse(content);
-    if (!isPlainObject(parsed) || !hasSafeConfigShape(parsed)) {
-      debug('Ignoring %s: expected a bounded JSON object without unsafe keys', configPath);
-      return null;
+      // Bound the read itself (not just the stat) so a file that grows after
+      // fstat can't slip an oversized payload past the cap; loop until done
+      // so a legal short read can't under-count an oversized file.
+      const buf = Buffer.alloc(MAX_CONFIG_FILE_BYTES + 1);
+      let off = 0;
+      let n = 0;
+      do {
+        n = fs.readSync(fd, buf, off, buf.length - off, off);
+        off += n;
+      } while (n > 0 && off < buf.length);
+      if (off > MAX_CONFIG_FILE_BYTES) {
+        debug('Ignoring %s: file exceeds %d bytes', configPath, MAX_CONFIG_FILE_BYTES);
+        return null;
+      }
+
+      const content = buf.subarray(0, off).toString('utf-8');
+      const parsed: unknown = JSON.parse(content);
+      if (!isPlainObject(parsed) || !hasSafeConfigShape(parsed)) {
+        debug('Ignoring %s: expected a bounded JSON object without unsafe keys', configPath);
+        return null;
+      }
+      return parsed;
+    } finally {
+      fs.closeSync(fd);
     }
-    return parsed;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
       return null;

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -677,6 +677,44 @@ test('loadConfig rejects oversized and symlinked claude-hud.json files', async (
   }
 });
 
+test('loadConfig rejects an oversized or symlinked shared config.json (TOCTOU-safe read)', async (t) => {
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  const customConfigDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-config-file-'));
+
+  try {
+    process.env.CLAUDE_CONFIG_DIR = customConfigDir;
+    const pluginDir = path.join(customConfigDir, 'plugins', 'claude-hud');
+    await mkdir(pluginDir, { recursive: true });
+    const configPath = path.join(pluginDir, 'config.json');
+
+    // A normal, small config still loads.
+    await writeFile(configPath, JSON.stringify({ display: { customLine: 'ok' } }), 'utf8');
+    assert.equal((await loadConfig()).display.customLine, 'ok');
+
+    // A config over MAX_CONFIG_FILE_BYTES is rejected; loadConfig falls back to defaults.
+    await writeFile(configPath, JSON.stringify({ padding: 'x'.repeat(70 * 1024) }), 'utf8');
+    assert.equal((await loadConfig()).display.customLine, '');
+
+    // A symlinked config.json is rejected (O_NOFOLLOW on open, not a post-hoc lstat check).
+    const targetPath = path.join(customConfigDir, 'config-target.json');
+    await writeFile(targetPath, JSON.stringify({ display: { customLine: 'poison' } }), 'utf8');
+    await rm(configPath, { force: true });
+    try {
+      await symlink(targetPath, configPath, 'file');
+    } catch (err) {
+      if (err?.code === 'EPERM' || err?.code === 'EACCES') {
+        t.skip('file symlinks are unavailable on this platform');
+        return;
+      }
+      throw err;
+    }
+    assert.equal((await loadConfig()).display.customLine, '');
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    await rm(customConfigDir, { recursive: true, force: true });
+  }
+});
+
 test('loadConfig keeps overrides isolated when config directories share plugins', async (t) => {
   const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
   const root = await mkdtemp(path.join(tmpdir(), 'claude-hud-shared-plugins-'));


### PR DESCRIPTION
## Summary

Fixes #731 — a TOCTOU between `readConfigFile`'s validation and its read.

`readConfigFile` validated a config path with `fs.lstatSync` (rejecting symlinks and files over `MAX_CONFIG_FILE_BYTES`) and then reopened the same path with a separate `fs.readFileSync`. Because the two calls resolve the path independently, a file swapped in between them (a symlink, or the file grown past the size cap) could bypass both guards — building on the symlink check that's already there, just closing the window between checking it and reading it.

## Fix

Validate and read through a single open file descriptor so no post-check path swap can change what's read:

- `fs.openSync` with `O_NOFOLLOW` (OR'd in only when the constant exists, since it's `undefined` on Windows) — a symlinked path fails to open with `ELOOP` on POSIX, caught by the existing outer `catch` and turned into `null`. Native-Windows symlink rejection isn't covered by `O_NOFOLLOW`; flagging as a known gap there rather than trying to paper over it.
- `fs.fstatSync(fd)` replaces the `lstatSync(path)` check, so `isFile()` is asserted on the handle that's actually about to be read, not a stale path lookup.
- The read itself is bounded (not just the earlier stat): it loops until done or `MAX_CONFIG_FILE_BYTES + 1` bytes are filled, so a legal short read can't under-count a file that grew after the check, and an oversized result is rejected the same way the old size check was.

Everything downstream (JSON parsing, `hasSafeConfigShape`, the `ENOENT` → `null` path) is unchanged.

## Tests

Added `loadConfig rejects an oversized or symlinked shared config.json (TOCTOU-safe read)` in `tests/config.test.js`, covering the primary `config.json` path the same way the existing `loadConfig rejects oversized and symlinked claude-hud.json files` test already covers the override path (both go through `readConfigFile`):
- a normal small config still loads,
- an oversized file is rejected and `loadConfig` falls back to defaults,
- a symlinked config file is rejected (skips gracefully if the platform can't create file symlinks, matching the existing test's pattern).

## Validation

- `npm ci`
- `npm run build` (tsc) — clean
- `npm test` — no regressions versus unmodified `main`; failing-test set is identical between the two runs (pre-existing platform-specific test issues on this machine, unrelated to `config.ts`)
- `tests/config.test.js` in isolation: 130 passed, 2 skipped (symlink creation needs elevated perms on this machine — same skip condition as the existing override-file test)

Credit to the existing symlink/size guard this builds on — the fix keeps its semantics, just moves them onto one file descriptor.
