### PR TITLE
test(cost): pin the clock in the Sonnet 5 point-release pricing test

### DIFF
--- a/tests/cost-coverage.test.js
+++ b/tests/cost-coverage.test.js
@@ -169,7 +169,11 @@ test('estimateSessionCost prices Claude 5 point releases like their base model',
   assert.ok(opus51);
   assert.equal(opus51.inputUsd, 5);
 
-  const sonnet51 = estimateSessionCost({ model: { display_name: 'Sonnet 5.1' } }, tokens);
+  const sonnet51 = estimateSessionCost(
+    { model: { display_name: 'Sonnet 5.1' } },
+    tokens,
+    { now: new Date('2026-08-31T23:59:59.999Z') },
+  );
   assert.ok(sonnet51);
   assert.equal(sonnet51.inputUsd, 2);
 });


### PR DESCRIPTION
## Symptom

`tests/cost-coverage.test.js`'s `estimateSessionCost prices Claude 5
point releases like their base model` test currently fails on `main`
with `3 !== 2`, with no code change involved, as of 2026-09-01 UTC.

## Mechanism

- `src/cost.ts:29` defines `SONNET_5_PROMO_END_MS = Date.UTC(2026, 8, 1)`
  (2026-09-01T00:00:00Z).
- `src/cost.ts:64-67` prices any Sonnet 5 variant at
  `{ inputUsdPerMillion: 2, outputUsdPerMillion: 10 }` while
  `now.getTime() < SONNET_5_PROMO_END_MS`, and
  `{ inputUsdPerMillion: 3, outputUsdPerMillion: 15 }` afterward.
- `src/cost.ts:106` defaults `now` to `options?.now ?? new Date()` when
  the caller doesn't pass one.
- The failing test's `sonnet51` case calls `estimateSessionCost` with no
  `now` override, so it reads the real wall clock. Once the promo window
  closed on 2026-09-01 UTC, the assertion of `inputUsd === 2` started
  receiving `3` instead.

The adjacent test, `estimateSessionCost ends Sonnet 5 introductory
pricing on September 1, 2026 UTC` (line 177), already pins `now` via
`{ now: new Date('2026-08-31T23:59:59.999Z') }` for exactly this
reason. This PR applies that same idiom to the point-release test,
which simply omitted it — a consistency fix in the file's own
established style.

## Fix

Pin `now` on the `sonnet51` assertion to a fixed pre-cutoff instant so
the test deterministically exercises the promo-era pricing equivalence
it was written to assert. The `opus51` assertion in the same test is
untouched since Opus 5 pricing has no date dependency. Expected values
are unchanged.

**No production behaviour changes.** `src/cost.ts` is untouched — the
pricing expiry is intentional and correct. Only the test becomes
deterministic.

## Note

Any future dated pricing boundary will reintroduce this class of
failure in any test that constructs its `stdin`/`tokens` inputs without
pinning `now`.
