### PR TITLE
fix(auth): resolve claude.json path for custom CLAUDE_CONFIG_DIR

### DIFF
--- a/src/claude-config-dir.ts
+++ b/src/claude-config-dir.ts
@@ -19,7 +19,19 @@ export function getClaudeConfigDir(homeDir: string): string {
 }
 
 export function getClaudeConfigJsonPath(homeDir: string): string {
-  return `${getClaudeConfigDir(homeDir)}.json`;
+  const configDir = getClaudeConfigDir(homeDir);
+  const defaultConfigDir = path.join(homeDir, '.claude');
+  if (configDir === defaultConfigDir) {
+    // Default profile — whether CLAUDE_CONFIG_DIR is unset, or explicitly
+    // set to the same location as the default (e.g. `CLAUDE_CONFIG_DIR=~/.claude`) —
+    // Claude Code stores its state file as a sibling of ~/.claude, not nested
+    // inside it.
+    return path.join(homeDir, '.claude.json');
+  }
+  // Custom CLAUDE_CONFIG_DIR (resolves somewhere other than the default):
+  // Claude Code nests the state file *inside* the configured directory
+  // (e.g. $CLAUDE_CONFIG_DIR/.claude.json), not as a sibling.
+  return path.join(configDir, '.claude.json');
 }
 
 export function getHudPluginDir(homeDir: string): string {

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { deriveAuthInfo, readAuthInfo, truncateUser, formatAuthSegment } from '../dist/auth.js';
@@ -81,6 +81,7 @@ test('deriveAuthInfo strips ANSI sequences and control characters from values', 
 test('readAuthInfo honors CLAUDE_CONFIG_DIR and handles unreadable profiles', async () => {
   const tempDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-auth-test-'));
   const configDir = path.join(tempDir, 'profile');
+  const jsonPath = path.join(configDir, '.claude.json');
   const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
   const originalApiKey = process.env.ANTHROPIC_API_KEY;
 
@@ -90,10 +91,11 @@ test('readAuthInfo honors CLAUDE_CONFIG_DIR and handles unreadable profiles', as
 
     assert.deepEqual(readAuthInfo(), { method: null, user: null });
 
-    await writeFile(`${configDir}.json`, JSON.stringify(MAX_ACCOUNT), 'utf8');
+    await mkdir(configDir, { recursive: true });
+    await writeFile(jsonPath, JSON.stringify(MAX_ACCOUNT), 'utf8');
     assert.deepEqual(readAuthInfo(), { method: 'Claude Max 20x', user: 'someone.long' });
 
-    await writeFile(`${configDir}.json`, '{invalid', 'utf8');
+    await writeFile(jsonPath, '{invalid', 'utf8');
     assert.deepEqual(readAuthInfo(), { method: null, user: null });
   } finally {
     restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
@@ -159,7 +161,7 @@ test('readAuthInfo caches derived auth and serves it on an unchanged file', asyn
     delete process.env.ANTHROPIC_API_KEY;   // force the file path
     process.env.CLAUDE_CONFIG_DIR = configDir;
     fsSync.mkdirSync(configDir, { recursive: true });
-    const jsonPath = `${configDir}.json`;
+    const jsonPath = path.join(configDir, '.claude.json');
     await writeFile(jsonPath, JSON.stringify(MAX_ACCOUNT), 'utf8');
 
     assert.deepEqual(readAuthInfo(), { method: 'Claude Max 20x', user: 'someone.long' });
@@ -188,7 +190,7 @@ test('readAuthInfo re-parses when claude.json actually changes', async () => {
     delete process.env.ANTHROPIC_API_KEY;
     process.env.CLAUDE_CONFIG_DIR = configDir;
     fsSync.mkdirSync(configDir, { recursive: true });
-    const jsonPath = `${configDir}.json`;
+    const jsonPath = path.join(configDir, '.claude.json');
     await writeFile(jsonPath, JSON.stringify(MAX_ACCOUNT), 'utf8');
     assert.equal(readAuthInfo().user, 'someone.long');
 
@@ -219,7 +221,7 @@ test('readAuthInfo busts the cache when only the SIZE differs', async () => {
     delete process.env.ANTHROPIC_API_KEY;
     process.env.CLAUDE_CONFIG_DIR = configDir;
     fsSync.mkdirSync(configDir, { recursive: true });
-    const jsonPath = `${configDir}.json`;
+    const jsonPath = path.join(configDir, '.claude.json');
     await writeFile(jsonPath, JSON.stringify(MAX_ACCOUNT), 'utf8');
     assert.equal(readAuthInfo().user, 'someone.long', 'seed the cache');
 
@@ -256,7 +258,7 @@ test('readAuthInfo rejects a poisoned cache even when source identity matches', 
     delete process.env.ANTHROPIC_API_KEY;
     process.env.CLAUDE_CONFIG_DIR = configDir;
     fsSync.mkdirSync(configDir, { recursive: true });
-    const jsonPath = `${configDir}.json`;
+    const jsonPath = path.join(configDir, '.claude.json');
     await writeFile(jsonPath, JSON.stringify(MAX_ACCOUNT), 'utf8');
     assert.equal(readAuthInfo().user, 'someone.long');
 
@@ -292,7 +294,7 @@ test('readAuthInfo rejects symlink cache files without touching their target', a
     delete process.env.ANTHROPIC_API_KEY;
     process.env.CLAUDE_CONFIG_DIR = configDir;
     fsSync.mkdirSync(configDir, { recursive: true });
-    await writeFile(`${configDir}.json`, JSON.stringify(MAX_ACCOUNT), 'utf8');
+    await writeFile(path.join(configDir, '.claude.json'), JSON.stringify(MAX_ACCOUNT), 'utf8');
     assert.equal(readAuthInfo().user, 'someone.long');
 
     const cacheFile = path.join(configDir, 'plugins', 'claude-hud', 'auth-cache', 'auth.json');
@@ -322,7 +324,7 @@ test('readAuthInfo detects same-size rewrites with a restored mtime', async () =
     delete process.env.ANTHROPIC_API_KEY;
     process.env.CLAUDE_CONFIG_DIR = configDir;
     fsSync.mkdirSync(configDir, { recursive: true });
-    const jsonPath = `${configDir}.json`;
+    const jsonPath = path.join(configDir, '.claude.json');
     const first = JSON.stringify(MAX_ACCOUNT);
     const second = first.replace('someone.long', 'another.long');
     assert.equal(first.length, second.length);

--- a/tests/claude-config-dir.test.js
+++ b/tests/claude-config-dir.test.js
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as path from 'node:path';
+import { getClaudeConfigDir, getClaudeConfigJsonPath, getHudPluginDir } from '../dist/claude-config-dir.js';
+
+function restoreEnvVar(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+test('getClaudeConfigJsonPath resolves to a sibling of ~/.claude when CLAUDE_CONFIG_DIR is unset', () => {
+  const original = process.env.CLAUDE_CONFIG_DIR;
+  try {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    const homeDir = '/Users/example';
+    assert.equal(getClaudeConfigDir(homeDir), path.join(homeDir, '.claude'));
+    assert.equal(getClaudeConfigJsonPath(homeDir), path.join(homeDir, '.claude.json'));
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', original);
+  }
+});
+
+test('getClaudeConfigJsonPath nests inside a custom CLAUDE_CONFIG_DIR instead of guessing a sibling file', () => {
+  const original = process.env.CLAUDE_CONFIG_DIR;
+  try {
+    const homeDir = '/Users/example';
+    const customDir = path.join(homeDir, '.claude-work');
+    process.env.CLAUDE_CONFIG_DIR = customDir;
+
+    assert.equal(getClaudeConfigDir(homeDir), customDir);
+    // Regression guard: the old implementation string-concatenated `.json`
+    // onto the directory path (`${customDir}.json`), which only happens to
+    // exist for the default `~/.claude` profile. For any custom directory,
+    // Claude Code actually nests the state file inside it.
+    assert.equal(getClaudeConfigJsonPath(homeDir), path.join(customDir, '.claude.json'));
+    assert.notEqual(getClaudeConfigJsonPath(homeDir), `${customDir}.json`);
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', original);
+  }
+});
+
+test('getClaudeConfigJsonPath still resolves to the sibling path when CLAUDE_CONFIG_DIR is explicitly set to the default location', () => {
+  // Some users set CLAUDE_CONFIG_DIR explicitly (e.g. a `claude1='CLAUDE_CONFIG_DIR=~/.claude command claude'`
+  // alias) even though it resolves to the same place the default would. The
+  // branch must key off the *resolved path*, not off whether the env var
+  // string happens to be present, or this regresses to guessing a
+  // nonexistent nested file for the default profile.
+  const original = process.env.CLAUDE_CONFIG_DIR;
+  try {
+    const homeDir = '/Users/example';
+    process.env.CLAUDE_CONFIG_DIR = path.join(homeDir, '.claude');
+
+    assert.equal(getClaudeConfigJsonPath(homeDir), path.join(homeDir, '.claude.json'));
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', original);
+  }
+});
+
+test('getClaudeConfigJsonPath nests correctly even when the custom dir is literally named .claude', () => {
+  // A directory that happens to be *named* `.claude` but lives somewhere
+  // other than directly under CLAUDE_CONFIG_DIR being unset must still use
+  // the nested convention, since it was reached via an explicit env var.
+  const original = process.env.CLAUDE_CONFIG_DIR;
+  try {
+    const homeDir = '/Users/example';
+    const customDir = path.join(homeDir, 'profiles', '.claude');
+    process.env.CLAUDE_CONFIG_DIR = customDir;
+
+    assert.equal(getClaudeConfigJsonPath(homeDir), path.join(customDir, '.claude.json'));
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', original);
+  }
+});
+
+test('getHudPluginDir stays nested under the resolved config dir in both modes', () => {
+  const original = process.env.CLAUDE_CONFIG_DIR;
+  try {
+    const homeDir = '/Users/example';
+
+    delete process.env.CLAUDE_CONFIG_DIR;
+    assert.equal(getHudPluginDir(homeDir), path.join(homeDir, '.claude', 'plugins', 'claude-hud'));
+
+    const customDir = path.join(homeDir, '.claude-work');
+    process.env.CLAUDE_CONFIG_DIR = customDir;
+    assert.equal(getHudPluginDir(homeDir), path.join(customDir, 'plugins', 'claude-hud'));
+  } finally {
+    restoreEnvVar('CLAUDE_CONFIG_DIR', original);
+  }
+});

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -2355,7 +2355,7 @@ test('countConfigs uses CLAUDE_CONFIG_DIR and matching .json sidecar for user sc
       'utf8'
     );
     await writeFile(
-      `${customConfigDir}.json`,
+      path.join(customConfigDir, '.claude.json'),
       JSON.stringify({ disabledMcpServers: ['customA'] }),
       'utf8'
     );


### PR DESCRIPTION

## Problem

`getClaudeConfigJsonPath()` (`src/claude-config-dir.ts`) resolves the
account/state JSON path via string concatenation:
`${getClaudeConfigDir(homeDir)}.json`. That only produces a real path for
the default profile (`~/.claude` → `~/.claude.json`, a sibling file — which
is genuinely how Claude Code lays out the default profile). For any custom
`CLAUDE_CONFIG_DIR`, Claude Code instead nests the state file inside the
directory (`$CLAUDE_CONFIG_DIR/.claude.json`), so the concatenation guesses
a nonexistent sibling path. `readAuthInfo()`'s `fs.statSync` throws ENOENT
on that path, the `catch` swallows it, and `showAuth`/`showAuthUser`
silently render nothing — no error, just a missing HUD segment.

Fixes #745.

All three consumers of `getClaudeConfigJsonPath` (`auth.ts`,
`config-reader.ts`'s `computeConfigCountsFresh` and `countConfigs`) go
through this one function, so they were all affected and are all fixed by
this change.

## Fix

The previous implementation branched on whether `CLAUDE_CONFIG_DIR` was
set at all. That doesn't cover the case where someone sets it explicitly
even though it points at the same place the default would (e.g. a shell
alias like `claude1='CLAUDE_CONFIG_DIR=~/.claude command claude'`, used to
switch between profiles by name) — there, the var is set, but the correct
path is still the *sibling* one, not the nested one.

So the fix branches on whether the *resolved* config directory equals the
true default (`homeDir/.claude`), instead of on whether the env var was
explicitly set:

- resolved dir equals the default → `path.join(homeDir, '.claude.json')`
  (sibling of `~/.claude`, unchanged behavior)
- resolved dir differs from the default → `path.join(configDir,
  '.claude.json')` (nested inside the resolved directory), instead of
  string concatenation

Note: the equality check is a plain `===`, so it's case-sensitive. On a
case-insensitive filesystem (the default on macOS and Windows), a
`CLAUDE_CONFIG_DIR` that differs from the default only in case (e.g.
`~/.Claude`) is the same directory on disk but won't match `===`, so it'll
be misdetected as custom — same underlying bug, different trigger. Left
out of scope for this PR; happy to follow up separately if that's wanted.

## Tests

- `tests/claude-config-dir.test.js` (new): direct coverage of both
  branches, a regression guard that the old sibling-guess path is no
  longer produced for a custom dir, a case for an explicit
  `CLAUDE_CONFIG_DIR` that resolves to the default location (the scenario
  above), and a case for a custom dir that happens to be literally *named*
  `.claude` but lives elsewhere (to confirm the branch is keyed on the
  resolved path, not the directory's name).
- `tests/auth.test.js`: the existing `CLAUDE_CONFIG_DIR`-backed tests
  wrote their test fixtures to the old (buggy) sibling path — i.e. they
  passed by matching the bug's behavior, not correct behavior. Updated
  all of them to write to the nested path instead, so they now assert
  what should actually happen.
- `tests/core.test.js`: same stale-fixture issue in the `countConfigs`
  test covering `config-reader.ts` (the third consumer of
  `getClaudeConfigJsonPath`) — its custom-profile fixture also wrote to
  the old sibling path, which silently regressed (`mcpCount` off by one)
  once the path helper was fixed. Pointed it at the nested path too.

`npm run build && npm test` passes for every test this diff touches.
16 unrelated `countConfigs` tests in `tests/core.test.js` fail both on
this branch and on a clean `upstream/main` checkout with no changes
applied — confirmed pre-existing and out of scope for this PR. Also
sanity-checked end-to-end against several real `CLAUDE_CONFIG_DIR`
profiles set up locally (unset, an explicit-default alias, and two custom
directories) — all four resolve to the correct account now.
