### PR TITLE
fix(setup): launch the Windows Git Bash statusline through cmd.exe

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -193,11 +193,36 @@ On Windows require `node` and always use `dist/index.js`.
 
 **Important**: Do **not** reuse the macOS/Linux awk-based command on Windows + Git Bash. The `awk` fragment requires `'"'"'` quoting to nest single quotes inside `bash -c '...'`. After JSON encoding and decoding, this quoting breaks on Windows Git Bash, causing a silent syntax error that prevents the HUD process from starting (see [#326](https://github.com/jarrodwatts/claude-hud/issues/326)).
 
-Instead, use `sort -V` (GNU version sort, included with Git for Windows) which avoids nested single quotes entirely. Also avoid wrapping the generated command in a second `bash -c ...` layer. Claude Code is already invoking the statusline through bash, so the direct shell command lets `exec` replace that shell instead of spawning an extra bash wrapper first. The command still exports `COLUMNS` so the HUD receives the real terminal width, and it uses the marketplace-aware cache glob:
+**Important**: Do **not** `exec` the runtime itself from Git Bash either. Git Bash creates every native child suspended and resumes it a moment later. If Claude Code terminates the statusLine shell inside that window, the child is stranded suspended: it never executes a single instruction, so it also never exits, and only a manual kill removes it. When the exec target is the runtime, each stranded child is a ~36 MB `node.exe`, one per lost render, and they accumulate for as long as the machine stays up (see [#747](https://github.com/jarrodwatts/claude-hud/issues/747)).
+
+Launch through `cmd.exe` instead, the way the Windows + PowerShell path already does. Git Bash then strands at worst a ~2 MB `cmd.exe` stub, and `node.exe` is started by `cmd.exe` through a plain Win32 `CreateProcess`, which has no suspended window. This also moves the version lookup into the launcher, so no `ls | sort -V | tail` pipeline runs on every refresh.
+
+1. Write the launcher. It is the same `statusline.mjs` as step 4 of **Windows + PowerShell** below; copy that body verbatim into a quoted heredoc so bash expands nothing. Run the block with no leading indentation: a quoted heredoc only ends on a `LAUNCHER` line that starts at column 0.
+
+   ```bash
+   claude_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+   mkdir -p "$claude_dir/plugins/claude-hud"
+   cat > "$claude_dir/plugins/claude-hud/statusline.mjs" <<'LAUNCHER'
+   <launcher body from Windows + PowerShell step 4>
+   LAUNCHER
+   ```
+
+2. Write the `cmd.exe` shim next to it. `%~dp0` expands to the shim's own directory, so the generated statusLine command carries no runtime path and no nested quoting:
+
+   ```bash
+   printf '@echo off\r\n"%s" "%%~dp0statusline.mjs"\r\n' "{RUNTIME_PATH_WIN}" \
+     > "$claude_dir/plugins/claude-hud/statusline.cmd"
+   ```
+
+   `{RUNTIME_PATH_WIN}` is the Windows form of the runtime detected in step 2, `cygpath -w "{RUNTIME_PATH}"`, typically `C:\Program Files\nodejs\node.exe`. Pass it as a `printf` argument, never inside the format string: `printf` expands backslash escapes in the format, so a literal `C:\Program Files\nodejs` would turn `\n` into a newline and split the file. Batch files also need CRLF line endings, which is why the format ends each line with `\r\n`.
+
+3. Generate command. The `COLUMNS` probe stays for Claude Code versions older than v2.1.153, but it now exports the raw terminal width: the launcher applies the `- 4` padding itself, so subtracting here too would take 8 columns off.
 
    ```
-   cols=${COLUMNS:-}; case "$cols" in ""|*[!0-9]*) cols=$(stty size 2>/dev/null </dev/tty | awk '{print $2}');; esac; case "$cols" in ""|*[!0-9]*) cols=120;; esac; export COLUMNS=$(( cols > 4 ? cols - 4 : 1 )); plugin_dir=$(ls -1d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/claude-hud/*/ 2>/dev/null | sort -V | tail -1); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"
+   cols=${COLUMNS:-}; case "$cols" in ""|*[!0-9]*) cols=$(stty size 2>/dev/null </dev/tty | awk '{print $2}');; esac; case "$cols" in ""|*[!0-9]*) cols=120;; esac; export COLUMNS="$cols"; exec "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/claude-hud/statusline.cmd"
    ```
+
+   Keep `exec`: Claude Code is already invoking the statusline through bash, so `exec` replaces that shell rather than adding another process to the chain.
 
 **Windows + PowerShell** (Platform: `win32`, Shell: `powershell`, `pwsh`, or `cmd`, OSTYPE: other/empty):
 
@@ -230,6 +255,8 @@ Instead, use `sort -V` (GNU version sort, included with Git for Windows) which a
 4. Write the Windows statusline launcher.
 
    Windows PowerShell startup plus `Get-ChildItem | Sort-Object [version]` can exceed Claude Code's render cadence on every statusLine refresh. Write a small Node launcher once during setup, then invoke it through `cmd.exe` on each refresh. The launcher uses the setup-time validated `node.exe`, preserves update discovery by finding the latest installed `claude-hud` version, and prefers inherited `COLUMNS` before falling back to 120.
+
+   Both Windows shells share this file, so keep the body below in sync with the heredoc in **Windows + Git Bash** above.
 
    The launcher file at `$claudeDir/plugins/claude-hud/statusline.mjs` should contain:
 
@@ -756,6 +783,15 @@ Use AskUserQuestion:
      '{}' | & cmd.exe /c '{GENERATED_COMMAND}'
      ```
      If you see either error, the existing setup predates the Node launcher format. Re-run `/claude-hud:setup` to regenerate `statusline.mjs` and a `cmd.exe`-launched command. See [#521](https://github.com/jarrodwatts/claude-hud/issues/521).
+
+   **Windows + Git Bash: idle `node.exe` processes pile up**:
+   - Symptoms: dozens to hundreds of `node.exe` processes whose command line ends in `dist/index.js`, several GB of working set, and a parent that no longer exists.
+   - Check: they have burnt no CPU at all, which is what separates them from a HUD that is merely slow.
+     ```powershell
+     Get-Process node | Where-Object { $_.TotalProcessorTime.TotalSeconds -eq 0 -and $_.Threads.Count -eq 1 }
+     ```
+   - Root cause: the setup predates the `cmd.exe` shim and still `exec`s the runtime from Git Bash, so a statusLine shell killed mid-spawn strands a suspended `node.exe` that can never run and never exit.
+   - Solution: kill the listed PIDs, then re-run `/claude-hud:setup` to regenerate `statusline.cmd` and the shim-launched command. See [#747](https://github.com/jarrodwatts/claude-hud/issues/747).
 
    **Windows: PowerShell execution policy error**:
    - Run: `Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned`

--- a/tests/setup-command.test.js
+++ b/tests/setup-command.test.js
@@ -2,9 +2,52 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
+const readSetup = () => readFile(new URL('../commands/setup.md', import.meta.url), 'utf8');
+
+// Match the headings, not the cross-references the prose makes to them.
+function windowsGitBashSection(setup) {
+  const start = setup.indexOf('**Windows + Git Bash** (Platform:');
+  const end = setup.indexOf('**Windows + PowerShell** (Platform:', start);
+  assert.ok(start !== -1 && end > start, 'Windows + Git Bash section not found');
+  return setup.slice(start, end);
+}
+
 test('setup commands silence /dev/tty failures before opening the device', async () => {
-  const setup = await readFile(new URL('../commands/setup.md', import.meta.url), 'utf8');
+  const setup = await readSetup();
 
   assert.doesNotMatch(setup, /stty size <\/dev\/tty 2>\/dev\/null/);
   assert.equal(setup.match(/stty size 2>\/dev\/null <\/dev\/tty/g)?.length, 3);
+});
+
+test('the Windows Git Bash statusline execs a cmd.exe shim, not the runtime', async () => {
+  const gitBash = windowsGitBashSection(await readSetup());
+
+  // Git Bash creates every native child suspended and resumes it a moment
+  // later. A statusLine shell killed inside that window strands whatever it
+  // was starting: the child never runs, so it never exits either. Stranding a
+  // ~2 MB cmd.exe stub is survivable; stranding the ~36 MB node.exe runtime is
+  // what filled machines in #747, one process per lost render.
+  assert.doesNotMatch(gitBash, /exec "\{RUNTIME_PATH\}"/);
+  assert.match(
+    gitBash,
+    /exec "\$\{CLAUDE_CONFIG_DIR:-\$HOME\/\.claude\}\/plugins\/claude-hud\/statusline\.cmd"/,
+  );
+});
+
+test('the Windows Git Bash command exports the raw terminal width', async () => {
+  const gitBash = windowsGitBashSection(await readSetup());
+
+  // statusline.mjs subtracts the 4 columns of Claude Code padding itself, so
+  // the shell must hand it the untouched width or the HUD renders 8 short.
+  assert.match(gitBash, /export COLUMNS="\$cols"/);
+  assert.doesNotMatch(gitBash, /export COLUMNS=\$\(\( cols > 4/);
+});
+
+test('the Windows Git Bash shim keeps the runtime path out of the printf format', async () => {
+  const gitBash = windowsGitBashSection(await readSetup());
+
+  // printf expands backslash escapes in its format string, so an inlined
+  // C:\Program Files\nodejs\node.exe would break the file at \n. The path
+  // belongs in a %s argument, and batch files need CRLF.
+  assert.match(gitBash, /printf '@echo off\\r\\n"%s" "%%~dp0statusline\.mjs"\\r\\n' "\{RUNTIME_PATH_WIN\}"/);
 });


### PR DESCRIPTION
## Summary

Fixes the Windows accumulation reported in #747, and corrects the hypothesis I put in that issue: the leak is not in `git-runner.ts`. The stranded processes never execute a single instruction, so no JavaScript can be responsible.

**Mechanism (measured, not inferred).** Git Bash creates every native child with `CREATE_SUSPENDED` and resumes it a moment later. If the statusLine shell is terminated inside that window, the child is stranded suspended: it never runs, therefore it never exits, and only a manual kill removes it. Every stranded process I found — in the wild and in the reproduction — has the same signature: zero CPU time ever, one thread in `Wait`/`Suspended` (`ThreadState=5`, `ThreadWaitReason=5`), zero loaded modules, ~36 MB working set.

The Windows + Git Bash command generated by `/claude-hud:setup` ends in `exec "{RUNTIME_PATH}" "${plugin_dir}dist/index.js"`, so the process caught in that window is the runtime itself. That is why the survivors are `dist/index.js` and never `windows-git-worker.js`: the worker is spawned by Node, which does not use `CREATE_SUSPENDED`.

**Fix.** Launch through `cmd.exe`, exactly as the Windows + PowerShell path already does, reached via a small `statusline.cmd` shim so the generated command carries no runtime path and needs no nested quoting. Git Bash then strands at worst a 2.3 MB `cmd.exe` stub, and `node.exe` is created by `cmd.exe` through a plain Win32 `CreateProcess`, which has no suspended window.

## Measurements

Windows 11 Pro 26200, Node 24.18.0, Git for Windows bash. Each arm launches the generated statusLine command the way Claude Code does (`bash -c <command>`) and kills the shell after a delay swept 0-400 ms; 802 launches per arm, identical protocol. A survivor is a process started during the run with zero CPU time and a single suspended thread.

| arm | stranded processes | image | total working set |
|---|---|---|---|
| current, `exec {RUNTIME_PATH}` | 7 | `node.exe` | 255.9 MB |
| this PR, `exec statusline.cmd` | 28 | `cmd.exe` | 63.8 MB |

```
arm=current  attempts=802 delays=0..400
  suspended orphans: 7   totalWorkingSet=255.9MB
    node.exe: 7
arm=proposed attempts=802 delays=0..400
  suspended orphans: 28  totalWorkingSet=63.8MB
    cmd.exe: 28
```

Two honest caveats on that table:

- The counts are not comparable between arms. The window is ~1-2 ms wide in both cases; what differs is how much start-up jitter the uniform delay sweep has to cover before reaching it (~250 ms for the current command, ~50 ms for the shim), so the sweep hits the shim's window more often. Against a fixed real-world kill-time distribution the exposure is the same. What changes is the size of what gets stranded: **36.5 MB against 2.3 MB, per event**.
- This does not make the residue zero. Anything Git Bash starts can be stranded; the fix makes the victim a stub instead of a full Node runtime. Eliminating it entirely would need the statusLine shell not to be killed mid-spawn.

Isolated control arms, 82 launches each, delays swept 20-60 ms:

```
exec node <script>              node stranded 15/82   cmd stranded  0/82
bash -c 'node <script>'         node stranded 15/82   cmd stranded  0/82
exec cmd.exe /c node <script>   node stranded  0/82   cmd stranded 18/82
direct spawn of node.exe        node stranded  0/82   cmd stranded  0/82
```

The last row is the control: with no MSYS process in the chain, nothing is ever stranded.

Behaviour of the new command, verified against the real launcher:

- stdin JSON reaches the HUD through `bash` → `cmd.exe` → `node`.
- stdout is byte-identical, UTF-8 intact (checked with `od -c` on accented text, box drawing and an emoji).
- `COLUMNS` still resolves: 200 in, 196 rendered; absent, 120 fallback, 116 rendered.
- End to end it is slightly faster, ~228 ms against ~248 ms, since `ls | sort -V | tail` no longer runs on every refresh.

## Testing

- [x] `npm test` — 1077 pass / 37 fail, against 1074 / 37 on `main` on this machine. The 37 are pre-existing Windows-environment failures (path separators, `cmd.exe` shims in `version.test.js`), unchanged by this PR.
- [ ] `npm run test:coverage`

The three new tests in `tests/setup-command.test.js` fail on `main` and pass with this change:

```
### commands/setup.md at upstream HEAD
+ setup commands silence /dev/tty failures before opening the device
x the Windows Git Bash statusline execs a cmd.exe shim, not the runtime
x the Windows Git Bash command exports the raw terminal width
x the Windows Git Bash shim keeps the runtime path out of the printf format
  tests 4  pass 1  fail 3

### with this change
+ setup commands silence /dev/tty failures before opening the device
+ the Windows Git Bash statusline execs a cmd.exe shim, not the runtime
+ the Windows Git Bash command exports the raw terminal width
+ the Windows Git Bash shim keeps the runtime path out of the printf format
  tests 4  pass 4  fail 0
```

## Notes for review

- `statusline.mjs` is now shared by both Windows shells. Rather than paste a third copy of the launcher into `setup.md`, the Git Bash branch points at the body in Windows + PowerShell step 4, with a note asking for the two to be kept in sync. Happy to inline the duplicate instead if you prefer.
- The `COLUMNS` probe is kept for Claude Code before v2.1.153 but now exports the raw width, because the launcher applies the 4-column padding itself. Subtracting in both places would cost 8 columns.
- The `.cmd` shim is written with `printf '...%s...' "$runtime"` rather than an inlined path: `printf` expands backslash escapes in its format string, so `C:\Program Files\nodejs` would break the file at `\n`.
- A troubleshooting entry is added so users on an existing setup can identify the stranded processes (zero CPU time is the discriminator) and clear them.

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed
- [x] Only `commands/` and `tests/` touched, no `dist/` changes
