### PR TITLE
fix: show the running session's Claude Code version, not the newest installed one

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Simplified and Traditional Chinese HUD labels are available as explicit opt-ins.
 | `display.showCompactions` | boolean | false | Show how many context compactions (manual `/compact` or auto) have occurred this session, counted from transcript `compact_boundary` entries, e.g. `Compactions: 2`. Hidden until the first compaction |
 | `display.showEffortLevel` | boolean | false | Show the current reasoning effort in the model badge. Ultracode renders as `ultracode(xhigh)`, detected from the session transcript so it tracks `/effort` changes made at runtime |
 | `display.effortFormat` | `full` \| `symbol` \| `text` | `full` | How the effort renders when `display.showEffortLevel` is on: symbol and level text (`◑ high`), symbol only (`◑`), or level text only (`high`). Ultracode keeps the full `◕ ultracode(xhigh)` form under `symbol` so the marker is not lost, and levels without a known symbol fall back to the level text |
-| `display.showClaudeCodeVersion` | boolean | false | Show the installed Claude Code version, e.g. `CC v2.1.81` |
+| `display.showClaudeCodeVersion` | boolean | false | Show the running session's Claude Code version, e.g. `CC v2.1.81`. Falls back to the installed version when the session doesn't report a usable one |
 | `display.showMemoryUsage` | boolean | false | Show an approximate system RAM usage line in expanded layout |
 | `display.showPromptCache` | boolean | false | Show the wall-clock time the session's prompt cache expires, read from the transcript |
 | `display.promptCacheTtlSeconds` | number | `300` | Compatibility fallback used only when the transcript has not reported a 5-minute or 1-hour cache tier |

--- a/README.zh.md
+++ b/README.zh.md
@@ -228,7 +228,7 @@ Claude Code → stdin JSON → claude-hud → stdout → 在终端中显示
 | `display.showCompactions` | boolean | false | 显示本会话已发生的上下文压缩次数（手动 `/compact` 或自动压缩），从 transcript 的 `compact_boundary` 记录计数，例如 `压缩次数: 2`。第一次压缩前不显示 |
 | `display.showEffortLevel` | boolean | false | 在模型徽章中显示当前推理力度。Ultracode 渲染为 `ultracode(xhigh)`，从会话 transcript 检测，因此能跟踪运行时的 `/effort` 变更 |
 | `display.effortFormat` | `full` \| `symbol` \| `text` | `full` | `showEffortLevel` 开启时的渲染方式：符号加级别文本（`◑ high`）、仅符号（`◑`）、或仅级别文本（`high`）。`symbol` 下 Ultracode 仍保持完整的 `◕ ultracode(xhigh)`，以免丢失标记；没有已知符号的级别回退到级别文本 |
-| `display.showClaudeCodeVersion` | boolean | false | 显示已安装的 Claude Code 版本，如 `CC v2.1.81` |
+| `display.showClaudeCodeVersion` | boolean | false | 显示当前会话运行的 Claude Code 版本，如 `CC v2.1.81`。会话未上报可用版本时回退显示已安装的版本 |
 | `display.showMemoryUsage` | boolean | false | 在展开布局中显示近似系统 RAM 使用行 |
 | `display.showPromptCache` | boolean | false | 显示 prompt cache 的过期时刻，数据来自 transcript |
 | `display.promptCacheTtlSeconds` | number | `300` | 仅当 transcript 尚未报告 5 分钟或 1 小时缓存层级时使用的兼容回退值 |

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { getGitStatus } from "./git.js";
 import { getJjStatus, isJjRepo } from "./jj.js";
 import { loadConfig } from "./config.js";
 import { parseExtraCmdArg, runExtraCmd } from "./extra-cmd.js";
-import { getClaudeCodeVersion } from "./version.js";
+import { getClaudeCodeVersion, parseReportedClaudeCodeVersion } from "./version.js";
 import { getMemoryUsage } from "./memory.js";
 import { readAuthInfo } from "./auth.js";
 import { resolveEffortLevel } from "./effort.js";
@@ -185,8 +185,13 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       transcript.sessionStart,
       deps.now,
     );
+    // Prefer the version Claude Code reports about its own process: PATH
+    // resolution reflects the newest installed binary, which diverges from
+    // running sessions after an auto-update. The stdin value is untrusted, so
+    // it must validate as a whole version token; anything else falls back to
+    // the verified PATH lookup (older builds, third-party feeders).
     const claudeCodeVersion = config.display.showClaudeCodeVersion
-      ? await deps.getClaudeCodeVersion()
+      ? (parseReportedClaudeCodeVersion(stdin.version) ?? await deps.getClaudeCodeVersion())
       : undefined;
     const effortInfo = config.display.showEffortLevel
       ? resolveEffortLevel(stdin.effort, { ultracodeActive: transcript.ultracodeActive })

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,9 @@ export interface StdinData {
   // shape is kept for backwards compatibility with the original PR #471 design
   // that future-proofed a string form before Anthropic had committed a schema.
   effort?: string | { level?: string | null; [key: string]: unknown } | null;
+  // Version of the running Claude Code process; omitted by older builds.
+  // Untrusted at runtime — index.ts validates it before display.
+  version?: string;
 }
 
 export interface ToolEntry {

--- a/src/version.ts
+++ b/src/version.ts
@@ -40,6 +40,11 @@ type ClaudeVersionInvocation = {
 };
 
 const CACHE_FILENAME = '.claude-code-version-cache.json';
+// Version-token shape shared by the extraction and validation parsers below.
+const VERSION_EXTRACTION_PATTERN = /\d+(?:\.\d+)+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/;
+const VERSION_VALIDATION_PATTERN = /^\d+(?:\.\d+)+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+// Cap for self-reported stdin versions; genuine versions are far shorter.
+const REPORTED_VERSION_MAX_LENGTH = 64;
 const defaultExecFile: ExecFileImpl = promisify(execFile) as ExecFileImpl;
 
 let execFileImpl: ExecFileImpl = defaultExecFile;
@@ -209,8 +214,30 @@ export function _parseClaudeCodeVersion(output: string): string | undefined {
     return undefined;
   }
 
-  const match = trimmed.match(/\d+(?:\.\d+)+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/);
+  const match = trimmed.match(VERSION_EXTRACTION_PATTERN);
   return match?.[0];
+}
+
+/**
+ * Validate a version reported by the statusline stdin JSON (`stdin.version`).
+ *
+ * Unlike `_parseClaudeCodeVersion`, which extracts the first version-shaped
+ * token from `claude --version` output, stdin is untrusted: the whole trimmed
+ * value must be a single version token, otherwise the caller should fall back
+ * to the verified PATH lookup. Non-strings, blanks, and overlong values
+ * return undefined.
+ */
+export function parseReportedClaudeCodeVersion(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > REPORTED_VERSION_MAX_LENGTH) {
+    return undefined;
+  }
+
+  return trimmed.match(VERSION_VALIDATION_PATTERN)?.[0];
 }
 
 export function _getClaudeVersionInvocation(

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -696,6 +696,107 @@ test("main skips Claude Code version lookup when disabled", async () => {
   assert.equal(lookupCalls, 0);
 });
 
+test("main prefers the Claude Code version reported by stdin over the PATH lookup", async () => {
+  let renderedContext;
+  let lookupCalls = 0;
+
+  await main({
+    readStdin: async () => makeStdin({ version: "2.1.252" }),
+    parseTranscript: async () => makeTranscript(),
+    countConfigs: async () => makeCounts(),
+    loadConfig: async () => makeConfig({
+      display: { showClaudeCodeVersion: true },
+    }),
+    getGitStatus: async () => null,
+    getClaudeCodeVersion: async () => {
+      lookupCalls += 1;
+      return "2.1.260";
+    },
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.equal(lookupCalls, 0);
+  assert.equal(renderedContext?.claudeCodeVersion, "2.1.252");
+});
+
+test("main falls back to the PATH lookup when stdin reports a non-version string", async () => {
+  let renderedContext;
+  let lookupCalls = 0;
+  const noisyVersion = `2.1.252${String.fromCharCode(27)}]0;pwned${String.fromCharCode(7)}more`;
+
+  await main({
+    readStdin: async () => makeStdin({ version: noisyVersion }),
+    parseTranscript: async () => makeTranscript(),
+    countConfigs: async () => makeCounts(),
+    loadConfig: async () => makeConfig({
+      display: { showClaudeCodeVersion: true },
+    }),
+    getGitStatus: async () => null,
+    getClaudeCodeVersion: async () => {
+      lookupCalls += 1;
+      return "2.1.260";
+    },
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.equal(lookupCalls, 1);
+  assert.equal(renderedContext?.claudeCodeVersion, "2.1.260");
+});
+
+test("main falls back to the PATH lookup when stdin reports a non-string version", async () => {
+  let renderedContext;
+  let lookupCalls = 0;
+
+  await main({
+    readStdin: async () => makeStdin({ version: 42 }),
+    parseTranscript: async () => makeTranscript(),
+    countConfigs: async () => makeCounts(),
+    loadConfig: async () => makeConfig({
+      display: { showClaudeCodeVersion: true },
+    }),
+    getGitStatus: async () => null,
+    getClaudeCodeVersion: async () => {
+      lookupCalls += 1;
+      return "2.1.260";
+    },
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.equal(lookupCalls, 1);
+  assert.equal(renderedContext?.claudeCodeVersion, "2.1.260");
+});
+
+test("main falls back to the PATH lookup when stdin reports an empty version", async () => {
+  let renderedContext;
+  let lookupCalls = 0;
+
+  await main({
+    readStdin: async () => makeStdin({ version: "" }),
+    parseTranscript: async () => makeTranscript(),
+    countConfigs: async () => makeCounts(),
+    loadConfig: async () => makeConfig({
+      display: { showClaudeCodeVersion: true },
+    }),
+    getGitStatus: async () => null,
+    getClaudeCodeVersion: async () => {
+      lookupCalls += 1;
+      return "2.1.260";
+    },
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.equal(lookupCalls, 1);
+  assert.equal(renderedContext?.claudeCodeVersion, "2.1.260");
+});
+
 test("main includes memoryUsage in render context only for expanded layout when enabled", async () => {
   let renderedContext;
   let lookupCalls = 0;

--- a/tests/version.test.js
+++ b/tests/version.test.js
@@ -12,6 +12,7 @@ import {
   _setResolveClaudeBinaryForTests,
   _setVersionInvocationEnvForTests,
   getClaudeCodeVersion,
+  parseReportedClaudeCodeVersion,
 } from '../dist/version.js';
 
 function restoreEnvVar(name, value) {
@@ -34,6 +35,23 @@ test('_parseClaudeCodeVersion preserves prerelease and build suffixes', () => {
   assert.equal(_parseClaudeCodeVersion('2.2.0-beta.1 (Claude Code)\n'), '2.2.0-beta.1');
   assert.equal(_parseClaudeCodeVersion('Claude Code 2.2.0-beta.1+abc123'), '2.2.0-beta.1+abc123');
   assert.equal(_parseClaudeCodeVersion(''), undefined);
+});
+
+test('parseReportedClaudeCodeVersion accepts only whole version strings', () => {
+  assert.equal(parseReportedClaudeCodeVersion('2.1.260'), '2.1.260');
+  assert.equal(parseReportedClaudeCodeVersion(' 2.1.260\n'), '2.1.260');
+  assert.equal(parseReportedClaudeCodeVersion('2.2.0-beta.1+abc123'), '2.2.0-beta.1+abc123');
+  assert.equal(parseReportedClaudeCodeVersion(`${' '.repeat(60)}2.1.252`), '2.1.252');
+
+  assert.equal(parseReportedClaudeCodeVersion('Opus 4.6'), undefined);
+  assert.equal(parseReportedClaudeCodeVersion('2.1.252 (Claude Code)'), undefined);
+  assert.equal(parseReportedClaudeCodeVersion(''), undefined);
+  assert.equal(parseReportedClaudeCodeVersion('   '), undefined);
+  assert.equal(parseReportedClaudeCodeVersion(42), undefined);
+  assert.equal(parseReportedClaudeCodeVersion(null), undefined);
+  assert.equal(parseReportedClaudeCodeVersion(undefined), undefined);
+  assert.equal(parseReportedClaudeCodeVersion(`2.1.252${String.fromCharCode(27)}]0;pwned`), undefined);
+  assert.equal(parseReportedClaudeCodeVersion(`2.1.252-${'a'.repeat(70)}`), undefined);
 });
 
 test('_getClaudeVersionInvocation executes binaries directly on non-Windows', () => {


### PR DESCRIPTION
## Summary

`display.showClaudeCodeVersion` shows the version of whatever binary `claude` on PATH currently resolves to — not the version the session process is actually executing. After Claude Code auto-updates, every session's HUD instantly "upgrades", including sessions still running the old binary (repro: session running 2.1.252, confirmed via `readlink /proc/<pid>/exe`, shows `CC v2.1.260`).

Root cause: `getClaudeCodeVersion()` (`src/version.ts`) resolves `claude` by scanning PATH and executes `claude --version`; the statusline input JSON is never consulted. That input already carries `version`, taken from the running process's own build-time VERSION constant — a documented field of the [statusline input JSON](https://code.claude.com/docs/en/statusline) (e.g. `"version": "2.1.90"`). `StdinData` just didn't declare it.

Fix: prefer the self-reported version, but only after it validates as a single version token — stdin is untrusted, so the new `parseReportedClaudeCodeVersion()` accessor (`src/version.ts`) requires the whole trimmed value to match the version pattern (anchored, 64-char cap); anything else falls back to the verified PATH lookup:

```ts
const claudeCodeVersion = config.display.showClaudeCodeVersion
    ? (parseReportedClaudeCodeVersion(stdin.version) ?? await deps.getClaudeCodeVersion())
    : undefined;
```

- `src/version.ts`: new `parseReportedClaudeCodeVersion()` accessor (shares the version-token pattern with the `claude --version` parser)
- `src/types.ts`: declare `version?: string` on `StdinData`
- `src/index.ts`: prefer the validated `stdin.version`, fall back to `deps.getClaudeCodeVersion()`
- `README.md` / `README.zh.md`: document the running-version semantics

One residual worth naming: a third-party statusline feeder that puts its own semver in `version` (e.g. wrappers that construct the stdin JSON themselves, like the Claudian Obsidian plugin referenced in `src/index.ts`) would have it displayed as the CC version. Validation requires an exactly version-shaped string but can't tell whose version it is — if you'd rather keep explicit semantics, happy to rework as a `display.versionSource: "running" | "installed"` option.

Possible follow-up (not in this diff): transcript JSONL entries already carry the running process's version per entry, and it steps mid-session on auto-update. Chaining `stdin.version` → `transcript.version` → PATH would also cover sessions started on ≤2.1.114 builds (which never send `stdin.version`) that auto-update mid-session. Happy to do that as a separate PR if you want it.

## Testing

- [x] `npm test` — 1122 tests, 1115 pass. The 1 failure ("estimateSessionCost prices Claude 5 point releases like their base model", `tests/cost-coverage.test.js`) is pre-existing on `main` and unrelated to this PR: it asserts Sonnet 5.1 costs $2/M input without pinning `now`, but Sonnet 5's introductory pricing ended 2026-09-01 UTC (`SONNET_5_PROMO_END_MS`, `src/cost.ts:29`), so the unpinned expectation evaluates to $3 now. Its sibling test pins `now` explicitly — doing the same there would fix it.
- [x] `npm run test:coverage` — 94.2% statements / 87.4% branches / 94.2% lines overall (same 1 pre-existing failure)

Tests written first (each watched failing against the old behavior): a unit matrix for `parseReportedClaudeCodeVersion` in `tests/version.test.js` (clean/whitespace-padded versions pass; prose like "Opus 4.6", escape-polluted strings, non-strings, blanks, and overlong values fall back), and wiring tests in `tests/index.test.js` (stdin's version wins and the PATH lookup is skipped; junk, non-string, and empty values fall back to PATH resolution).

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed