### PR TITLE
docs(contributing): write down the HUD scope bar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,20 @@
 
 Thanks for contributing to Claude HUD. This repo is small and fast-moving, so we optimize for clarity and quick review.
 
+## Scope
+
+The default HUD stays a two-line local statusline. New display stays opt-in unless it fixes a wrong default. Do not add onboarding steps.
+
+We will not take:
+
+- `extra-cmd` in `config.json`, or raw multiline extra-cmd output. The command stays on argv behind `CLAUDE_HUD_ALLOW_EXTRA_CMD`.
+- Per-window `timeFormat` knobs. Use `display.timeFormat`.
+- Per-metric color slots beyond the existing `colors.*` keys.
+- Timer-based fade for Skills or MCP. Use `showTools`, `showSkills`, and `showMcp`.
+- A hardcoded catalog of Anthropic-compatible proxies. Use `display.providerName`.
+- OS disk or other system gauges. Use `extra-cmd`.
+- A HUD-side guess for advisor or multi-iteration context double-count, or for local models that omit `context_window`. Those need a same-invocation stdin fixture from Claude Code.
+
 ## How to Contribute
 
 1) Fork and clone the repo


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Six remaining issues ask for more knobs, a command in config, or a HUD-side guess we cannot make safely. The token on this agent cannot comment on or close issues directly. Recording the bar in `CONTRIBUTING.md` is the honest close, and it stops the next review from re-arguing the same requests.

## Scope

Adds a Scope section to `CONTRIBUTING.md`. No `src/` changes. No `dist/` changes. Default HUD is unchanged.

## Tradeoffs

A short deny-list in CONTRIBUTING is better than six silent closes. Users who want those features still have `extra-cmd`, `display.providerName`, `display.timeFormat`, and `colors.*`.

## Blast Radius

Contributors only. Install and onboarding do not change.

## Verification

Read `CONTRIBUTING.md`. The new section names each declined request in one line.

Closes #733.
Closes #725.
Closes #689.
Closes #688.
Closes #675.
Closes #666.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b4b6d6d-145c-47c4-8045-249a200622a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b4b6d6d-145c-47c4-8045-249a200622a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

