### PR TITLE
fix(cost): price 1-hour prompt-cache writes at 2x input, not 1.25x

### DIFF
--- a/src/cost.ts
+++ b/src/cost.ts
@@ -25,6 +25,7 @@ export interface SessionCostDisplay {
 
 const TOKENS_PER_MILLION = 1_000_000;
 const CACHE_WRITE_MULTIPLIER = 1.25;
+const CACHE_WRITE_ONE_HOUR_MULTIPLIER = 2;
 const CACHE_READ_MULTIPLIER = 0.1;
 const SONNET_5_PROMO_END_MS = Date.UTC(2026, 8, 1);
 const SONNET_5_PATTERN = /\bsonnet 5(?: \d+)?\b/i;
@@ -125,11 +126,27 @@ export function estimateSessionCost(
   }
 
   const inputUsd = calculateUsd(sessionTokens.inputTokens, pricing.inputUsdPerMillion);
-  const cacheWriteUsdPerMillion = pricing.cacheWriteUsdPerMillion === undefined
-    ? pricing.inputUsdPerMillion * CACHE_WRITE_MULTIPLIER
+  // Cache writes are priced per TTL: Anthropic charges 1.25x input for the
+  // 5-minute tier and 2x input for the 1-hour tier. The 1-hour portion comes
+  // from usage.cache_creation.ephemeral_1h_input_tokens and is clamped to the
+  // total cache write so a malformed counter cannot overbill. Models with an
+  // explicitly published cache-write rate keep that rate for both tiers — the
+  // TTL premium is an Anthropic-specific surcharge on top of the base rate.
+  const cacheWriteTotal = Math.max(0, sessionTokens.cacheCreationTokens);
+  const cacheWriteOneHour = Math.min(
+    Math.max(0, sessionTokens.cacheCreationOneHourTokens ?? 0),
+    cacheWriteTotal,
+  );
+  const cacheWriteFiveMinute = cacheWriteTotal - cacheWriteOneHour;
+  const explicitCacheWriteUsdPerMillion = pricing.cacheWriteUsdPerMillion === undefined
+    ? null
     : pricing.cacheWriteUsdPerMillion ?? 0;
+  const cacheWriteUsdPerMillion = explicitCacheWriteUsdPerMillion ?? pricing.inputUsdPerMillion * CACHE_WRITE_MULTIPLIER;
+  const cacheWriteOneHourUsdPerMillion = explicitCacheWriteUsdPerMillion
+    ?? pricing.inputUsdPerMillion * CACHE_WRITE_ONE_HOUR_MULTIPLIER;
   const cacheReadUsdPerMillion = pricing.cacheReadUsdPerMillion ?? pricing.inputUsdPerMillion * CACHE_READ_MULTIPLIER;
-  const cacheCreationUsd = calculateUsd(sessionTokens.cacheCreationTokens, cacheWriteUsdPerMillion);
+  const cacheCreationUsd = calculateUsd(cacheWriteFiveMinute, cacheWriteUsdPerMillion)
+    + calculateUsd(cacheWriteOneHour, cacheWriteOneHourUsdPerMillion);
   const cacheReadUsd = calculateUsd(sessionTokens.cacheReadTokens, cacheReadUsdPerMillion);
   const outputUsd = calculateUsd(sessionTokens.outputTokens, pricing.outputUsdPerMillion);
 

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -130,7 +130,7 @@ interface TranscriptCacheFile {
   data: SerializedTranscriptData;
 }
 
-const TRANSCRIPT_CACHE_VERSION = 18;
+const TRANSCRIPT_CACHE_VERSION = 19;
 const MCP_TOOL_NAME_PATTERN = /^mcp__(.+?)__(.+)$/;
 const ACTIVITY_NAME_MAX_LEN = 64;
 const MESSAGE_ID_MAX_LEN = 128;
@@ -258,17 +258,26 @@ function accumulateMessageUsage(
     cacheCreationTokens: 0,
     cacheReadTokens: 0,
   };
+  const priorOneHour = prior.cacheCreationOneHourTokens ?? 0;
+  const currentOneHour = current.cacheCreationOneHourTokens ?? 0;
 
   total.inputTokens += Math.max(0, current.inputTokens - prior.inputTokens);
   total.outputTokens += Math.max(0, current.outputTokens - prior.outputTokens);
   total.cacheCreationTokens += Math.max(0, current.cacheCreationTokens - prior.cacheCreationTokens);
   total.cacheReadTokens += Math.max(0, current.cacheReadTokens - prior.cacheReadTokens);
+  if (currentOneHour > 0 || priorOneHour > 0 || total.cacheCreationOneHourTokens !== undefined) {
+    total.cacheCreationOneHourTokens = (total.cacheCreationOneHourTokens ?? 0)
+      + Math.max(0, currentOneHour - priorOneHour);
+  }
 
   usageByMessageId.set(messageId, {
     inputTokens: Math.max(prior.inputTokens, current.inputTokens),
     outputTokens: Math.max(prior.outputTokens, current.outputTokens),
     cacheCreationTokens: Math.max(prior.cacheCreationTokens, current.cacheCreationTokens),
     cacheReadTokens: Math.max(prior.cacheReadTokens, current.cacheReadTokens),
+    ...(currentOneHour > 0 || priorOneHour > 0
+      ? { cacheCreationOneHourTokens: Math.max(priorOneHour, currentOneHour) }
+      : {}),
   });
 }
 
@@ -278,11 +287,16 @@ function normalizeSessionTokens(tokens: unknown): SessionTokenUsage | undefined 
   }
 
   const raw = tokens as Record<string, unknown>;
+  const oneHour = normalizeTokenCount(raw.cacheCreationOneHourTokens);
   return {
     inputTokens: normalizeTokenCount(raw.inputTokens),
     outputTokens: normalizeTokenCount(raw.outputTokens),
     cacheCreationTokens: normalizeTokenCount(raw.cacheCreationTokens),
     cacheReadTokens: normalizeTokenCount(raw.cacheReadTokens),
+    // Only carry a positive split forward, so cached snapshots written before
+    // the field existed (and sessions that never use the 1-hour TTL) keep the
+    // legacy shape instead of pinning a meaningless 0.
+    ...(oneHour > 0 ? { cacheCreationOneHourTokens: oneHour } : {}),
   };
 }
 
@@ -617,18 +631,22 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
         if (entry.type === 'assistant' && entry.message?.usage) {
           const usage = entry.message.usage;
           const msgId = normalizeMessageId(entry.message.id);
+          const oneHourWriteTokens = normalizeTokenCount(
+            usage.cache_creation?.ephemeral_1h_input_tokens,
+          );
           const normalizedUsage: SessionTokenUsage = {
             inputTokens: normalizeTokenCount(usage.input_tokens),
             outputTokens: normalizeTokenCount(usage.output_tokens),
             cacheCreationTokens: normalizeTokenCount(usage.cache_creation_input_tokens),
             cacheReadTokens: normalizeTokenCount(usage.cache_read_input_tokens),
+            ...(oneHourWriteTokens > 0 ? { cacheCreationOneHourTokens: oneHourWriteTokens } : {}),
           };
 
           if (msgId !== null) {
             lastUsageKey = undefined;
             accumulateMessageUsage(usageByMessageId, msgId, normalizedUsage, sessionTokens);
           } else {
-            const usageKey = `${usage.input_tokens}|${usage.output_tokens}|${usage.cache_creation_input_tokens}|${usage.cache_read_input_tokens}`;
+            const usageKey = `${usage.input_tokens}|${usage.output_tokens}|${usage.cache_creation_input_tokens}|${usage.cache_read_input_tokens}|${oneHourWriteTokens}`;
             const shouldCount = usageKey !== lastUsageKey;
             lastUsageKey = usageKey;
             if (shouldCount) {
@@ -636,6 +654,10 @@ export async function parseTranscript(transcriptPath: string): Promise<Transcrip
               sessionTokens.outputTokens += normalizedUsage.outputTokens;
               sessionTokens.cacheCreationTokens += normalizedUsage.cacheCreationTokens;
               sessionTokens.cacheReadTokens += normalizedUsage.cacheReadTokens;
+              if (oneHourWriteTokens > 0 || sessionTokens.cacheCreationOneHourTokens !== undefined) {
+                sessionTokens.cacheCreationOneHourTokens = (sessionTokens.cacheCreationOneHourTokens ?? 0)
+                  + oneHourWriteTokens;
+              }
             }
           }
         } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,11 @@ export interface SessionTokenUsage {
   outputTokens: number;
   cacheCreationTokens: number;
   cacheReadTokens: number;
+  // Portion of cacheCreationTokens written under the 1-hour TTL
+  // (usage.cache_creation.ephemeral_1h_input_tokens). Anthropic prices the
+  // 1-hour write at 2x input versus 1.25x for the 5-minute write, so the
+  // cost estimate needs the split. Undefined/0 keeps legacy 1.25x pricing.
+  cacheCreationOneHourTokens?: number;
 }
 
 export interface TranscriptData {


### PR DESCRIPTION
**Commit tested:** `939eb66` (main, 2026-08-28)

`estimateSessionCost` prices all `cache_creation_input_tokens` at 1.25x input. Anthropic charges 2x input for cache writes under the 1-hour TTL, and the transcript parser already reads the per-tier split (`cache_creation.ephemeral_1h_input_tokens`) to drive the prompt-cache clock — the cost path just drops it.

This threads the 1-hour portion through `SessionTokenUsage` (watermarked per message.id exactly like the existing four counters) and prices it at 2x, clamped to the total write. Models with an explicitly published cache-write rate keep that rate for both tiers; the `null` (not separately priced) semantics are unchanged. `TRANSCRIPT_CACHE_VERSION` 18→19 so cached snapshots re-parse.

Numbers (synthetic fixture, Sonnet 4.5 @ $3/M input, 2M tokens all written under the 1h tier):

| | cacheCreationUsd |
|---|---|
| before | $7.50 |
| after | $12.00 |

Sessions that never use the 1-hour TTL are bit-for-bit unchanged ($7.50 for the same 2M at the 5m tier). `node --test`: no new failures.

*(Fixture constructed with AgentMeasure, a token-accounting test harness.)*

###