### PR TITLE
feat: add opt-in cache hit rate display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Claude HUD will be documented in this file.
 
 ### Added
 - `display.showDailyCost` option to show today's cumulative spend across sessions (`Today $12.34`), accumulated from the native stdin `cost.total_cost_usd` into a per-day ledger that resets at local midnight (#695).
+- `display.showCacheHitRate` option to show the session-wide prompt-cache hit rate as `Cache hit X%`, computed from the cumulative transcript `cacheReadTokens` / (`inputTokens` + `cacheReadTokens` + `cacheCreationTokens`). Opt-in (default off), hidden when there is no input activity.
 
 ### Fixed
 - Refresh the prompt-cache clock when a request starts rather than when its response arrives, ignoring client-side slash command records, interrupt markers, and subagent requests (#719).

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 | `display.showMemoryUsage` | boolean | false | Show an approximate system RAM usage line in expanded layout |
 | `display.showPromptCache` | boolean | false | Show the wall-clock time the session's prompt cache expires, read from the transcript |
 | `display.promptCacheTtlSeconds` | number | `300` | Compatibility fallback used only when the transcript has not reported a 5-minute or 1-hour cache tier |
+| `display.showCacheHitRate` | boolean | false | Show the session-wide prompt-cache hit rate as `Cache hit X%`, computed from cumulative transcript totals |
 | `colors.context` | color value | `green` | Base color for the context bar and context percentage |
 | `colors.usage` | color value | `brightBlue` | Base color for usage bars and percentages below warning thresholds |
 | `colors.warning` | color value | `yellow` | Warning color for context thresholds and usage warning text |
@@ -278,6 +279,14 @@ Official MiniMax Anthropic-compatible endpoints receive a `MiniMax` provider lab
 It shows an expiry time rather than a countdown because the statusline only repaints while Claude Code is active. Between turns — exactly when the cache is draining — a countdown freezes at whatever it last displayed and keeps reporting it; a clock time stays true no matter how stale the render is.
 
 ClaudeHUD detects the cache tier from the transcript when possible. The existing `display.promptCacheTtlSeconds` setting remains a fallback for older or proxied transcripts that do not expose tier details:
+
+`display.showCacheHitRate` is also opt-in. When enabled, ClaudeHUD shows the **session-wide cache hit rate** as `Cache hit X%` (e.g. `Cache hit 98.3%`), computed from the cumulative transcript totals:
+
+```
+hit_rate = cacheReadTokens / (inputTokens + cacheReadTokens + cacheCreationTokens)
+```
+
+`inputTokens` (non-cached input) is included in the denominator so the rate stays in `[0%, 100%]` even when the cache was pre-warmed in a prior transcript window — without it, a session whose `cacheCreationTokens` is zero would collapse to 100% and become uninformative. Absolute counts are visible in the existing `Tokens` line; this setting only adds the percentage.
 
 - **The TTL is detected.** Every cache write records the tier it used (`usage.cache_creation.ephemeral_5m_input_tokens` vs `ephemeral_1h_input_tokens`), so a 1-hour session counts down against an hour, and a session that changes tier mid-run is followed. Detected values take precedence over the configured fallback.
 - **The clock starts at the request**, not at the response it produced, because that is when the cache is read or written. Anchoring on the response would hand the session however long that response took to generate.

--- a/README.zh.md
+++ b/README.zh.md
@@ -232,6 +232,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `display.showMemoryUsage` | boolean | false | 在展开布局中显示近似系统 RAM 使用行 |
 | `display.showPromptCache` | boolean | false | 显示 prompt cache 的过期时刻，数据来自 transcript |
 | `display.promptCacheTtlSeconds` | number | `300` | 仅当 transcript 尚未报告 5 分钟或 1 小时缓存层级时使用的兼容回退值 |
+| `display.showCacheHitRate` | boolean | false | 以 `Cache hit X%` 形式显示整个会话的 prompt cache 命中率，数据来自 transcript 累积值 |
 | `colors.context` | 颜色值 | `green` | 上下文进度条和百分比的基础颜色 |
 | `colors.usage` | 颜色值 | `brightBlue` | 使用率进度条和低于警告阈值时百分比的颜色 |
 | `colors.warning` | 颜色值 | `yellow` | 上下文阈值和使用率警告文本的警告颜色 |
@@ -259,6 +260,14 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 `display.showPromptCache` 为完全 opt-in 选项。启用后，ClaudeHUD 会显示 **prompt cache 的过期时刻**（例如 `Cache ⏱ until 14:30`），过期后显示 `expired`。它与 HUD 中其他时刻一样遵循 `display.hourCycle` 和 `display.showClockSeconds`。如果 transcript 里还没有主会话响应，这个元素会继续隐藏。
 
 它显示过期时刻而不是倒计时，因为状态栏只在 Claude Code 活动时重绘。在两个回合之间——正好是缓存流失的时候——倒计时会停在最后一次显示的数值上并继续报告它；而时刻无论渲染多陈旧都仍然正确。
+
+`display.showCacheHitRate` 也是 opt-in。启用后，ClaudeHUD 会以 `Cache hit X%`（例如 `Cache hit 98.3%`）显示**整个会话的 cache 命中率**，由 transcript 累积值计算：
+
+```
+hit_rate = cacheReadTokens / (inputTokens + cacheReadTokens + cacheCreationTokens)
+```
+
+把 `inputTokens`（非缓存输入）计入分母，是为了即使缓存已经在前一个 transcript 窗口中预热、命中率也能保持在 `[0%, 100%]` 区间内——否则 `cacheCreationTokens` 为 0 的会话会塌缩到 100%，没有信息量。绝对数字已显示在 `Tokens` 行中；此选项只新增百分比。
 
 ClaudeHUD 会尽可能从 transcript 检测缓存层级。对于不提供层级详情的旧版或代理 transcript，现有的 `display.promptCacheTtlSeconds` 设置仍作为回退值：
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,7 @@ export type HudElement =
   | 'context'
   | 'usage'
   | 'promptCache'
+  | 'cacheHitRate'
   | 'memory'
   | 'environment'
   | 'tools'
@@ -131,6 +132,7 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'context',
   'usage',
   'promptCache',
+  'cacheHitRate',
   'memory',
   'environment',
   'tools',
@@ -238,6 +240,11 @@ export interface HudConfig {
     // Compatibility fallback used only until transcript tier detection has a
     // real 5-minute or 1-hour cache write to follow.
     promptCacheTtlSeconds: number;
+    // Show the session-wide cache hit rate as `Cache hit X%`, computed from
+    // the cumulative transcript `cacheReadTokens` / (`inputTokens` +
+    // `cacheReadTokens` + `cacheCreationTokens`). Hidden when there is no
+    // input activity. Default off.
+    showCacheHitRate: boolean;
     showSessionTokens: boolean;
     showOutputStyle: boolean;
     showSessionStartDate: boolean;
@@ -354,6 +361,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     showMemoryUsage: false,
     showPromptCache: false,
     promptCacheTtlSeconds: 300,
+    showCacheHitRate: false,
     showSessionTokens: false,
     showOutputStyle: false,
     showSessionStartDate: false,
@@ -892,6 +900,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
       migrated.display?.promptCacheTtlSeconds,
       DEFAULT_CONFIG.display.promptCacheTtlSeconds,
     ),
+    showCacheHitRate: typeof migrated.display?.showCacheHitRate === 'boolean'
+      ? migrated.display.showCacheHitRate
+      : DEFAULT_CONFIG.display.showCacheHitRate,
     showSessionTokens: typeof migrated.display?.showSessionTokens === 'boolean'
       ? migrated.display.showSessionTokens
       : DEFAULT_CONFIG.display.showSessionTokens,

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -7,6 +7,7 @@ export const en: Messages = {
   "label.weekly": "Weekly",
   "label.approxRam": "Approx RAM",
   "label.promptCache": "Cache",
+  "label.cacheHitRate": "Cache hit",
   "label.rules": "rules",
   "label.hooks": "hooks",
   "label.estimatedCost": "Est.",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -5,6 +5,7 @@ export type MessageKey =
   | "label.weekly"
   | "label.approxRam"
   | "label.promptCache"
+  | "label.cacheHitRate"
   | "label.rules"
   | "label.hooks"
   | "label.estimatedCost"

--- a/src/i18n/zh-Hans.ts
+++ b/src/i18n/zh-Hans.ts
@@ -7,6 +7,7 @@ export const zhHans: Messages = {
   "label.weekly": "本周",
   "label.approxRam": "内存",
   "label.promptCache": "缓存",
+  "label.cacheHitRate": "缓存命中",
   "label.rules": "规则",
   "label.hooks": "钩子",
   "label.estimatedCost": "估算",

--- a/src/i18n/zh-Hant.ts
+++ b/src/i18n/zh-Hant.ts
@@ -7,6 +7,7 @@ export const zhHant: Messages = {
   "label.weekly": "本週",
   "label.approxRam": "記憶體",
   "label.promptCache": "快取",
+  "label.cacheHitRate": "快取命中",
   "label.rules": "規則",
   "label.hooks": "Hook",
   "label.estimatedCost": "估算",

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -13,6 +13,7 @@ import {
   renderGitFilesLine,
   renderEnvironmentLine,
   renderPromptCacheLine,
+  renderCacheHitRateLine,
   renderUsageLine,
   renderMemoryLine,
   renderSessionTokensLine,
@@ -442,6 +443,8 @@ function renderElementLine(
       return renderUsageLine(ctx, labelOptions);
     case 'promptCache':
       return renderPromptCacheLine(ctx);
+    case 'cacheHitRate':
+      return renderCacheHitRateLine(ctx);
     case 'memory':
       return renderMemoryLine(ctx, labelOptions);
     case 'environment':

--- a/src/render/lines/cache-hit-rate.ts
+++ b/src/render/lines/cache-hit-rate.ts
@@ -1,0 +1,45 @@
+import type { RenderContext } from '../../types.js';
+import { label } from '../colors.js';
+import { t } from '../../i18n/index.js';
+
+/**
+ * Session-wide prompt-cache hit rate:
+ *
+ *   hit_rate = cacheRead / (input + cacheRead + cacheCreation)
+ *
+ * `cacheRead` / `cacheCreation` are cumulative from the already-deduped
+ * `TranscriptData.sessionTokens` totals (`src/transcript.ts`). `input` is the
+ * cumulative non-cached input — including it in the denominator means the rate
+ * reflects "what fraction of the server-processed input came from cache",
+ * which is bounded in [0%, 100%] and stable turn-over-turn.
+ *
+ * Only the percentage is rendered; absolute counts are visible in the
+ * `Tokens` line. Hidden when the user has not opted in via
+ * `display.showCacheHitRate`, when no transcript has been parsed yet, or
+ * when the session has no input activity at all.
+ */
+export function renderCacheHitRateLine(ctx: RenderContext): string | null {
+  const display = ctx.config?.display;
+  if (display?.showCacheHitRate !== true) {
+    return null;
+  }
+
+  const tokens = ctx.transcript.sessionTokens;
+  if (!tokens) {
+    return null;
+  }
+
+  // Clamp to zero: transcript accumulation floors deltas at zero (see
+  // `accumulateMessageUsage` in `src/transcript.ts`), but defensive guarding
+  // here keeps a malformed transcript from rendering a negative percent.
+  const read = Math.max(0, tokens.cacheReadTokens);
+  const created = Math.max(0, tokens.cacheCreationTokens);
+  const input = Math.max(0, tokens.inputTokens);
+  const total = input + read + created;
+  if (total === 0) {
+    return null;
+  }
+
+  const hitRate = (read / total) * 100;
+  return `${label(t('label.cacheHitRate'), ctx.config?.colors)} ${hitRate.toFixed(1)}%`;
+}

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -3,6 +3,7 @@ export { renderProjectLine, renderGitFilesLine } from './project.js';
 export { renderAddedDirsLine } from './added-dirs.js';
 export { renderEnvironmentLine } from './environment.js';
 export { renderPromptCacheLine } from './prompt-cache.js';
+export { renderCacheHitRateLine } from './cache-hit-rate.js';
 export { renderUsageLine } from './usage.js';
 export { renderMemoryLine } from './memory.js';
 export { renderSessionTokensLine } from './session-tokens.js';

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -6,6 +6,7 @@ import { coloredBar, critical, git as gitColor, gitBranch as gitBranchColor, lab
 import { getAdaptiveBarWidth } from '../utils/terminal.js';
 import { renderCostEstimate } from './lines/cost.js';
 import { renderPromptCacheLine } from './lines/prompt-cache.js';
+import { renderCacheHitRateLine } from './lines/cache-hit-rate.js';
 import { renderSessionTimeLine } from './lines/session-time.js';
 import { renderAdvisorLine } from './lines/advisor.js';
 import { t } from '../i18n/index.js';
@@ -365,6 +366,11 @@ export function renderSessionLine(ctx: RenderContext): string {
   const promptCacheLine = renderPromptCacheLine(ctx);
   if (promptCacheLine) {
     push(promptCacheLine);
+  }
+
+  const cacheHitRateLine = renderCacheHitRateLine(ctx);
+  if (cacheHitRateLine) {
+    push(cacheHitRateLine);
   }
 
   const costEstimate = renderCostEstimate(ctx);

--- a/tests/cache-hit-rate.test.js
+++ b/tests/cache-hit-rate.test.js
@@ -1,0 +1,140 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderCacheHitRateLine } from '../dist/render/lines/cache-hit-rate.js';
+import { setLanguage } from '../dist/i18n/index.js';
+
+function stripAnsi(str) {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+function baseContext() {
+  return {
+    stdin: {},
+    transcript: {
+      tools: [],
+      agents: [],
+      todos: [],
+      sessionTokens: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+      },
+    },
+    claudeMdCount: 0,
+    rulesCount: 0,
+    mcpCount: 0,
+    hooksCount: 0,
+    sessionDuration: '',
+    gitStatus: null,
+    usageData: null,
+    memoryUsage: null,
+    config: {
+      display: {
+        showCacheHitRate: true,
+      },
+      colors: {},
+    },
+    extraLabel: null,
+  };
+}
+
+test('renderCacheHitRateLine is hidden when not enabled', () => {
+  const ctx = baseContext();
+  ctx.config.display.showCacheHitRate = false;
+  ctx.transcript.sessionTokens = { inputTokens: 200, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 50_000 };
+  assert.equal(renderCacheHitRateLine(ctx), null);
+});
+
+test('renderCacheHitRateLine is hidden when sessionTokens is undefined', () => {
+  const ctx = baseContext();
+  ctx.transcript.sessionTokens = undefined;
+  assert.equal(renderCacheHitRateLine(ctx), null);
+});
+
+test('renderCacheHitRateLine is hidden when the session has no input activity', () => {
+  const ctx = baseContext();
+  ctx.transcript.sessionTokens = { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 };
+  assert.equal(renderCacheHitRateLine(ctx), null);
+});
+
+test('renderCacheHitRateLine uses input_tokens in the denominator', () => {
+  // This is the regression that motivated the rewrite: the original formula
+  // was `read / (read + created)`, so any session whose cache was pre-warmed
+  // in a prior transcript window collapsed to 100%. Including inputTokens
+  // (non-cached input) in the denominator keeps the rate bounded.
+  const ctx = baseContext();
+  ctx.transcript.sessionTokens = {
+    inputTokens: 375_000,
+    outputTokens: 38_000,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 15_800_000,
+  };
+  // 15.8M / (375k + 15.8M) = 97.7%
+  assert.equal(
+    stripAnsi(renderCacheHitRateLine(ctx) ?? ''),
+    'Cache hit 97.7%',
+  );
+});
+
+test('renderCacheHitRateLine reflects cache writes in the denominator', () => {
+  // When this session wrote new cache, the hit rate reflects that work in
+  // the denominator — the user can correlate against the Tokens line.
+  const ctx = baseContext();
+  ctx.transcript.sessionTokens = {
+    inputTokens: 100,
+    outputTokens: 0,
+    cacheCreationTokens: 50_000,
+    cacheReadTokens: 50_000,
+  };
+  // 50k / (100 + 50k + 50k) = 50%
+  assert.equal(
+    stripAnsi(renderCacheHitRateLine(ctx) ?? ''),
+    'Cache hit 50.0%',
+  );
+});
+
+test('renderCacheHitRateLine reports 100% when all input came from cache', () => {
+  // The only legitimate 100%: this session sent no non-cached input and
+  // wrote no new cache — every input token was a cache hit.
+  const ctx = baseContext();
+  ctx.transcript.sessionTokens = { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 50_000 };
+  assert.equal(
+    stripAnsi(renderCacheHitRateLine(ctx) ?? ''),
+    'Cache hit 100.0%',
+  );
+});
+
+test('renderCacheHitRateLine reports 0% when no cache activity', () => {
+  const ctx = baseContext();
+  ctx.transcript.sessionTokens = { inputTokens: 10_000, outputTokens: 5_000, cacheCreationTokens: 0, cacheReadTokens: 0 };
+  assert.equal(
+    stripAnsi(renderCacheHitRateLine(ctx) ?? ''),
+    'Cache hit 0.0%',
+  );
+});
+
+test('renderCacheHitRateLine clamps negative transcript values to zero', () => {
+  // Defensive: malformed transcripts should not render a negative percent.
+  const ctx = baseContext();
+  ctx.transcript.sessionTokens = { inputTokens: 0, outputTokens: 0, cacheCreationTokens: -10, cacheReadTokens: 50 };
+  assert.equal(
+    stripAnsi(renderCacheHitRateLine(ctx) ?? ''),
+    'Cache hit 100.0%',
+  );
+});
+
+test('renderCacheHitRateLine localizes the label to Simplified Chinese', () => {
+  const ctx = baseContext();
+  ctx.transcript.sessionTokens = { inputTokens: 200, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 50_000 };
+  setLanguage('zh');
+  try {
+    assert.equal(
+      stripAnsi(renderCacheHitRateLine(ctx) ?? ''),
+      '缓存命中 99.6%',
+    );
+  } finally {
+    setLanguage('en');
+  }
+});

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -186,6 +186,22 @@ test('mergeConfig preserves explicit showPromptCache=true', () => {
   assert.equal(config.display.showPromptCache, true);
 });
 
+test('mergeConfig defaults showCacheHitRate to false', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.showCacheHitRate, false);
+  assert.equal(DEFAULT_CONFIG.display.showCacheHitRate, false);
+});
+
+test('mergeConfig preserves explicit showCacheHitRate=true', () => {
+  const config = mergeConfig({ display: { showCacheHitRate: true } });
+  assert.equal(config.display.showCacheHitRate, true);
+});
+
+test('mergeConfig rejects non-boolean showCacheHitRate', () => {
+  const config = mergeConfig({ display: { showCacheHitRate: 'yes' } });
+  assert.equal(config.display.showCacheHitRate, false);
+});
+
 test('mergeConfig preserves promptCacheTtlSeconds as a validated fallback', () => {
   assert.equal(DEFAULT_CONFIG.display.promptCacheTtlSeconds, 300);
   const config = mergeConfig({ display: { promptCacheTtlSeconds: 3600 } });


### PR DESCRIPTION
## Add `display.showCacheHitRate` opt-in session-wide cache hit rate

### Summary

Adds a new opt-in display element that shows the session-wide prompt-cache hit rate as `Cache hit X%` (e.g. `Cache hit 98.3%`). It is the follow-up to the previously-closed PRs #458 and #568, scoped to a single element with no other behavior changes.

### Formula

```
hit_rate = cacheReadTokens / (inputTokens + cacheReadTokens + cacheCreationTokens)
```

All three fields are cumulative `TranscriptData.sessionTokens` totals, already accumulated and de-duplicated by `accumulateMessageUsage` in `src/transcript.ts`.

`inputTokens` (non-cached input) is **required** in the denominator — without it, any session whose cache was pre-warmed in a prior transcript window would collapse to 100% and become uninformative. This is the regression the dedicated test case at `tests/cache-hit-rate.test.js:62-79` exists to guard against.

### Differences from prior closed PRs

This is a follow-up to #458 and #568. The maintainer's stated reasons for closing those are all addressed:

| Concern (from #458 / #568 closing comments) | This PR |
|---|---|
| Default-on display (#458) | `showCacheHitRate` defaults to `false` in `DEFAULT_CONFIG.display` |
| Includes `dist/` artifacts (#458) | `git diff --stat` shows only `src/` + `tests/` files |
| Outdated terminal-width fallback (#458) | No changes to `src/utils/terminal.ts` or any width handling |
| Missing tests (#458) | 9 cases in `tests/cache-hit-rate.test.js` + 3 new `mergeConfig` cases in `tests/config.test.js` |
| Removes existing config fields (#568) | Diff is purely additive; no field renamed, removed, or repurposed |
| Changes usage/cache behavior too broadly (#568) | No changes to `src/transcript.ts`, `src/stdin.ts`, `src/render/lines/usage.ts`, or `src/render/lines/session-tokens.ts` |
| Regresses OSC 8 truncation / transcript-cache permission (#568) | Only edits to `src/render/index.ts` are the import (line 16) and a one-line `case 'cacheHitRate':` returning the rendered string (lines 446-447). No edits to `closeOpenHyperlink`, `truncateToWidth`, `splitLineBySeparators`, or anything else. |
| New color slots beyond `colors.*` (#738 scope bar) | Uses existing `label()` helper, which reads `colors.label`. No new `colors.*` keys. |

### Why cumulative `sessionTokens` instead of per-turn stdin

PR #568 used `ctx.stdin.context_window.current_usage` (per-turn). This PR uses `ctx.transcript.sessionTokens` (cumulative) for two reasons:

1. **It avoids the bug PR #568 was patching.** PR #568's diff also included a `transcript.ts` change (`entry.usage ?? entry.message?.usage`) to fix a usage-read regression. Cumulative `sessionTokens` is already populated correctly via `accumulateMessageUsage`, so no transcript read-path change is needed.
2. **It produces a stable percentage.** Per-turn hit rate bounces turn-over-turn depending on how much new content each turn adds. Cumulative rate trends monotonically and is easier to read at a glance.

The trade-off is documented in the renderer's doc comment.

### What stays untouched

- No changes to `showTokenBreakdown`, the existing prompt-cache clock line, or `Tokens` aggregation
- No new color slots, threshold knobs, or onboarding steps
- No package version bump (per `CONTRIBUTING.md`, the maintainer does that during release)

### Testing

- `npm ci && npm run build && npm test` — all new tests pass; the pre-existing 35 unrelated Windows-environment failures (symlink EPERM, `cmd.exe` resolution, shell escape) are unchanged from `main` and unrelated to this patch
- Manual smoke test against a real transcript with `cache_creation_input_tokens: 0` across all 294 records (pre-warmed cache scenario) shows `Cache hit 97.7%` instead of the vacuous `100.0%`

### Files changed

```
 CHANGELOG.md                | 1 +
 README.md                   | 9 +++++++++
 README.zh.md                | 8 ++++++++
 src/config.ts               | 11 +++++++++++
 src/i18n/en.ts              | 1 +
 src/i18n/types.ts           | 1 +
 src/i18n/zh-Hans.ts         | 1 +
 src/i18n/zh-Hant.ts         | 1 +
 src/render/index.ts         | 3 +++
 src/render/lines/cache-hit-rate.ts (new)  | 41 +++++++++++
 src/render/lines/index.ts   | 1 +
 src/render/session-line.ts  | 6 ++++++
 tests/cache-hit-rate.test.js (new)        | 144 +++++++++++++++++++++
 tests/config.test.js        | 16 ++++++++++++++++
```