### PR TITLE
fix: display automatically generated session titles

### DIFF
--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -24,6 +24,7 @@ interface TranscriptLine {
   content?: string;
   slug?: string;
   customTitle?: string;
+  aiTitle?: string;
   // True on subagent (Task tool) records. These are interleaved into the main
   // session's transcript but belong to a separate conversation with its own
   // prompt cache.
@@ -130,7 +131,7 @@ interface TranscriptCacheFile {
   data: SerializedTranscriptData;
 }
 
-const TRANSCRIPT_CACHE_VERSION = 18;
+const TRANSCRIPT_CACHE_VERSION = 19;
 const MCP_TOOL_NAME_PATTERN = /^mcp__(.+?)__(.+)$/;
 const ACTIVITY_NAME_MAX_LEN = 64;
 const MESSAGE_ID_MAX_LEN = 128;
@@ -515,6 +516,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   const queueCompletionMap = new Map<string, Date>();
   let latestSlug: string | undefined;
   let customTitle: string | undefined;
+  let aiTitle: string | undefined;
   let latestAdvisorModel: string | undefined;
   let latestUltracodeActive: boolean | undefined;
   let lastCompactBoundaryAt: Date | undefined;
@@ -557,6 +559,8 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
         const entry = JSON.parse(line) as TranscriptLine;
         if (entry.type === 'custom-title' && typeof entry.customTitle === 'string') {
           customTitle = entry.customTitle;
+        } else if (entry.type === 'ai-title' && typeof entry.aiTitle === 'string') {
+          aiTitle = entry.aiTitle;
         } else if (typeof entry.slug === 'string') {
           latestSlug = entry.slug;
         }
@@ -757,7 +761,7 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
   result.mcpErrors = Array.from(mcpErrorSet.values());
   result.agents = Array.from(agentMap.values()).slice(-10);
   result.todos = latestTodos;
-  result.sessionName = customTitle ?? latestSlug;
+  result.sessionName = customTitle ?? aiTitle ?? latestSlug;
   result.sessionTokens = sessionTokens;
   result.lastCompactBoundaryAt = lastCompactBoundaryAt;
   result.lastCompactPostTokens = lastCompactPostTokens;

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1518,6 +1518,91 @@ test('parseTranscript falls back to latest slug when custom title is missing', a
   }
 });
 
+for (const { name, entries, expected } of [
+  {
+    name: 'uses the generated session title without a manual rename',
+    entries: [{ type: 'ai-title', aiTitle: 'Investigate failing build' }],
+    expected: 'Investigate failing build',
+  },
+  {
+    name: 'prefers the latest generated title over legacy slugs',
+    entries: [
+      { type: 'ai-title', aiTitle: 'Initial title' },
+      { type: 'ai-title', aiTitle: 'Updated title' },
+      { type: 'assistant', slug: 'legacy-slug' },
+    ],
+    expected: 'Updated title',
+  },
+  {
+    name: 'preserves a manual rename when a generated title follows it',
+    entries: [
+      { type: 'custom-title', customTitle: 'My title' },
+      { type: 'ai-title', aiTitle: 'Generated title' },
+    ],
+    expected: 'My title',
+  },
+  {
+    name: 'applies a manual rename after a generated title',
+    entries: [
+      { type: 'ai-title', aiTitle: 'Generated title' },
+      { type: 'custom-title', customTitle: 'My title' },
+    ],
+    expected: 'My title',
+  },
+  {
+    name: 'ignores malformed generated titles and titles on unrelated records',
+    entries: [
+      { type: 'ai-title', aiTitle: 'Valid title' },
+      { type: 'ai-title', aiTitle: 42 },
+      { type: 'ai-title', aiTitle: null },
+      { type: 'assistant', aiTitle: 'Unrelated title' },
+    ],
+    expected: 'Valid title',
+  },
+  {
+    name: 'retains the legacy slug when no valid generated title exists',
+    entries: [
+      { type: 'user', slug: 'legacy-slug' },
+      { type: 'ai-title', aiTitle: 42 },
+    ],
+    expected: 'legacy-slug',
+  },
+]) {
+  test(`parseTranscript ${name}`, async () => {
+    const result = await parseTempTranscript('generated-session-name.jsonl', entries);
+    assert.equal(result.sessionName, expected);
+  });
+}
+
+test('parseTranscript refreshes cached session names from before ai-title support', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'claude-hud-ai-title-cache-'));
+  const configDir = path.join(dir, 'config');
+  const transcriptPath = path.join(dir, 'session.jsonl');
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+
+  try {
+    await writeFile(transcriptPath, JSON.stringify({ type: 'ai-title', aiTitle: 'Generated title' }), 'utf8');
+    await parseTranscript(transcriptPath);
+    const cachePath = await getTranscriptCacheFile(configDir);
+    const cache = JSON.parse(await readFile(cachePath, 'utf8'));
+    cache.version = 18;
+    delete cache.data.sessionName;
+    await writeFile(cachePath, JSON.stringify(cache), 'utf8');
+
+    const refreshed = await parseTranscript(transcriptPath);
+    assert.equal(refreshed.sessionName, 'Generated title');
+
+    _setCreateReadStreamForTests(() => { throw new Error('unchanged transcript should use the refreshed cache'); });
+    const cached = await parseTranscript(transcriptPath);
+    assert.equal(cached.sessionName, 'Generated title');
+  } finally {
+    _setCreateReadStreamForTests(null);
+    restoreEnvVar('CLAUDE_CONFIG_DIR', originalConfigDir);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('parseTranscript returns empty result when file is missing', async () => {
   const result = await parseTranscript('/tmp/does-not-exist.jsonl');
   assert.equal(result.tools.length, 0);


### PR DESCRIPTION
## Summary

Fixes #750. With `showSessionName` enabled, automatically named sessions can show no name because the transcript parser ignores Claude Code's `ai-title` records.

Read the latest valid `aiTitle`, keeping manual `custom-title` names first and legacy slugs as the fallback. Bump the transcript cache version so unchanged transcripts with an older cached result also pick up their title.

Seven regression cases cover generated titles, title updates, manual renames in either order, malformed/unrelated records, legacy fallback, and refreshing then reusing a persisted cache. Four of these fail against the unchanged implementation.

## Testing

- [x] `npm test` run: baseline has 1,110 passing, six skipped, and one failing test; the change adds seven passing tests.
- [x] `npm run test:coverage` run on Node 20: 1,117 passing, six skipped, and the same baseline failure; 94.04% statement coverage.
- `npm run build` and `node --test tests/core.test.js tests/render.test.js tests/integration.test.js`: all 470 tests pass.

The full-suite failure is `estimateSessionCost prices Claude 5 point releases like their base model`, which expects the expired promotional price. It reproduces before this change and is already addressed by #744. The pricing code/test is unchanged here.

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed (restores the existing session-name option; no configuration changes)

AI disclosure: investigation, implementation, regression tests, and this PR description were primarily written with Codex.
