### PR TITLE
fix(context): synthesize used_percentage before the cache write gate when current_usage is real

### DIFF
--- a/src/context-cache.ts
+++ b/src/context-cache.ts
@@ -367,20 +367,29 @@ export function applyContextWindowFallback(
     } else if (cached) {
       applyCachedContext(contextWindow, cached);
     }
-  } else if (isZeroPercentWithLiveUsage(contextWindow)) {
-    // Zero native percent, but current_usage is real: synthesize the percent
-    // in place, before hasGoodContext() runs below, so the write gate sees it
-    // and the cached value matches what the renderer's own fallback already
-    // computed and displayed for this same frame.
-    const synced = synthesizePercentFromUsage(stdin, contextWindow);
-    if (synced !== null) {
-      contextWindow.used_percentage = synced;
-      contextWindow.remaining_percentage = 100 - synced;
-    }
   }
 
-  if (hasGoodContext(contextWindow)) {
-    writeCache(homeDir, transcriptPath, contextWindow, now, sessionName);
+  // Zero native percent, but current_usage is real: synthesize the percent
+  // that would be cached, without mutating the live frame. used_percentage
+  // doubles as getNativePercent()'s sentinel for "a native percentage
+  // exists" (see stdin.ts), so writing it here would make the renderer skip
+  // getBufferedPercent()'s autocompact buffer for this same frame.
+  const syntheticPercent = isZeroPercentWithLiveUsage(contextWindow)
+    ? synthesizePercentFromUsage(stdin, contextWindow)
+    : null;
+
+  const frameToCache = hasGoodContext(contextWindow)
+    ? contextWindow
+    : syntheticPercent !== null
+      ? {
+          ...contextWindow,
+          used_percentage: syntheticPercent,
+          remaining_percentage: 100 - syntheticPercent,
+        }
+      : null;
+
+  if (frameToCache) {
+    writeCache(homeDir, transcriptPath, frameToCache, now, sessionName);
     if (deps.random() < SWEEP_SAMPLE_RATE) {
       sweepCacheDir(getCacheDir(homeDir), now);
     }

--- a/src/context-cache.ts
+++ b/src/context-cache.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { createHash } from "node:crypto";
 import { getHudPluginDir } from "./claude-config-dir.js";
 import { createDebug } from "./debug.js";
+import { getTotalTokens } from "./stdin.js";
 import type { StdinData } from "./types.js";
 
 const debug = createDebug('context-cache');
@@ -255,6 +256,39 @@ function hasGoodContext(contextWindow: ContextWindow): boolean {
 }
 
 /**
+ * True when the native percentage reads zero but current_usage already has
+ * real tokens in it — the in-flight-request gap documented on
+ * getNativePercent() in stdin.ts (Claude Code can emit used_percentage: 0
+ * before the first API response arrives while current_usage already reflects
+ * the initial-context tokens). Distinct from isSuspiciousZero(), which only
+ * fires when current_usage is ALSO all zero.
+ */
+function isZeroPercentWithLiveUsage(contextWindow: ContextWindow): boolean {
+  const usedPercentage = contextWindow.used_percentage ?? 0;
+  if (usedPercentage !== 0) {
+    return false;
+  }
+  return !isAllUsageZero(contextWindow.current_usage);
+}
+
+/**
+ * Recompute used_percentage from current_usage the same way stdin.ts's
+ * getContextPercent()/getBufferedPercent() fallback does (via
+ * getTotalTokens()), so the value we cache matches what the renderer is
+ * already showing. Returns null when context_window_size is unusable.
+ */
+function synthesizePercentFromUsage(
+  stdin: StdinData,
+  contextWindow: ContextWindow
+): number | null {
+  const size = contextWindow.context_window_size ?? 0;
+  if (size <= 0) {
+    return null;
+  }
+  return Math.min(100, Math.round((getTotalTokens(stdin) / size) * 100));
+}
+
+/**
  * Merge cached context fields into the current frame.
  * Prefer the frame's context_window_size when already present.
  */
@@ -332,6 +366,16 @@ export function applyContextWindowFallback(
       }
     } else if (cached) {
       applyCachedContext(contextWindow, cached);
+    }
+  } else if (isZeroPercentWithLiveUsage(contextWindow)) {
+    // Zero native percent, but current_usage is real: synthesize the percent
+    // in place, before hasGoodContext() runs below, so the write gate sees it
+    // and the cached value matches what the renderer's own fallback already
+    // computed and displayed for this same frame.
+    const synced = synthesizePercentFromUsage(stdin, contextWindow);
+    if (synced !== null) {
+      contextWindow.used_percentage = synced;
+      contextWindow.remaining_percentage = 100 - synced;
     }
   }
 

--- a/tests/context-cache.test.js
+++ b/tests/context-cache.test.js
@@ -175,7 +175,7 @@ test('applyContextWindowFallback ignores corrupted cache without throwing', asyn
   }
 });
 
-test('applyContextWindowFallback synthesizes used_percentage when a zero-percent frame already has current_usage data', async () => {
+test('applyContextWindowFallback caches a synthesized percent without mutating a zero-percent frame that has live current_usage', async () => {
   const tempHome = await createTempHome();
   const transcriptPath = '/tmp/session-a.jsonl';
 
@@ -199,9 +199,12 @@ test('applyContextWindowFallback synthesizes used_percentage when a zero-percent
 
     applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
 
-    // getTotalTokens excludes output_tokens: (48000 + 400 + 100) / 200000 = 24%.
-    assert.equal(stdin.context_window.used_percentage, 24);
-    assert.equal(stdin.context_window.remaining_percentage, 76);
+    // The live frame's used_percentage is the renderer's sentinel for "a
+    // native percentage exists" (getNativePercent() in stdin.ts): writing to
+    // it here would disable getBufferedPercent()'s autocompact buffer. The
+    // frame must stay untouched even though a percent gets cached.
+    assert.equal(stdin.context_window.used_percentage, 0);
+    assert.equal(stdin.context_window.remaining_percentage, 100);
     assert.deepEqual(stdin.context_window.current_usage, {
       input_tokens: 48000,
       output_tokens: 2000,
@@ -209,6 +212,7 @@ test('applyContextWindowFallback synthesizes used_percentage when a zero-percent
       cache_read_input_tokens: 100,
     });
 
+    // getTotalTokens excludes output_tokens: (48000 + 400 + 100) / 200000 = 24%.
     const cachePath = getCachePath(tempHome, transcriptPath);
     const cached = JSON.parse(await readFile(cachePath, 'utf8'));
     assert.equal(cached.used_percentage, 24);
@@ -243,6 +247,10 @@ test('applyContextWindowFallback refreshes a stale cache when a later frame has 
     // to write, so this frame never refreshed the cache and it stayed frozen
     // at 38% indefinitely while the renderer moved on to ~61%.
     applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
+
+    // The live frame must not be mutated by the cache write.
+    assert.equal(stdin.context_window.used_percentage, 0);
+    assert.equal(stdin.context_window.remaining_percentage, 100);
 
     const cachePath = getCachePath(tempHome, transcriptPath);
     const cached = JSON.parse(await readFile(cachePath, 'utf8'));

--- a/tests/context-cache.test.js
+++ b/tests/context-cache.test.js
@@ -175,7 +175,7 @@ test('applyContextWindowFallback ignores corrupted cache without throwing', asyn
   }
 });
 
-test('applyContextWindowFallback keeps live usage when zero-percent frame already has current_usage data', async () => {
+test('applyContextWindowFallback synthesizes used_percentage when a zero-percent frame already has current_usage data', async () => {
   const tempHome = await createTempHome();
   const transcriptPath = '/tmp/session-a.jsonl';
 
@@ -199,14 +199,54 @@ test('applyContextWindowFallback keeps live usage when zero-percent frame alread
 
     applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
 
-    assert.equal(stdin.context_window.used_percentage, 0);
-    assert.equal(stdin.context_window.remaining_percentage, 100);
+    // getTotalTokens excludes output_tokens: (48000 + 400 + 100) / 200000 = 24%.
+    assert.equal(stdin.context_window.used_percentage, 24);
+    assert.equal(stdin.context_window.remaining_percentage, 76);
     assert.deepEqual(stdin.context_window.current_usage, {
       input_tokens: 48000,
       output_tokens: 2000,
       cache_creation_input_tokens: 400,
       cache_read_input_tokens: 100,
     });
+
+    const cachePath = getCachePath(tempHome, transcriptPath);
+    const cached = JSON.parse(await readFile(cachePath, 'utf8'));
+    assert.equal(cached.used_percentage, 24);
+  } finally {
+    await rm(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('applyContextWindowFallback refreshes a stale cache when a later frame has zero used_percentage but real current_usage', async () => {
+  const tempHome = await createTempHome();
+  const transcriptPath = '/tmp/session-a.jsonl';
+
+  try {
+    applyContextWindowFallback(
+      makeHealthyFrame(transcriptPath, { used_percentage: 38, remaining_percentage: 62 }),
+      makeDeps(tempHome, 1_000_000),
+    );
+
+    const stdin = makeSuspiciousFrame({
+      current_usage: {
+        input_tokens: 120000,
+        output_tokens: 4000,
+        cache_creation_input_tokens: 1500,
+        cache_read_input_tokens: 500,
+      },
+    });
+    stdin.transcript_path = transcriptPath;
+
+    // Simulates the in-flight-request gap: Claude Code emits used_percentage: 0
+    // while current_usage already carries the real, higher token counts.
+    // Before this fix, hasGoodContext() required the raw used_percentage > 0
+    // to write, so this frame never refreshed the cache and it stayed frozen
+    // at 38% indefinitely while the renderer moved on to ~61%.
+    applyContextWindowFallback(stdin, makeDeps(tempHome, 1_100_000));
+
+    const cachePath = getCachePath(tempHome, transcriptPath);
+    const cached = JSON.parse(await readFile(cachePath, 'utf8'));
+    assert.equal(cached.used_percentage, 61);
   } finally {
     await rm(tempHome, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Fixes #742 — the context cache freezes while the statusline moves on.

When Claude Code emits `used_percentage: 0` on a tick where `current_usage` already holds real, non-zero tokens (the in-flight-request gap documented on `getNativePercent()`), the renderer correctly falls back to a percentage computed from `current_usage`, but `hasGoodContext()` gates the *cache write* on the raw `used_percentage`. The write is skipped, so the session-scoped cache stays frozen at whatever it last held and silently diverges from what is on screen.

The fix is on the write gate only: when a frame has `used_percentage: 0` but live `current_usage`, cache a percentage synthesized from `current_usage` instead of skipping the write. **The live frame is not modified.**

## Prior art

This is the cache half of an asymmetry whose render half already landed: #430 introduced the `getNativePercent()`/fallback split in `stdin.ts`, so the renderer learned to cope with a zero `used_percentage` while the cache write gate did not. #508 and #576 (and the `isSuspiciousZero()` logic they shaped) cover `used_percentage: 0` combined with an **all-zero** `current_usage` — the opposite combination from this one, which needs `current_usage` to be real and non-zero. I found no open or closed issue/PR covering the write-gate-vs-render asymmetry itself.

## Why the frame must not be mutated

An earlier revision of this PR synthesized the value *into* the frame, before `hasGoodContext()`. That was wrong, and this PR's own CI caught it — worth writing down, because the trap is not obvious.

`used_percentage` is not just a value, it is the sentinel for "a native percentage exists". `getNativePercent()` returns `null` when it is absent or `0`, and `getBufferedPercent()` applies its usage-scaled autocompact buffer **only** on that non-native fallback path. So writing a synthesized number into the frame flips the renderer out of its buffered path.

Concretely, with the `tests/integration.test.js` fixture (`context_window_size: 200000`, `current_usage.input_tokens: 45000`, no `used_percentage`):

- unmutated: no native value, so the buffered fallback runs — `scale = (0.225 - 0.05) / 0.45 = 0.3889`, `round((45000 + buffer) / 200000 * 100)` = **29%**
- mutated: `used_percentage = round(45000 / 200000 * 100) = 23`, so `getNativePercent()` returns 23, `getBufferedPercent()` short-circuits and the buffer is never applied = **23%**

The bar visibly dropped on exactly the frames the fix was meant to help. Caching a copy leaves the renderer's sentinel intact.

The raw, unbuffered percentage is the right thing to *cache*: `applyCachedContext()` restores cached values straight into `used_percentage`, where they are read back through `getNativePercent()` — so the cache holds native-equivalent percentages, not buffered display ones.

## Changes

- **`src/context-cache.ts`**
  - Import `getTotalTokens` from `./stdin.js` — the same summation the renderer's own fallback uses (input + cache-creation + cache-read, excluding output tokens).
  - `isZeroPercentWithLiveUsage()`: true when `used_percentage` is `0`/missing but `current_usage` is not all-zero. Distinct from the existing `isSuspiciousZero()`, which requires `current_usage` to *also* be all-zero — the two are mutually exclusive.
  - `synthesizePercentFromUsage()`: recomputes a percentage from `current_usage` via `getTotalTokens()`, the same formula as `getContextPercent()`'s manual fallback.
  - `applyContextWindowFallback()`: after the existing `isSuspiciousZero` handling, when the frame is zero-percent-with-live-usage, write a shallow **copy** carrying the synthesized `used_percentage`/`remaining_percentage`. The frame itself is untouched, so the renderer still takes its buffered path.
- **`tests/context-cache.test.js`**
  - The existing zero-percent-with-live-usage test now asserts the contract directly: the frame is unchanged (`used_percentage` stays `0`) while the cache file reads the synthesized `24`.
  - New test reproducing the reported shape: a cache frozen at 38% is refreshed to 61% by a later zero-percent frame carrying real `current_usage`, and that frame is likewise not mutated.

## Validation

`npm run build` (tsc) clean; `node --test tests/context-cache.test.js` and `tests/integration.test.js` both pass, including the 29% render assertion that caught the earlier approach.

One unrelated failure remains on CI here: `tests/cost-coverage.test.js` — "estimateSessionCost prices Claude 5 point releases like their base model". It is not caused by this PR. That test calls `estimateSessionCost` without pinning `now`, so it reads the wall clock, and the introductory-pricing window at `src/cost.ts:29` closed on 2026-09-01 — it fails on a clean checkout of `main` too.

I have sent that as its own one-line fix in #744, which is green. Once #744 lands I will rebase this branch onto it and CI here should follow. I have deliberately not patched around it inside this PR, since it has no overlap with `context-cache.ts` or `stdin.ts`.
