### PR TITLE
feat: add display.skillsMaxVisible to cap the skills line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Claude HUD will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `display.skillsMaxVisible` option to control how many skill names the skills line shows before `+N more`; `0` means unlimited, default stays 4.
 - `display.showDailyCost` option to show today's cumulative spend across sessions (`Today $12.34`), accumulated from the native stdin `cost.total_cost_usd` into a per-day ledger that resets at local midnight (#695).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Claude HUD will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- `display.skillsMaxVisible` option to control how many skill names the skills line shows before `+N more`; `0` means unlimited, default stays 4.
+- `display.skillsMaxVisible` option to control how many skill names the skills line shows before `+N more`; `0` means unlimited, default stays 4 (#739).
 - `display.showDailyCost` option to show today's cumulative spend across sessions (`Today $12.34`), accumulated from the native stdin `cost.total_cost_usd` into a per-day ledger that resets at local midnight (#695).
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 | `display.showMcp` | boolean | false | Show active MCP servers detected from `mcp__server__tool` invocations |
 | `display.toolNameMaxLength` | number | `0` | Maximum displayed tool-name length. `0` keeps full names; MCP names may shorten to their final segment when truncating |
 | `display.toolsMaxVisible` | number | `4` | Maximum completed tools shown on the tools line. `0` means unlimited |
+| `display.skillsMaxVisible` | number | `4` | Maximum skill names shown on the skills line before `+N more`. `0` means unlimited |
 | `display.showAgents` | boolean | false | Show agents activity line |
 | `display.showTodos` | boolean | false | Show todos progress line |
 | `display.showSessionName` | boolean | false | Show session slug or custom title from `/rename` |

--- a/README.zh.md
+++ b/README.zh.md
@@ -215,6 +215,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `display.showMcp` | boolean | false | 显示从 `mcp__server__tool` 调用检测到的活动 MCP 服务器 |
 | `display.toolNameMaxLength` | number | `0` | 工具名称最大显示长度。`0` 保留完整名称；截断 MCP 名称时可能缩短为最后一段 |
 | `display.toolsMaxVisible` | number | `4` | 工具行最多显示的已完成工具数。`0` 表示不限制 |
+| `display.skillsMaxVisible` | number | `4` | Skills 行在 `+N more` 之前最多显示的 Skill 名称数。`0` 表示不限制 |
 | `display.showAgents` | boolean | false | 显示 Agent 活动行 |
 | `display.showTodos` | boolean | false | 显示待办进度行 |
 | `display.showSessionName` | boolean | false | 显示会话 slug 或 `/rename` 设置的自定义标题 |

--- a/src/config.ts
+++ b/src/config.ts
@@ -219,6 +219,7 @@ export interface HudConfig {
     showMcp: boolean;
     toolNameMaxLength: number;
     toolsMaxVisible: number;
+    skillsMaxVisible: number;
     showAgents: boolean;
     showTodos: boolean;
     showSessionName: boolean;
@@ -342,6 +343,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showMcp: false,
     toolNameMaxLength: 0,
     toolsMaxVisible: 4,
+    skillsMaxVisible: 4,
     showAgents: false,
     showTodos: false,
     showSessionName: false,
@@ -853,6 +855,10 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     toolsMaxVisible: validateNonNegativeInteger(
       migrated.display?.toolsMaxVisible,
       DEFAULT_CONFIG.display.toolsMaxVisible,
+    ),
+    skillsMaxVisible: validateNonNegativeInteger(
+      migrated.display?.skillsMaxVisible,
+      DEFAULT_CONFIG.display.skillsMaxVisible,
     ),
     showAgents: typeof migrated.display?.showAgents === 'boolean'
       ? migrated.display.showAgents

--- a/src/render/skills-mcp-line.ts
+++ b/src/render/skills-mcp-line.ts
@@ -11,7 +11,12 @@ export function renderSkillsLine(ctx: RenderContext): string | null {
     return null;
   }
 
-  return renderNameListLine('Skills', ctx.transcript.skills ?? [], ctx.config?.colors);
+  return renderNameListLine(
+    'Skills',
+    ctx.transcript.skills ?? [],
+    ctx.config?.colors,
+    ctx.config?.display?.skillsMaxVisible ?? MAX_ITEMS_SHOWN,
+  );
 }
 
 export function renderMcpLine(ctx: RenderContext): string | null {
@@ -26,13 +31,15 @@ function renderNameListLine(
   title: string,
   names: string[],
   colors?: Partial<HudColorOverrides>,
+  maxVisible: number = MAX_ITEMS_SHOWN,
 ): string | null {
   const safeNames = names.map(safeActivityName).filter((name): name is string => Boolean(name));
   if (safeNames.length === 0) {
     return null;
   }
 
-  const visibleNames = safeNames.slice(0, MAX_ITEMS_SHOWN).map(name => cyan(name));
+  const shown = maxVisible === 0 ? safeNames : safeNames.slice(0, maxVisible);
+  const visibleNames = shown.map(name => cyan(name));
   const hiddenCount = safeNames.length - visibleNames.length;
   if (hiddenCount > 0) {
     visibleNames.push(label(`+${hiddenCount} more`, colors));

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1862,7 +1862,7 @@ test('renderToolsLine preserves running targets and path truncation with shorten
   assert.ok(line.includes('.../authentication.ts'));
 });
 
-test('mergeConfig validates tool display counts as non-negative integers', () => {
+test('mergeConfig validates display counts as non-negative integers', () => {
   assert.equal(mergeConfig({ display: { toolNameMaxLength: 12 } }).display.toolNameMaxLength, 12);
   assert.equal(mergeConfig({ display: { toolsMaxVisible: 0 } }).display.toolsMaxVisible, 0);
   assert.equal(mergeConfig({ display: { toolsMaxVisible: 2 } }).display.toolsMaxVisible, 2);
@@ -2334,14 +2334,24 @@ test('renderSkillsLine shows every skill when skillsMaxVisible is unlimited', ()
   assert.ok(!line.includes('more'));
 });
 
-test('renderSkillsLine keeps the default cap of 4 when skillsMaxVisible is unset', () => {
+test('renderSkillsLine keeps the default cap of 4 when the context omits skillsMaxVisible', () => {
   const ctx = baseContext();
   ctx.config.display.showSkills = true;
-  delete ctx.config.display.skillsMaxVisible;
+  assert.equal(ctx.config.display.skillsMaxVisible, undefined);
   ctx.transcript.skills = ['a', 'b', 'c', 'd', 'e'];
 
   const line = stripAnsi(renderSkillsLine(ctx) ?? '');
   assert.equal(line, '✓ Skills (5): a, b, c, d, +1 more');
+});
+
+test('renderMcpLine keeps its cap of 4 and ignores skillsMaxVisible', () => {
+  const ctx = baseContext();
+  ctx.config.display.showMcp = true;
+  ctx.config.display.skillsMaxVisible = 0;
+  ctx.transcript.mcpServers = ['a', 'b', 'c', 'd', 'e'];
+
+  const line = stripAnsi(renderMcpLine(ctx) ?? '');
+  assert.equal(line, '✓ MCPs (5): a, b, c, d, +1 more');
 });
 
 test('renderSkillsLine and renderMcpLine sanitize direct transcript names before display', () => {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1866,10 +1866,13 @@ test('mergeConfig validates tool display counts as non-negative integers', () =>
   assert.equal(mergeConfig({ display: { toolNameMaxLength: 12 } }).display.toolNameMaxLength, 12);
   assert.equal(mergeConfig({ display: { toolsMaxVisible: 0 } }).display.toolsMaxVisible, 0);
   assert.equal(mergeConfig({ display: { toolsMaxVisible: 2 } }).display.toolsMaxVisible, 2);
+  assert.equal(mergeConfig({ display: { skillsMaxVisible: 0 } }).display.skillsMaxVisible, 0);
+  assert.equal(mergeConfig({ display: { skillsMaxVisible: 7 } }).display.skillsMaxVisible, 7);
 
   for (const value of [-1, 'abc', null, 1.5]) {
     assert.equal(mergeConfig({ display: { toolNameMaxLength: value } }).display.toolNameMaxLength, 0);
     assert.equal(mergeConfig({ display: { toolsMaxVisible: value } }).display.toolsMaxVisible, 4);
+    assert.equal(mergeConfig({ display: { skillsMaxVisible: value } }).display.skillsMaxVisible, 4);
   }
 });
 
@@ -2308,6 +2311,37 @@ test('renderSkillsLine and renderMcpLine show counts and names when enabled', ()
 
   assert.equal(skillsLine, '✓ Skills (1): frontend-design');
   assert.equal(mcpLine, '✓ MCPs (2): linear, slack');
+});
+
+test('renderSkillsLine respects skillsMaxVisible and preserves overflow indicator', () => {
+  const ctx = baseContext();
+  ctx.config.display.showSkills = true;
+  ctx.config.display.skillsMaxVisible = 2;
+  ctx.transcript.skills = ['a', 'b', 'c', 'd', 'e'];
+
+  const line = stripAnsi(renderSkillsLine(ctx) ?? '');
+  assert.equal(line, '✓ Skills (5): a, b, +3 more');
+});
+
+test('renderSkillsLine shows every skill when skillsMaxVisible is unlimited', () => {
+  const ctx = baseContext();
+  ctx.config.display.showSkills = true;
+  ctx.config.display.skillsMaxVisible = 0;
+  ctx.transcript.skills = ['a', 'b', 'c', 'd', 'e'];
+
+  const line = stripAnsi(renderSkillsLine(ctx) ?? '');
+  assert.equal(line, '✓ Skills (5): a, b, c, d, e');
+  assert.ok(!line.includes('more'));
+});
+
+test('renderSkillsLine keeps the default cap of 4 when skillsMaxVisible is unset', () => {
+  const ctx = baseContext();
+  ctx.config.display.showSkills = true;
+  delete ctx.config.display.skillsMaxVisible;
+  ctx.transcript.skills = ['a', 'b', 'c', 'd', 'e'];
+
+  const line = stripAnsi(renderSkillsLine(ctx) ?? '');
+  assert.equal(line, '✓ Skills (5): a, b, c, d, +1 more');
 });
 
 test('renderSkillsLine and renderMcpLine sanitize direct transcript names before display', () => {


### PR DESCRIPTION
## Problem

The skills line hardcodes a 4-name cap (`MAX_ITEMS_SHOWN` in `src/render/skills-mcp-line.ts`). A session that has used five skills always renders `+1 more`, and there is no config option to raise the cap, unlike the tools line, which has `display.toolsMaxVisible`.

## Fix

Add `display.skillsMaxVisible`, mirroring `display.toolsMaxVisible`:

- same validation (`validateNonNegativeInteger`; invalid values fall back to the default)
- same semantics: `0` means unlimited
- default stays `4`, so existing output is unchanged for everyone who does not set it
- the MCP line is left as is

`src/` only; `dist/` untouched per CONTRIBUTING.

## Tests

- `renderSkillsLine respects skillsMaxVisible and preserves overflow indicator` (cap 2 over 5 skills → `a, b, +3 more`)
- `renderSkillsLine shows every skill when skillsMaxVisible is unlimited`
- `renderSkillsLine keeps the default cap of 4 when skillsMaxVisible is unset`
- `mergeConfig validates tool display counts as non-negative integers` extended to the new key

Mutation-checked: making the renderer ignore the setting fails the first two. Full suite: 1114 pass, 0 fail (run with a clean `HOME`; with a personal `claude-hud/config.json` that customises `elementOrder`, the pre-existing `loadConfig returns valid config structure` test fails on `main` too, unrelated to this change).

## Docs

Rows added to `README.md` and `README.zh.md` (keeps `readme-options.test.js` green) and a line under `[Unreleased] / Added` in `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)