### PR TITLE
fix: agents, git locks, cache wording, and zh docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to Claude HUD will be documented in this file.
 
 ### Fixed
 - Refresh the prompt-cache clock when a request starts rather than when its response arrives, ignoring client-side slash command records, interrupt markers, and subagent requests (#719).
+- Treat Agent `tool_result` payloads with `isAsync` or `status: async_launched` as background so the agents line stays up until the task-notification (#734).
+- Pass `--no-optional-locks` on `git diff --numstat` so a timed-out statusline poll cannot leave `.git/index.lock` behind (#726).
+- Render the prompt-cache clock as `until <time>` so the value reads as expiry, not write time (#727).
+
+### Docs
+- Add the ten missing config options and the absolute-path caveat for `display.externalUsagePath` to `README.zh.md` (#730).
 
 ## [0.8.0] - 2026-08-18
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Supported color names: `dim`, `red`, `green`, `yellow`, `magenta`, `cyan`, `brig
 
 Official MiniMax Anthropic-compatible endpoints receive a `MiniMax` provider label. MiniMax M2.7 can use its published token and cache prices for local estimates; M3 pricing depends on each request's context tier, which cumulative session tokens cannot safely infer, so ClaudeHUD does not guess an M3 estimate.
 
-`display.showPromptCache` is fully opt-in. When enabled, ClaudeHUD shows **the wall-clock time the session's prompt cache expires** (e.g. `Cache ⏱ at 14:30`), or `expired` once that time has passed. It follows `display.hourCycle` and `display.showClockSeconds` like every other clock time in the HUD. If the transcript has no main-session response yet, the cache element stays hidden.
+`display.showPromptCache` is fully opt-in. When enabled, ClaudeHUD shows **the wall-clock time the session's prompt cache expires** (e.g. `Cache ⏱ until 14:30`), or `expired` once that time has passed. It follows `display.hourCycle` and `display.showClockSeconds` like every other clock time in the HUD. If the transcript has no main-session response yet, the cache element stays hidden.
 
 It shows an expiry time rather than a countdown because the statusline only repaints while Claude Code is active. Between turns — exactly when the cache is draining — a countdown freezes at whatever it last displayed and keeps reporting it; a clock time stays true no matter how stale the render is.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -182,10 +182,13 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `jjStatus.showConflicts` | boolean | true | 当 jj 工作副本提交包含未解决冲突时显示 `!conflict` |
 | `display.showModel` | boolean | true | 显示模型名称 `[Opus]` |
 | `display.modelSource` | `stdin` \| `auto` \| `transcript` | `stdin` | 控制模型名称来源。`stdin` 保持默认行为；`auto` 仅在 transcript 返回非 Claude 模型时切换，用于检测代理路由；`transcript` 始终使用 API 响应中的模型。Transcript 模型值会清理终端转义字符并截断为 80 个字符 |
+| `display.showProvider` | boolean | false | 在模型名称*之前*显示提供商标签，例如 `[Bedrock \| Opus 4.6]`。自定义代理提供同名模型时有用。关闭时，自动检测的提供商仍跟在模型后面 |
+| `display.providerName` | string | `""` | 与 `display.showProvider` 一起使用的显式提供商标签，例如无法自动检测的自定义代理。为空时回退到自动检测（Bedrock/Vertex/MiniMax/Enterprise）；上限 40 字符 |
 | `display.showAddedDirs` | boolean | true | 显示来自 `/add-dir` 的额外工作区目录（如 `+sparkle +lib-foo`）；空数组不显示任何内容。在两种布局中最多渲染 5 个目录（溢出显示为 `+N more`），基名截断为 24 个字符并加 `…` |
 | `display.addedDirsLayout` | `inline` \| `line` | `inline` | `inline` 将目录放在项目名称旁边，每个目录带 `+name` 前缀；`line` 在单独的 `Added dirs: name1, name2` 行渲染（无 `+` 前缀，逗号分隔） |
 | `display.showContextBar` | boolean | true | 显示可视化上下文进度条 `████░░░░░░` |
 | `display.contextValue` | `percent` \| `tokens` \| `remaining` \| `both` | `percent` | 上下文显示格式（`45%`、`45k/200k`、剩余 `55%` 或 `45% (45k/200k)`） |
+| `display.autoCompactWindow` | number \| `null` | `null` | 设为正数（如 `200000`）时，按此自动压缩窗口而不是完整模型上下文窗口计算上下文百分比，以匹配 `/context`。留空或 `null` 保持默认全窗口行为 |
 | `display.showConfigCounts` | boolean | false | 显示 CLAUDE.md、rules、MCPs、hooks 数量 |
 | `display.showCost` | boolean | false | 使用 Claude Code 原生提供的 `cost.total_cost_usd` 显示会话费用（可用时），并附带本地估算回退方案 |
 | `display.showRoutedCost` | boolean | false | 同时为路由提供商（Bedrock/Vertex）显示费用，`showCost` 默认将其隐藏。需同时开启 `showCost`。原生 `cost.total_cost_usd` 为正值时使用它（`Cost`），否则用 token 估算（`Est.`） |
@@ -203,21 +206,28 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `display.hourCycle` | `auto` \| `h11` \| `h12` \| `h23` \| `h24` | `auto` | 墙钟重置时间（`absolute`/`both`/`elapsedAndAbsolute` 模式）的时制。`auto` 跟随系统区域设置；`h23` 强制使用 24 小时制（`14:30`），不受区域设置影响 |
 | `display.showClockSeconds` | boolean | false | 在墙钟重置时间中显示秒数，如 `at 14:30:07` |
 | `display.sevenDayThreshold` | 0-100 | 80 | 当 7 天使用率 ≥ 阈值时显示（0 = 始终显示） |
-| `display.externalUsagePath` | string | `""` | 可选的本地使用率快照文件路径。stdin `rate_limits` 存在时会附加 `balance_label`，并在 stdin 缺少 `model_scoped` 窗口时用快照补齐；stdin 窗口缺失时可整体作为回退 |
+| `display.externalUsagePath` | string | `""` | 可选的本地使用率快照文件**绝对路径**。相对路径会被忽略。stdin `rate_limits` 存在时会附加 `balance_label`，并在 stdin 缺少 `model_scoped` 窗口时用快照补齐；stdin 窗口缺失时可整体作为回退 |
 | `display.externalUsageWritePath` | string | `""` | 可选的绝对 `.json` 路径，父目录必须已存在。当 stdin `rate_limits` 存在时，ClaudeHUD 会写入私有权限快照供其他本地工具读取。相对路径、非 json 文件和缺失父目录会被忽略 |
 | `display.externalUsageFreshnessMs` | number | `300000` | 外部使用率快照允许的最长存活时间，超时后会被忽略 |
 | `display.showTokenBreakdown` | boolean | true | 在高上下文时（85%+）显示 Token 详情 |
 | `display.showTools` | boolean | false | 显示工具活动行 |
+| `display.showSkills` | boolean | false | 显示从 `Skill` 工具调用检测到的活动 Skills |
+| `display.showMcp` | boolean | false | 显示从 `mcp__server__tool` 调用检测到的活动 MCP 服务器 |
 | `display.toolNameMaxLength` | number | `0` | 工具名称最大显示长度。`0` 保留完整名称；截断 MCP 名称时可能缩短为最后一段 |
 | `display.toolsMaxVisible` | number | `4` | 工具行最多显示的已完成工具数。`0` 表示不限制 |
 | `display.showAgents` | boolean | false | 显示 Agent 活动行 |
 | `display.showTodos` | boolean | false | 显示待办进度行 |
 | `display.showSessionName` | boolean | false | 显示会话 slug 或 `/rename` 设置的自定义标题 |
+| `display.showAuth` | boolean | false | 在第一行末尾显示当前登录的认证方式（订阅计划），例如 `Claude Max 20x`。来自 `{CLAUDE_CONFIG_DIR}.json` 的 `oauthAccount`；无 OAuth 但设置了 `ANTHROPIC_API_KEY` 时显示 `API Key` |
+| `display.showAuthUser` | boolean | false | 在认证方式旁显示已登录账号（邮箱本地部分，回退到资料显示名） |
+| `display.authUserLength` | number | `8` | 账号名截断前的最大字符数，超出以 `…` 截断。`0` 显示全名 |
 | `display.showAdvisor` | boolean | false | 在 project 行内联显示 Claude Code `/advisor` 配置的顾问模型，例如 `Advisor: Opus 4.7`。来自 Claude Code 写入每条 assistant transcript 记录的 `advisorModel` 字段；渲染前会做控制字符/双向标记/ANSI 过滤并截断到 64 字符 |
 | `display.advisorOverride` | string | `""` | 手动覆盖顾问显示文本。非空时优先于 transcript 检测，同样会做过滤和截断 |
 | `display.showSessionStartDate` | boolean | false | 显示 transcript 会话开始时间戳 |
 | `display.showLastResponseAt` | boolean | false | 显示最后一次 assistant 响应写入的时间距现在多久 |
 | `display.showCompactions` | boolean | false | 显示本会话已发生的上下文压缩次数（手动 `/compact` 或自动压缩），从 transcript 的 `compact_boundary` 记录计数，例如 `压缩次数: 2`。第一次压缩前不显示 |
+| `display.showEffortLevel` | boolean | false | 在模型徽章中显示当前推理力度。Ultracode 渲染为 `ultracode(xhigh)`，从会话 transcript 检测，因此能跟踪运行时的 `/effort` 变更 |
+| `display.effortFormat` | `full` \| `symbol` \| `text` | `full` | `showEffortLevel` 开启时的渲染方式：符号加级别文本（`◑ high`）、仅符号（`◑`）、或仅级别文本（`high`）。`symbol` 下 Ultracode 仍保持完整的 `◕ ultracode(xhigh)`，以免丢失标记；没有已知符号的级别回退到级别文本 |
 | `display.showClaudeCodeVersion` | boolean | false | 显示已安装的 Claude Code 版本，如 `CC v2.1.81` |
 | `display.showMemoryUsage` | boolean | false | 在展开布局中显示近似系统 RAM 使用行 |
 | `display.showPromptCache` | boolean | false | 显示 prompt cache 的过期时刻，数据来自 transcript |
@@ -246,7 +256,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 
 官方 MiniMax Anthropic 兼容端点会显示 `MiniMax` 提供商标签。MiniMax M2.7 可使用其公开 token 和缓存价格进行本地估算；M3 的价格取决于单次请求的上下文层级，而累计会话 token 无法安全推断该层级，因此不会猜测 M3 费用。
 
-`display.showPromptCache` 为完全 opt-in 选项。启用后，ClaudeHUD 会显示 **prompt cache 的过期时刻**（例如 `Cache ⏱ at 14:30`），过期后显示 `expired`。它与 HUD 中其他时刻一样遵循 `display.hourCycle` 和 `display.showClockSeconds`。如果 transcript 里还没有主会话响应，这个元素会继续隐藏。
+`display.showPromptCache` 为完全 opt-in 选项。启用后，ClaudeHUD 会显示 **prompt cache 的过期时刻**（例如 `Cache ⏱ until 14:30`），过期后显示 `expired`。它与 HUD 中其他时刻一样遵循 `display.hourCycle` 和 `display.showClockSeconds`。如果 transcript 里还没有主会话响应，这个元素会继续隐藏。
 
 它显示过期时刻而不是倒计时，因为状态栏只在 Claude Code 活动时重绘。在两个回合之间——正好是缓存流失的时候——倒计时会停在最后一次显示的数值上并继续报告它；而时刻无论渲染多陈旧都仍然正确。
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -84,7 +84,7 @@ export async function getGitStatus(cwd?: string): Promise<GitStatus | null> {
     if (isDirty) {
       try {
         const { stdout: numstatOut } = await runner.run(
-          ['-c', 'core.quotePath=false', 'diff', '--numstat', 'HEAD'],
+          ['-c', 'core.quotePath=false', '--no-optional-locks', 'diff', '--numstat', 'HEAD'],
           2000,
         );
         const trackedPaths = new Set(fileStats?.trackedFiles.map((file) => file.fullPath) ?? []);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -27,6 +27,7 @@ export const en: Messages = {
   "format.resets": "resets",
   "format.resetsIn": "resets in",
   "format.absoluteTime": "at {time}",
+  "format.untilTime": "until {time}",
   "format.in": "in",
   "format.cache": "cache",
   "format.out": "out",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -23,6 +23,7 @@ export type MessageKey =
   | "format.resets"
   | "format.resetsIn"
   | "format.absoluteTime"
+  | "format.untilTime"
   | "format.in"
   | "format.cache"
   | "format.out"

--- a/src/i18n/zh-Hans.ts
+++ b/src/i18n/zh-Hans.ts
@@ -27,6 +27,7 @@ export const zhHans: Messages = {
   "format.resets": "重置于",
   "format.resetsIn": "重置剩余",
   "format.absoluteTime": "{time}",
+  "format.untilTime": "至 {time}",
   "format.in": "输入",
   "format.cache": "缓存",
   "format.out": "输出",

--- a/src/i18n/zh-Hant.ts
+++ b/src/i18n/zh-Hant.ts
@@ -27,6 +27,7 @@ export const zhHant: Messages = {
   "format.resets": "重置於",
   "format.resetsIn": "重置剩餘",
   "format.absoluteTime": "{time}",
+  "format.untilTime": "至 {time}",
   "format.in": "輸入",
   "format.cache": "快取",
   "format.out": "輸出",

--- a/src/render/format-reset-time.ts
+++ b/src/render/format-reset-time.ts
@@ -1,4 +1,5 @@
 import type { HourCycleMode, TimeFormatMode } from '../config.js';
+import type { MessageKey } from '../i18n/types.js';
 import { interpolate, t } from '../i18n/index.js';
 
 /** Options controlling how wall-clock time is rendered. */
@@ -78,19 +79,17 @@ export function formatAbsoluteTime(
   resetAt: Date,
   now: Date,
   opts: WallClockOptions = DEFAULT_WALL_CLOCK_OPTIONS,
+  pattern: MessageKey = 'format.absoluteTime',
 ): string {
-  // The preposition + spacing live in each locale's "format.absoluteTime"
-  // pattern (en: "at {time}", zh: "{time}" — bare, preposition baked elsewhere).
   const timeOpts: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit' };
   if (opts.showSeconds) timeOpts.second = '2-digit';
   if (opts.hourCycle !== 'auto') timeOpts.hourCycle = opts.hourCycle;
   const timeStr = resetAt.toLocaleTimeString([], timeOpts);
 
-  // Show the date only when the reset falls on a different calendar day
   if (resetAt.toDateString() === now.toDateString()) {
-    return interpolate(t('format.absoluteTime'), { time: timeStr });
+    return interpolate(t(pattern), { time: timeStr });
   }
 
   const dateStr = resetAt.toLocaleDateString([], { month: 'short', day: 'numeric' });
-  return interpolate(t('format.absoluteTime'), { time: `${dateStr} ${timeStr}` });
+  return interpolate(t(pattern), { time: `${dateStr} ${timeStr}` });
 }

--- a/src/render/lines/prompt-cache.ts
+++ b/src/render/lines/prompt-cache.ts
@@ -65,7 +65,7 @@ export function renderPromptCacheLine(ctx: RenderContext, now: number = Date.now
   };
   const value = state === 'expired'
     ? t('status.expired')
-    : formatAbsoluteTime(expiresAt, new Date(now), wallClockOpts);
+    : formatAbsoluteTime(expiresAt, new Date(now), wallClockOpts, 'format.untilTime');
 
   return `${label(t('label.promptCache'), ctx.config?.colors)} ${colorPromptCacheValue(`⏱ ${value}`, state, ctx)}`;
 }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -61,6 +61,8 @@ interface TranscriptLine {
   // model instead of passing `model` explicitly.
   toolUseResult?: {
     resolvedModel?: unknown;
+    isAsync?: unknown;
+    status?: unknown;
   };
   compactMetadata?: {
     trigger?: string;
@@ -128,7 +130,7 @@ interface TranscriptCacheFile {
   data: SerializedTranscriptData;
 }
 
-const TRANSCRIPT_CACHE_VERSION = 17;
+const TRANSCRIPT_CACHE_VERSION = 18;
 const MCP_TOOL_NAME_PATTERN = /^mcp__(.+?)__(.+)$/;
 const ACTIVITY_NAME_MAX_LEN = 64;
 const MESSAGE_ID_MAX_LEN = 128;
@@ -950,6 +952,12 @@ function processEntry(
         const resolvedModel = sanitizeTranscriptModel(entry.toolUseResult?.resolvedModel);
         if (resolvedModel) {
           agent.model = resolvedModel;
+        }
+        if (
+          entry.toolUseResult?.isAsync === true
+          || entry.toolUseResult?.status === 'async_launched'
+        ) {
+          agent.background = true;
         }
         if (!agent.background) {
           agent.endTime = timestamp;

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -3248,6 +3248,41 @@ function agentLaunchEntries(toolUseId, input, toolUseResult) {
   return entries;
 }
 
+test('parseTranscript treats async_launched Agent results as background', async () => {
+  const result = await parseTempTranscript(
+    'agent-async-launched.jsonl',
+    agentLaunchEntries(
+      'agent-async',
+      { subagent_type: 'claude', description: 'long run', model: 'opus' },
+      { status: 'async_launched', isAsync: true, resolvedModel: 'claude-opus-5[1m]' },
+    ),
+  );
+
+  assert.equal(result.agents.length, 1);
+  assert.equal(result.agents[0]?.status, 'running');
+  assert.equal(result.agents[0]?.background, true);
+  assert.equal(result.agents[0]?.endTime, undefined);
+});
+
+test('parseTranscript completes async-launched agents from the task-notification timestamp', async () => {
+  const result = await parseTempTranscript('agent-async-completed.jsonl', [
+    ...agentLaunchEntries(
+      'agent-async-done',
+      { subagent_type: 'claude', description: 'long run' },
+      { status: 'async_launched', isAsync: true },
+    ),
+    {
+      timestamp: '2026-07-19T11:00:00.000Z',
+      type: 'queue-operation',
+      operation: 'enqueue',
+      content: '<task-id>aa21d445</task-id><tool-use-id>agent-async-done</tool-use-id>',
+    },
+  ]);
+
+  assert.equal(result.agents[0]?.status, 'completed');
+  assert.equal(result.agents[0]?.endTime?.toISOString(), '2026-07-19T11:00:00.000Z');
+});
+
 test('parseTranscript reads the agent model from toolUseResult.resolvedModel', async () => {
   const result = await parseTempTranscript(
     'agent-resolved-model.jsonl',

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -177,6 +177,7 @@ test("t() returns Traditional Chinese strings when language is zh-Hant", () => {
   assert.equal(t("format.cache"), "快取");
   assert.equal(t("format.out"), "輸出");
   assert.equal(t("format.absoluteTime"), "{time}");
+  assert.equal(t("format.untilTime"), "至 {time}");
   assert.equal(t("format.relativeTime"), "{value} 前");
   setLanguage("en");
 });

--- a/tests/prompt-cache.test.js
+++ b/tests/prompt-cache.test.js
@@ -62,7 +62,7 @@ test('renderPromptCacheLine shows the expiry time, not a countdown', () => {
   const expiresAt = now - 60_000 + 300_000;
   assert.equal(
     stripAnsi(renderPromptCacheLine(ctx, now) ?? ''),
-    `Cache ⏱ at ${expectedClock(expiresAt)}`,
+    `Cache ⏱ until ${expectedClock(expiresAt)}`,
   );
 });
 
@@ -77,7 +77,7 @@ test('renderPromptCacheLine holds the same value as the render goes stale', () =
   const later = stripAnsi(renderPromptCacheLine(ctx, anchor + 30 * 60_000) ?? '');
   const last = stripAnsi(renderPromptCacheLine(ctx, anchor + 59 * 60_000) ?? '');
 
-  assert.equal(first, `Cache ⏱ at ${expectedClock(anchor + 3_600_000)}`);
+  assert.equal(first, `Cache ⏱ until ${expectedClock(anchor + 3_600_000)}`);
   assert.equal(later, first);
   assert.equal(last, first);
 });
@@ -93,7 +93,7 @@ test('renderPromptCacheLine prefers the detected TTL over the 5m default', () =>
   ctx.transcript.promptCacheTtlSeconds = 3600;
   assert.equal(
     stripAnsi(renderPromptCacheLine(ctx, now) ?? ''),
-    `Cache ⏱ at ${expectedClock(now - 10 * 60_000 + 3_600_000)}`,
+    `Cache ⏱ until ${expectedClock(now - 10 * 60_000 + 3_600_000)}`,
   );
 });
 
@@ -105,7 +105,7 @@ test('renderPromptCacheLine keeps the configured TTL as a detection fallback', (
 
   assert.equal(
     stripAnsi(renderPromptCacheLine(ctx, now) ?? ''),
-    `Cache ⏱ at ${expectedClock(now - 10 * 60_000 + 3_600_000)}`,
+    `Cache ⏱ until ${expectedClock(now - 10 * 60_000 + 3_600_000)}`,
   );
 
   ctx.transcript.promptCacheTtlSeconds = 300;
@@ -121,7 +121,7 @@ test('renderPromptCacheLine ignores a TTL that is not a real tier', () => {
   // Falls back to 5m rather than counting down against a fabricated tier.
   assert.equal(
     stripAnsi(renderPromptCacheLine(ctx, now) ?? ''),
-    `Cache ⏱ at ${expectedClock(now + 300_000)}`,
+    `Cache ⏱ until ${expectedClock(now + 300_000)}`,
   );
 });
 
@@ -145,7 +145,7 @@ test('renderPromptCacheLine follows hourCycle and showClockSeconds', () => {
 
   assert.equal(
     stripAnsi(renderPromptCacheLine(ctx, now) ?? ''),
-    `Cache ⏱ at ${expectedClock(now + 300_000, { hourCycle: 'h23', showSeconds: true })}`,
+    `Cache ⏱ until ${expectedClock(now + 300_000, { hourCycle: 'h23', showSeconds: true })}`,
   );
 });
 

--- a/tests/readme-options.test.js
+++ b/tests/readme-options.test.js
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function tableOptionKeys(markdown) {
+  return [...markdown.matchAll(/^\| `([A-Za-z][\w.]+)` \|/gm)].map((match) => match[1]);
+}
+
+test('README.zh.md documents every English options-table key', () => {
+  const en = tableOptionKeys(readFileSync(join(root, 'README.md'), 'utf8'));
+  const zh = tableOptionKeys(readFileSync(join(root, 'README.zh.md'), 'utf8'));
+  assert.deepEqual([...new Set(zh)].sort(), [...new Set(en)].sort());
+});
+
+test('README.zh.md states that externalUsagePath must be absolute', () => {
+  const zh = readFileSync(join(root, 'README.zh.md'), 'utf8');
+  const row = zh.split('\n').find((line) => line.includes('`display.externalUsagePath`'));
+  assert.ok(row, 'expected an externalUsagePath row');
+  assert.match(row, /绝对路径/);
+});

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -40,7 +40,7 @@ function stripAnsi(str) {
  */
 function expectedCacheExpiry(anchorAt, ttlSeconds) {
   const expiresAt = new Date(anchorAt.getTime() + ttlSeconds * 1000);
-  return `Cache ⏱ at ${expiresAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+  return `Cache ⏱ until ${expiresAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
 }
 
 function baseContext() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Four open reports are real bugs or docs gaps. They do not change the default HUD.

## Scope

- `src/transcript.ts` treats Agent `tool_result` payloads with `isAsync` or `status: async_launched` as background. Completion still comes from the task-notification queue-operation. Closes #734.
- `src/git.ts` passes `--no-optional-locks` on `git diff --numstat`, matching the porcelain status call. Closes #726.
- The prompt-cache clock uses `format.untilTime` (`until 12:16 PM` in English, `至` in Chinese). `format.absoluteTime` stays `at {time}` for usage resets. Closes #727.
- `README.zh.md` gains the ten missing options and the absolute-path caveat on `display.externalUsagePath`. `tests/readme-options.test.js` fails if the tables drift. Closes #730.
- No `dist/` changes.

## Tradeoffs

The cache wording change is visible to anyone who already enabled `showPromptCache`. That is the point of #727.

## Blast Radius

Default layout is unchanged. Git users on Windows stop getting a stale `index.lock` from the statusline. Async Agent-tool subagents stay on the agents line until they finish.

## Verification

- `npm run build`
- New and related tests passed: async Agent launch and completion, prompt-cache `until`, README option-key sync, dirty-repo numstat, i18n key parity.
- The four failures on `countConfigs` nested-rules cache and git `branchUrl` also fail on current `main` in this environment. They are not from this diff.

Closes #734.
Closes #726.
Closes #727.
Closes #730.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b4b6d6d-145c-47c4-8045-249a200622a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b4b6d6d-145c-47c4-8045-249a200622a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

