### PR TITLE
test(cost): pin promo-price clock so the coverage test passes after 2026-09-01

### DIFF
--- a/tests/cost-coverage.test.js
+++ b/tests/cost-coverage.test.js
@@ -164,12 +164,17 @@ test('estimateSessionCost prices Claude 5 ids carrying a context-window suffix',
 
 test('estimateSessionCost prices Claude 5 point releases like their base model', () => {
   const tokens = { inputTokens: 1000000, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 };
+  // Pin the clock inside the Sonnet 5 introductory window: the Sonnet 5.1
+  // assertion expects the promo input rate ($2/M), which only holds before
+  // 2026-09-01 UTC. Without a pinned `now` this test fails on every run
+  // after the promo ends.
+  const now = new Date('2026-08-15T00:00:00.000Z');
 
-  const opus51 = estimateSessionCost({ model: { display_name: 'Opus 5.1' } }, tokens);
+  const opus51 = estimateSessionCost({ model: { display_name: 'Opus 5.1' } }, tokens, { now });
   assert.ok(opus51);
   assert.equal(opus51.inputUsd, 5);
 
-  const sonnet51 = estimateSessionCost({ model: { display_name: 'Sonnet 5.1' } }, tokens);
+  const sonnet51 = estimateSessionCost({ model: { display_name: 'Sonnet 5.1' } }, tokens, { now });
   assert.ok(sonnet51);
   assert.equal(sonnet51.inputUsd, 2);
 });


### PR DESCRIPTION
"estimateSessionCost prices Claude 5 point releases like their base model" asserts the promo input rate ($2/M) for Sonnet 5.1 without passing `now`, so it has failed on every run since the introductory pricing ended on 2026-09-01 UTC (`SONNET_5_PROMO_END_MS`). The product behavior is correct; only the test lacks a pinned clock. This pins `now` to 2026-08-15 for both assertions. The neighboring test already pins both sides of the boundary, so no coverage is lost.