### PR TITLE
fix(version): read the Claude Code version from stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Claude HUD will be documented in this file.
 - Treat Agent `tool_result` payloads with `isAsync` or `status: async_launched` as background so the agents line stays up until the task-notification (#734).
 - Pass `--no-optional-locks` on `git diff --numstat` so a timed-out statusline poll cannot leave `.git/index.lock` behind (#726).
 - Render the prompt-cache clock as `until <time>` so the value reads as expiry, not write time (#727).
+- Read the Claude Code version from the statusline stdin payload, falling back to `claude --version` only when the field is absent, so `CC v…` no longer pins forever when PATH's `claude` is a wrapper script whose path and mtime never change across an upgrade (#752).
 
 ### Docs
 - Add the ten missing config options and the absolute-path caveat for `display.externalUsagePath` to `README.zh.md` (#730).

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { getGitStatus } from "./git.js";
 import { getJjStatus, isJjRepo } from "./jj.js";
 import { loadConfig } from "./config.js";
 import { parseExtraCmdArg, runExtraCmd } from "./extra-cmd.js";
-import { getClaudeCodeVersion } from "./version.js";
+import { getClaudeCodeVersion, resolveStdinClaudeCodeVersion } from "./version.js";
 import { getMemoryUsage } from "./memory.js";
 import { readAuthInfo } from "./auth.js";
 import { resolveEffortLevel } from "./effort.js";
@@ -186,7 +186,8 @@ export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
       deps.now,
     );
     const claudeCodeVersion = config.display.showClaudeCodeVersion
-      ? await deps.getClaudeCodeVersion()
+      ? (resolveStdinClaudeCodeVersion(stdin.version)
+        ?? await deps.getClaudeCodeVersion())
       : undefined;
     const effortInfo = config.display.showEffortLevel
       ? resolveEffortLevel(stdin.effort, { ultracodeActive: transcript.ultracodeActive })

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,13 @@ import type { AuthInfo } from './auth.js';
 
 export interface StdinData {
   session_id?: string;
+  /**
+   * Claude Code's own version, sent with every statusline invocation.
+   * Authoritative: it comes from the process that produced this payload, so it
+   * stays correct regardless of how `claude` was launched (symlink, wrapper
+   * script, or shim). See `resolveStdinClaudeCodeVersion` in version.ts.
+   */
+  version?: string | null;
   transcript_path?: string;
   cwd?: string;
   workspace?: {

--- a/src/version.ts
+++ b/src/version.ts
@@ -233,6 +233,26 @@ export function _getClaudeVersionInvocation(
   };
 }
 
+/**
+ * Read the Claude Code version out of the statusline payload.
+ *
+ * Claude Code sends its own version as a top-level `version` string on every
+ * statusline invocation. That value is authoritative — it comes from the very
+ * process that asked for this render — so it is correct however `claude` was
+ * launched, and it costs no subprocess.
+ *
+ * `getClaudeCodeVersion()` (exec + on-disk cache) stays as the fallback for
+ * payloads that omit the field, such as hand-written stdin used to drive the
+ * HUD directly.
+ */
+export function resolveStdinClaudeCodeVersion(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  return _parseClaudeCodeVersion(value);
+}
+
 export async function getClaudeCodeVersion(): Promise<string | undefined> {
   const homeDir = os.homedir();
   const diskCache = readVersionCache(homeDir);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -675,6 +675,38 @@ test("main includes Claude Code version in render context only when enabled", as
   assert.equal(renderedContext?.claudeCodeVersion, "2.1.81");
 });
 
+// Regression for the launcher-script case: when PATH's `claude` is a wrapper
+// script rather than a symlink into versions/<ver>, every signal the on-disk
+// cache in getClaudeCodeVersion() keys on (resolved path, mtime) belongs to the
+// launcher, not to the binary it execs. The launcher is untouched by a Claude
+// Code upgrade, so that cache stays valid and pins the first version it saw --
+// modelled here by the lookup still reporting 2.1.258. The payload wins because
+// it comes from the process doing the render.
+test("main prefers the Claude Code version from stdin over the binary lookup", async () => {
+  let renderedContext;
+  let lookupCalls = 0;
+
+  await main({
+    readStdin: async () => makeStdin({ version: "2.1.261" }),
+    parseTranscript: async () => makeTranscript(),
+    countConfigs: async () => makeCounts(),
+    loadConfig: async () => makeConfig({
+      display: { showClaudeCodeVersion: true },
+    }),
+    getGitStatus: async () => null,
+    getClaudeCodeVersion: async () => {
+      lookupCalls += 1;
+      return "2.1.258";
+    },
+    render: (ctx) => {
+      renderedContext = ctx;
+    },
+  });
+
+  assert.equal(lookupCalls, 0);
+  assert.equal(renderedContext?.claudeCodeVersion, "2.1.261");
+});
+
 test("main skips Claude Code version lookup when disabled", async () => {
   let lookupCalls = 0;
 

--- a/tests/version.test.js
+++ b/tests/version.test.js
@@ -12,6 +12,7 @@ import {
   _setResolveClaudeBinaryForTests,
   _setVersionInvocationEnvForTests,
   getClaudeCodeVersion,
+  resolveStdinClaudeCodeVersion,
 } from '../dist/version.js';
 
 function restoreEnvVar(name, value) {
@@ -284,4 +285,19 @@ test('getClaudeCodeVersion uses the Windows wrapper invocation for .cmd binaries
     restoreEnvVar('COMSPEC', originalComspec);
     await rm(tempHome, { recursive: true, force: true });
   }
+});
+
+test('resolveStdinClaudeCodeVersion reads the version Claude Code sends on stdin', () => {
+  assert.equal(resolveStdinClaudeCodeVersion('2.1.261'), '2.1.261');
+  assert.equal(resolveStdinClaudeCodeVersion('2.2.0-beta.1'), '2.2.0-beta.1');
+  assert.equal(resolveStdinClaudeCodeVersion('2.1.261 (Claude Code)'), '2.1.261');
+});
+
+test('resolveStdinClaudeCodeVersion falls through for absent or unusable values', () => {
+  assert.equal(resolveStdinClaudeCodeVersion(undefined), undefined);
+  assert.equal(resolveStdinClaudeCodeVersion(null), undefined);
+  assert.equal(resolveStdinClaudeCodeVersion(''), undefined);
+  assert.equal(resolveStdinClaudeCodeVersion('   '), undefined);
+  assert.equal(resolveStdinClaudeCodeVersion('unknown'), undefined);
+  assert.equal(resolveStdinClaudeCodeVersion(2.1), undefined);
 });


### PR DESCRIPTION
## Summary

Fixes #752 — `CC v…` pins to the version that was current the first time the HUD ran and never moves again, whenever the `claude` on `PATH` is a **launcher script** (a `cmux` / `mise` / `asdf` shim, or a corporate wrapper) rather than a symlink into `versions/<ver>`.

This is the structural sibling of #429. That fix keys invalidation on the launcher's resolved path and mtime, which is enough for the native installer, where `~/.local/bin/claude` is a symlink and an upgrade repoints it at a new real path. When the launcher is a script, `realpathSync` stops at the script, and **every signal the cache keys on describes the launcher rather than the binary it execs**. A Claude Code upgrade never touches the launcher, so the cache can't invalidate — by construction, not by accident. I sat on a stale version across four consecutive upgrades before noticing.

Rather than adding another heuristic to the cache, this takes the value Claude Code already provides. The statusline payload carries a top-level `version` string ([documented](https://code.claude.com/docs/en/statusline), and present in the shipped binary's payload builder as `version: {…, VERSION: "2.1.261", …}.VERSION`). It's authoritative in a way `claude --version` isn't: it comes from the process that asked for this render, so it's right however `claude` was launched — and it's right even when the binary actually running isn't the one `PATH` resolves to.

```ts
const claudeCodeVersion = config.display.showClaudeCodeVersion
  ? (resolveStdinClaudeCodeVersion(stdin.version) ?? await deps.getClaudeCodeVersion())
  : undefined;
```

The exec + on-disk cache stays as the fallback for payloads that omit the field, so nothing regresses for anyone driving the HUD with hand-written stdin. Preferring the payload also drops a ~199 MB subprocess spawn (2 s timeout) from the common path.

This follows the line already in `CONTRIBUTING.md` — *"Those need a same-invocation stdin fixture from Claude Code"* — by replacing a HUD-side inference with the same-invocation value. No new config, no new display, no new dependency.

I deliberately left the launcher limitation in the **fallback** rather than adding a TTL there: that would change cache semantics for a path now only reachable on payloads without `version`. Happy to add it if you'd prefer.

Verified on a fixture where the stale cache genuinely validates (launcher exists, mtime matches, cached version older than what it execs):

| build | stdin `version` | rendered |
|---|---|---|
| `main` | `2.1.261` | `CC v2.1.258` ← bug |
| this branch | *absent* | `CC v2.1.258` ← fallback unchanged |
| this branch | `2.1.261` | `CC v2.1.261` ← fixed |

## Testing

- [x] `npm test`
- [x] `npm run test:coverage`

Run on Node 20 to match the CI matrix: **1120 tests, 1113 pass, 1 fail, 6 skipped.**

⚠️ The one failure is pre-existing on `main` and unrelated to this change: `estimateSessionCost prices Claude 5 point releases like their base model` expects `Sonnet 5.1` at `$2/M` input but gets `$3`. The very next test in that file is `estimateSessionCost ends Sonnet 5 introductory pricing on September 1, 2026 UTC` — that date has now passed, so the assertion expired on its own. It fails identically on unmodified `main` on both Node 20 and Node 26, so CI should be red for every PR right now. I left it alone to keep this change focused; say the word and I'll send a separate PR. (`TESTING.md` asks for time-independent assertions, so it's arguably a real bug in the test rather than in the pricing table.)

New coverage:

- `tests/index.test.js` — the regression test: the binary lookup still reports the stale `2.1.258`, stdin says `2.1.261`, and the render must use the payload and skip the lookup entirely. Confirmed red on `main` (both assertions fail) and green here.
- `tests/version.test.js` — `resolveStdinClaudeCodeVersion` accepts bare and suffixed version strings, and falls through on `undefined` / `null` / empty / whitespace / non-version text / non-strings so the fallback still runs.

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed

`CHANGELOG.md` gets an `[Unreleased] → Fixed` entry. No README change: this adds no config option and doesn't alter what `display.showClaudeCodeVersion` renders, only whether the value is correct.

Per `CONTRIBUTING.md`, `src/` only — `dist/` is untouched in this branch.
